### PR TITLE
Phase 3b: Feed Feature — FeedPage and FeedItem

### DIFF
--- a/src/features/feed/FeedItem.module.scss
+++ b/src/features/feed/FeedItem.module.scss
@@ -1,0 +1,68 @@
+@use "../../styles/media" as *;
+@use "../../styles/theme_variables" as *;
+
+.p {
+    margin: 2px 0;
+
+    @media #{$mobile-only} {
+      margin-bottom: 5px;
+      margin-top: 0;
+   }
+  }
+
+  a {
+    cursor: pointer;
+    text-decoration: none;
+  }
+
+  .title {
+    font-size: 16px;
+    font-family: Verdana, Geneva, sans-serif;
+  }
+
+  .subtext-laptop {
+    font-size: 12px;
+    font-weight: bold;
+    letter-spacing: 0.5px;
+
+    a {
+      &:hover {
+        text-decoration: underline;
+      };
+    }
+    @media #{$mobile-only} {
+      display: none;
+    }
+  }
+
+  .subtext-palm {
+    font-size: 13px;
+    font-weight: bold;
+    letter-spacing: 0.5px;
+
+    a {
+      &:hover {
+        text-decoration: underline;
+      };
+    }
+
+    .details {
+      margin-top: 5px;
+
+      .right {
+        float: right;
+      }
+    }
+    @media #{$laptop-only} {
+      display: none;
+    }
+  }
+
+  .domain {
+    color: #696969;
+    letter-spacing: 0.5px;
+  }
+
+  .item-details {
+    padding: 10px;
+  }

--- a/src/features/feed/FeedItem.tsx
+++ b/src/features/feed/FeedItem.tsx
@@ -1,0 +1,81 @@
+import { Link } from 'react-router-dom';
+import { useSettings } from '../../contexts/SettingsContext';
+import { formatComment } from '../../utils/formatComment';
+import { Story } from '../../types/story';
+import styles from './FeedItem.module.scss';
+
+interface FeedItemProps {
+    item: Story;
+}
+
+export function FeedItem({ item }: FeedItemProps) {
+    const settings = useSettings();
+    const hasUrl = item.url?.indexOf('http') === 0;
+
+    return (
+        <div style={{ marginBottom: `${settings.listSpacing}px` }}>
+            {hasUrl ? (
+                <p className={styles.p}>
+                    <a
+                        className={styles.title}
+                        style={{ fontSize: `${settings.titleFontSize}px` }}
+                        href={item.url}
+                        target={settings.openLinkInNewTab ? '_blank' : undefined}
+                        rel={settings.openLinkInNewTab ? 'noopener' : undefined}
+                    >
+                        {item.title}
+                    </a>
+                    {item.domain && (
+                        <span className={`domain ${styles.domain}`}>({item.domain})</span>
+                    )}
+                </p>
+            ) : (
+                <p className={styles.p}>
+                    <a
+                        className={styles.title}
+                        style={{ fontSize: `${settings.titleFontSize}px` }}
+                    >
+                        <Link to={`/item/${item.id}`}>{item.title}</Link>
+                    </a>
+                </p>
+            )}
+            <div className={`subtext-palm ${styles['subtext-palm']}`}>
+                {item.type !== 'job' && (
+                    <div className={styles.details}>
+                        <span className={styles.name}>
+                            <Link to={`/user/${item.user}`}>{item.user}</Link>
+                        </span>
+                        <span className={styles.right}>{item.points} ★</span>
+                    </div>
+                )}
+                <div className={styles.details}>
+                    {item.time_ago}
+                    {item.type !== 'job' && (
+                        <Link to={`/item/${item.id}`} className={styles['comment-number']}>
+                            {' '}• {formatComment(item.comments_count)}
+                        </Link>
+                    )}
+                </div>
+            </div>
+            <div className={`subtext-laptop ${styles['subtext-laptop']}`}>
+                {item.type !== 'job' && (
+                    <span>
+                        {item.points} points by{' '}
+                        <Link to={`/user/${item.user}`}>{item.user}</Link>
+                    </span>
+                )}
+                <span className={item.type !== 'job' ? styles['item-details'] : undefined}>
+                    {item.time_ago}
+                    {item.type !== 'job' && (
+                        <span>
+                            {' '}|{' '}
+                            <Link to={`/item/${item.id}`}>
+                                {formatComment(item.comments_count)}
+                            </Link>
+                        </span>
+                    )}
+                </span>
+            </div>
+        </div>
+    );
+}

