### PR TITLE
React migration: Settings panel component

### DIFF
--- a/src/layout/SettingsPanel.scss
+++ b/src/layout/SettingsPanel.scss
@@ -1,0 +1,74 @@
+@import 'media';
+@import 'theme_variables';
+
+.overlay {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: rgba(0, 0, 0, 0.7);
+  opacity: 1;
+  z-index: 1;
+}
+
+.popup {
+  margin: 70px auto;
+  padding: 30px;
+  border-radius: 5px;
+  width: 30%;
+  position: relative;
+  h1 {
+    margin-top: 0;
+    margin-bottom: 0px;
+    color: #fff;
+    text-align: center;
+    letter-spacing: 1px;
+  }
+  h2 {
+    padding-top: 10px;
+  }
+  hr {
+    width: 40%;
+    margin-bottom: 20px;
+  }
+  .close {
+    position: absolute;
+    top: 12px;
+    right: 20px;
+    font-size: 30px;
+    font-weight: bold;
+    text-decoration: none;
+    color: rgba(255,255,255,0.8);
+    &:hover {
+      color: #fff;
+      cursor: pointer;
+    }
+  }
+  .content {
+    max-height: 30%;
+    color: #fff;
+    letter-spacing: 1px;
+    overflow: auto;
+  }
+  input[type=number] {
+      display: block;
+      width: 80%;
+      height: 20px;
+      margin-bottom: 15px;
+      border-radius: 5px;
+      padding: 2px;
+  }
+}
+
+.control-section {
+    margin-bottom: 15px;
+    padding-bottom: 15px;
+    border-bottom: 1px solid white;
+}
+
+@media screen and (max-width: 700px) {
+  .box, .popup {
+    width: 70%;
+  }
+}

--- a/src/layout/SettingsPanel.test.tsx
+++ b/src/layout/SettingsPanel.test.tsx
@@ -1,0 +1,46 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { SettingsPanel } from './SettingsPanel';
+import { SettingsProvider } from '../context/SettingsContext';
+
+beforeAll(() => {
+    vi.stubGlobal(
+        'matchMedia',
+        vi.fn().mockImplementation((query: string) => ({
+            matches: false,
+            media: query,
+            onchange: null,
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+            addListener: vi.fn(),
+            removeListener: vi.fn(),
+            dispatchEvent: vi.fn(),
+        }))
+    );
+});
+
+function renderPanel() {
+    return render(
+        <SettingsProvider>
+            <SettingsPanel />
+        </SettingsProvider>
+    );
+}
+
+describe('SettingsPanel', () => {
+    it('renders the three theme radios', () => {
+        renderPanel();
+        expect(screen.getByLabelText('Default')).toBeInTheDocument();
+        expect(screen.getByLabelText('Night')).toBeInTheDocument();
+        expect(screen.getByLabelText('Black (AMOLED)')).toBeInTheDocument();
+    });
+
+    it('toggles the "open links in a new tab" checkbox', () => {
+        renderPanel();
+        const checkbox = screen.getByRole('checkbox') as HTMLInputElement;
+        expect(checkbox.checked).toBe(false);
+        fireEvent.click(checkbox);
+        expect(checkbox.checked).toBe(true);
+    });
+});

--- a/src/layout/SettingsPanel.tsx
+++ b/src/layout/SettingsPanel.tsx
@@ -1,16 +1,99 @@
-// PLACEHOLDER — to be implemented in the migration child session for the Settings panel.
-// Parity target: src/app/core/settings/settings.component.{ts,html,scss} on the `master` branch.
 import { useSettings } from '../context/SettingsContext';
