### PR TITLE
React migration: Footer component

### DIFF
--- a/src/layout/Footer.scss
+++ b/src/layout/Footer.scss
@@ -1,0 +1,23 @@
+@import 'media';
+@import 'theme_variables';
+
+#footer {
+  position: relative;
+  padding: 10px;
+  height: 60px;
+  letter-spacing: 0.7px;
+  text-align: center;
+
+  a {
+  font-weight: bold;
+  text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  @media #{$mobile-only} {
+    display: none;
+  }
+}

--- a/src/layout/Footer.test.tsx
+++ b/src/layout/Footer.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { Footer } from './Footer';
+
+describe('Footer', () => {
+    it('renders the footer container', () => {
+        const { container } = render(<Footer />);
+        expect(container.querySelector('#footer')).not.toBeNull();
+    });
+
+    it('renders the GitHub link with the correct href and target', () => {
+        render(<Footer />);
+        const link = screen.getByRole('link', { name: 'GitHub' });
+        expect(link).toHaveAttribute('href', 'https://github.com/hdjirdeh/angular2-hn');
+        expect(link).toHaveAttribute('target', '_blank');
+    });
+});

--- a/src/layout/Footer.tsx
+++ b/src/layout/Footer.tsx
@@ -1,5 +1,5 @@
-// PLACEHOLDER — to be implemented in the migration child session for the Footer.
-// Parity target: src/app/core/footer/footer.component.{ts,html,scss} on the `master` branch.
+import './Footer.scss';
+
 export function Footer() {
     return (
         <div id="footer">


### PR DESCRIPTION
## Summary
Ports the Angular footer (`src/app/core/footer/footer.component.*` on `master`) to React, finalizing the `Footer` component for the migration.

- `src/layout/Footer.tsx`: cleaned the placeholder into the final component, importing `./Footer.scss`. Markup is `<div id="footer"><p>Show this project some ❤ on <a href=".../hdjirdeh/angular2-hn" target="_blank" rel="noopener noreferrer">GitHub</a></p></div>`.
- `src/layout/Footer.scss`: ported verbatim from the original, with imports rewritten to `@import 'media';` / `@import 'theme_variables';` per the Vite `loadPaths` config. `#footer` class name preserved so the original CSS applies; hidden on mobile via `@media #{$mobile-only}`.
- `src/layout/Footer.test.tsx`: Vitest + @testing-library/react render smoke test plus an assertion that the GitHub link renders with the correct `href` and `target="_blank"`.

Verification (all clean): `npm run lint` (`--max-warnings 0`), `npm run typecheck`, `npm run build`, `npm test` (5 tests pass).


Link to Devin session: https://app.devin.ai/sessions/2f50e962027f4766b6cd20115a1c3c63
Requested by: @devanshi-gpta
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/290?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/290" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->