--- a/src/features/feed/FeedPage.module.scss
+++ b/src/features/feed/FeedPage.module.scss
@@ -1,0 +1,108 @@
+@use "../../styles/media" as *;
+@use "../../styles/theme_variables" as *;
+
+a {
+  text-decoration: none;
+  font-weight: bold;
+
+  &:hover {
+    text-decoration: underline;
+  };
+}
+
+ol {
+  padding: 0 40px;
+  margin: 0;
+
+  @media #{$mobile-only} {
+    box-sizing: border-box;
+    list-style: none;
+    padding: 0 10px;
+  }
+
+  li {
+    position: relative;
+    -webkit-transition: background-color .2s ease;
+    transition: background-color .2s ease;
+  }
+}
+
+.list-margin {
+  @media #{$mobile-only} {
+    margin-top: 55px;
+  }
+}
+
+.main-content {
+  position: relative;
+  width: 100%;
+  min-height: 100vh;
+  -webkit-transition: opacity .2s ease;
+  transition: opacity .2s ease;
+  box-sizing: border-box;
+  padding: 8px 0;
+  z-index: 0;
+}
+
+.post {
+  padding: 10px 0 10px 5px;
+  transition: background-color 0.2s ease;
+  border-bottom: 1px solid #CECECB;
+
+  .itemNum {
+    color: #696969;
+    position: absolute;
+    width: 30px;
+    text-align: right;
+    left: 0;
+    top: 4px;
+  }
+}
+
+.item-block {
+  display: block;
+}
+
+
+.nav {
+  padding: 10px 40px;
+  margin-top: 10px;
+  font-size: 17px;
+
+  a {
+    @media #{$mobile-only} {
+      text-decoration: none;
+    }
+  }
+
+  @media #{$mobile-only} {
+    margin: 20px 0;
+    text-align: center;
+    padding: 10px 80px;
+    height: 20px;
+  }
+
+  .prev {
+    padding-right: 20px;
+
+    @media #{$mobile-only} {
+      float: left;
+      padding-right: 0;
+    }
+  }
+
+  .more {
+    @media #{$mobile-only} {
+      float: right;
+    }
+  }
+}
+
+.job-header {
+  font-size: 15px;
+  padding: 0 40px 10px;
+
+  @media #{$mobile-only} {
+    padding: 60px 15px 25px 15px;
+  }
+}

--- a/src/features/feed/FeedPage.tsx
+++ b/src/features/feed/FeedPage.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { fetchFeed } from '../../hooks/useHackerNewsApi';
+import { Story } from '../../types/story';
+import { Loader } from '../../components/Loader';
+import { ErrorMessage } from '../../components/ErrorMessage';
+import { FeedItem } from './FeedItem';
+import styles from './FeedPage.module.scss';
+
+export function FeedPage() {
+    const { feedType = 'news', page = '1' } = useParams<{ feedType: string; page: string }>();
+    const pageNum = Number(page) || 1;
+    const listStart = (pageNum - 1) * 30 + 1;
+
+    const [items, setItems] = useState<Story[] | null>(null);
+    const [errorMessage, setErrorMessage] = useState('');
+
+    useEffect(() => {
+        setItems(null);
+        setErrorMessage('');
+        fetchFeed(feedType, pageNum)
+            .then((data) => {
+                setItems(data);
+                window.scrollTo(0, 0);
+            })
+            .catch(() => {
+                setErrorMessage(`Could not load ${feedType} stories.`);
+            });
+    }, [feedType, pageNum]);
+
+    return (
+        <div className={styles['main-content']}>
+            {!items && !errorMessage && <Loader />}
+            {!items && errorMessage !== '' && <ErrorMessage message={errorMessage} />}
+
+            {items && (
+                <div>
+                    {feedType === 'jobs' && (
+                        <p className={`job-header ${styles['job-header']}`}>
+                            These are jobs at startups that were funded by Y Combinator.
+                            You can also get a job at a YC startup through{' '}
+                            <a href="https://triplebyte.com/?ref=yc_jobs">Triplebyte</a>.
+                        </p>
+                    )}
+                    {feedType !== 'new' && (
+                        <ol
+                            className={feedType !== 'jobs' ? styles['list-margin'] : undefined}
+                            start={listStart}
+                        >
+                            {items.map((item) => (
+                                <li key={item.id} className={styles.post}>
+                                    <div className={styles['item-block']}>
+                                        <FeedItem item={item} />
+                                    </div>
+                                </li>
+                            ))}
+                        </ol>
+                    )}
+                    <div className={`nav ${styles.nav}`}>
+                        {listStart !== 1 && (
+                            <Link
+                                to={`/${feedType}/${pageNum - 1}`}
+                                className={styles.prev}
+                            >
+                                ‹ Prev
+                            </Link>
+                        )}
+                        {items.length === 30 && (
+                            <Link
+                                to={`/${feedType}/${pageNum + 1}`}
+                                className={styles.more}
+                            >
+                                More ›
+                            </Link>
+                        )}
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary

Ports the feed listing pages from Angular to React.

**FeedPage** (`src/features/feed/FeedPage.tsx`):
- `useParams()` for `feedType` and `page`
- `fetchFeed(feedType, pageNum)` in `useEffect`, resets state on param change
- Loading → `<Loader>`, error → `<ErrorMessage>`
- `<ol start={listStart}>` where `listStart = (pageNum - 1) * 30 + 1`
- Pagination: `<Link to="/${feedType}/${pageNum ± 1}">` (Prev when not page 1, More when 30 items)
- Jobs header with Triplebyte link

**FeedItem** (`src/features/feed/FeedItem.tsx`):
- `hasUrl = item.url?.indexOf('http') === 0` — external `<a href>` vs internal `<Link to="/item/:id">`
- Settings-driven: `fontSize`, `listSpacing`, `openLinkInNewTab` (target/rel attrs)
- Dual layout: `.subtext-palm` (mobile) / `.subtext-laptop` (desktop) with `formatComment()` for counts

PR 4 of 6. Depends on PR #329.

Link to Devin session: https://app.devin.ai/sessions/4c1a7551837044aaa372dbdc89096cdf
Requested by: @vibhaseshadri-cognition
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/330?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/330" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->