+import './SettingsPanel.scss';
 
 export function SettingsPanel() {
-    const { toggleSettings } = useSettings();
+    const { settings, toggleSettings, toggleOpenLinksInNewTab, setTheme, setFont, setSpacing } = useSettings();
+
     return (
         <div id="popup1" className="overlay">
             <div className="popup">
                 <h1>Settings</h1>
-                <button type="button" className="close" onClick={toggleSettings}>
-                    ×
-                </button>
+                <hr />
+                <span className="close" onClick={() => toggleSettings()}>
+                    &times;
+                </span>
+                <div className="content">
+                    <div className="control-section">
+                        <h2>Links</h2>
+                        <input
+                            type="checkbox"
+                            checked={settings.openLinkInNewTab}
+                            onChange={() => toggleOpenLinksInNewTab()}
+                        />
+                        Open links in a new tab
+                    </div>
+                    <div className="theme-controls">
+                        <div className="control-section">
+                            <h2>Select a theme</h2>
+                            <div>
+                                <label>
+                                    <input
+                                        name="theme"
+                                        type="radio"
+                                        value="default"
+                                        checked={settings.theme === 'default'}
+                                        onChange={() => setTheme('default')}
+                                        onClick={() => setTheme('default')}
+                                    />
+                                    Default
+                                </label>
+                            </div>
+                            <div>
+                                <label>
+                                    <input
+                                        name="theme"
+                                        type="radio"
+                                        value="night"
+                                        checked={settings.theme === 'night'}
+                                        onChange={() => setTheme('night')}
+                                        onClick={() => setTheme('night')}
+                                    />
+                                    Night
+                                </label>
+                            </div>
+                            <div>
+                                <label>
+                                    <input
+                                        name="theme"
+                                        type="radio"
+                                        value="amoledblack"
+                                        checked={settings.theme === 'amoledblack'}
+                                        onChange={() => setTheme('amoledblack')}
+                                        onClick={() => setTheme('amoledblack')}
+                                    />
+                                    Black (AMOLED)
+                                </label>
+                            </div>
+                        </div>
+                        <div className="control-section">
+                            <h2>Change Font</h2>
+                            <div>
+                                <label>
+                                    Font size:
+                                    <input
+                                        min="1"
+                                        value={settings.titleFontSize}
+                                        name="theme"
+                                        type="number"
+                                        onChange={(e) => setFont(e.target.value)}
+                                    />
+                                </label>
+                            </div>
+                            <div>
+                                <label>
+                                    List spacing:
+                                    <input
+                                        min="0"
+                                        value={settings.listSpacing}
+                                        name="theme"
+                                        type="number"
+                                        onChange={(e) => setSpacing(e.target.value)}
+                                    />
+                                </label>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
     );


### PR DESCRIPTION
## Summary
Ports the Angular `SettingsComponent` (`src/app/core/settings/settings.component.{html,scss,ts}` on `master`) to React, replacing the `PLACEHOLDER` in `src/layout/SettingsPanel.tsx`.

- Uses `useSettings()` for all state/actions — no local state.
- Renders the original markup structure with identical class names so the ported SCSS applies: `div.overlay > div.popup` with `h1`/`hr`/`span.close` and `div.content` containing the **Links** checkbox, the three **theme** radios (`default`/`night`/`amoledblack`), and the **Change Font** number inputs (font size, list spacing).
- `span.close` `onClick` → `toggleSettings()` (mirrors original `closeSettings()`).
- Angular `(click)`-driven radios mapped to both `onChange` and `onClick` → `setTheme(value)`; `(keyup)` font/spacing inputs mapped to `onChange` → `setFont`/`setSpacing`.

`src/layout/SettingsPanel.scss` ports the original SCSS verbatim, only rewriting `@import "../../shared/scss/media"` / `theme_variables` to `@import 'media'` / `@import 'theme_variables'` (Vite `loadPaths`). No SCSS division present, so no `math.div` needed.

Test (`SettingsPanel.test.tsx`, wrapped in `<SettingsProvider>`): asserts the three theme radios render and that the "open links in a new tab" checkbox state flips on click. Stubs `window.matchMedia` locally since `SettingsProvider`'s effect calls it under jsdom.

## Verification
`npm install`, `npm run lint` (`--max-warnings 0`), `npm run typecheck`, `npm run build`, `npm test` — all pass (5 tests).

Link to Devin session: https://app.devin.ai/sessions/7ffdf047ac094ab3b5bc967d6b43a68d
Requested by: @devanshi-gpta
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/289?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/289" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->