### PR TITLE
Phase 3c: Item Details Feature — ItemDetailsPage and Comment

### DIFF
--- a/src/features/item-details/Comment.module.scss
+++ b/src/features/item-details/Comment.module.scss
@@ -1,0 +1,83 @@
+@use "../../styles/media" as *;
+@use "../../styles/theme_variables" as *;
+
+a {
+  font-weight: bold;
+  text-decoration: none;
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.meta {
+  font-size: 13px;
+  color: #696969;
+  font-weight: bold;
+  letter-spacing: 0.5px;
+  margin-bottom: 8px;
+  a {
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+  .time {
+    padding-left: 5px;
+  }
+}
+
+@media #{$mobile-only} {
+  .meta {
+    font-size: 14px;
+    margin-bottom: 10px;
+    .time {
+      padding: 0;
+      float: right;
+    }
+  }
+}
+
+.meta-collapse {
+  margin-bottom: 20px;
+}
+
+.deleted-meta {
+  font-size: 12px;
+  font-weight: bold;
+  letter-spacing: 0.5px;
+  margin: 30px 0;
+  a {
+    text-decoration: none;
+  }
+}
+
+.collapse {
+  font-size: 13px;
+  letter-spacing: 2px;
+  cursor: pointer;
+}
+
+.comment-tree {
+  margin-left: 24px;
+}
+
+@media #{$tablet-only} {
+  .comment-tree {
+    margin-left: 8px;
+  }
+}
+
+.comment-text {
+  font-size: 15px;
+  margin-top: 0;
+  margin-bottom: 20px;
+  word-wrap: break-word;
+  line-height: 1.5em;
+}
+
+.subtree {
+  margin-left: 0;
+  padding: 0;
+  list-style-type: none;
+}

--- a/src/features/item-details/Comment.tsx
+++ b/src/features/item-details/Comment.tsx
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { Comment as CommentType } from '../../types/comment';
+import styles from './Comment.module.scss';
+
+interface CommentProps {
+    comment: CommentType;
+}
+
+export function Comment({ comment }: CommentProps) {
+    const [collapse, setCollapse] = useState(false);
+
+    if (comment.deleted) {
+        return (
+            <div>
+                <div className={`deleted-meta ${styles['deleted-meta']}`}>
+                    <span className={styles.collapse}>[deleted]</span> | Comment Deleted
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div>
+            <div className={`meta ${styles.meta} ${collapse ? styles['meta-collapse'] : ''}`}>
+                <span className={styles.collapse} onClick={() => setCollapse(!collapse)}>
+                    [{collapse ? '+' : '-'}]
+                </span>{' '}
+                <Link to={`/user/${comment.user}`}>{comment.user}</Link>
+                <span className={styles.time}>{comment.time_ago}</span>
+            </div>
+            <div className={styles['comment-tree']}>
+                {!collapse && (
+                    <div>
+                        <p
+                            className={styles['comment-text']}
+                            dangerouslySetInnerHTML={{ __html: comment.content }}
+                        />
+                        <ul className={styles.subtree}>
+                            {comment.comments?.map((subComment) => (
+                                <li key={subComment.id}>
+                                    <Comment comment={subComment} />
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/src/features/item-details/ItemDetailsPage.module.scss
+++ b/src/features/item-details/ItemDetailsPage.module.scss
@@ -1,0 +1,151 @@
+@use "../../styles/media" as *;
+@use "../../styles/theme_variables" as *;
+
+.main-content {
+  position: relative;
+  width: 100%;
+  min-height: 100vh;
+  -webkit-transition: opacity .2s ease;
+  transition: opacity .2s ease;
+  box-sizing: border-box;
+  padding: 8px 0;
+  z-index: 0;
+}
+
+.item {
+  box-sizing: border-box;
+  padding: 10px 40px 0 40px;
+  z-index: 0;
+}
+
+@media #{$tablet-only} {
+  .item {
+    padding: 10px 20px 0 40px;
+  }
+}
+
+@media #{$mobile-only} {
+  .item {
+    box-sizing: border-box;
+    padding: 110px 15px 0 15px;
+  }
+}
+
+.head-margin {
+  margin-bottom: 15px;
+}
+
+p {
+  margin: 2px 0;
+}
+
+.subject {
+  word-wrap: break-word;
+  margin-top: 20px;
+}
+
+a {
+  cursor: pointer;
+  text-decoration: none;
+}
+
+@media #{$mobile-only} {
+  .laptop {
+    display: none;
+  }
+}
+
+@media #{$laptop-only} {
+  .mobile {
+    display: none;
+  }
+}
+
+.title {
+  font-size: 16px;
+  font-family: Verdana, Geneva, sans-serif;
+}
+
+.title-block {
+  text-align: center;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  margin: 0 75px;
+}
+
+@media #{$mobile-only} {
+  .title {
+    font-size: 15px;
+  }
+  .back-button {
+    position: absolute;
+    top: 52%;
+    width: 0.6rem;
+    height: 0.6rem;
+    background: transparent;
+    box-shadow: 0 0 0 lightgray;
+    transition: all 200ms ease;
+    left: 4%;
+    transform: translate3d(0, -50%, 0) rotate(-135deg);
+  }
+}
+
+.subtext {
+  font-size: 12px;
+  font-weight: bold;
+  letter-spacing: 0.5px;
+}
+
+.domain {
+  letter-spacing: 0.5px;
+}
+
+.subtext a {
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.item-details {
+  padding: 10px;
+}
+
+.item-header {
+  padding-bottom: 10px;
+}
+
+@media #{$mobile-only} {
+  .item-header {
+    padding: 10px 0 10px 0;
+    position: fixed;
+    width: 100%;
+    left: 0;
+    top: 62px;
+  }
+}
+
+.pollResults {
+  margin-bottom: 1em;
+}
+
+.pollContent {
+  * {
+    padding-bottom: 0;
+    margin-bottom: -1em;
+    margin-top: 1em;
+  }
+  :global(.pollBar) {
+    height: 10px;
+    margin-bottom: 1em;
+  }
+}
+
+.comment-list {
+  list-style-type: none;
+  padding: 10px 0;
+}
+
+.comment-list li {
+  display: list-item;
+}

--- a/src/features/item-details/ItemDetailsPage.tsx
+++ b/src/features/item-details/ItemDetailsPage.tsx
@@ -1,0 +1,151 @@
+import { useEffect, useState } from 'react';
+import { useParams, useNavigate, Link } from 'react-router-dom';
+import { fetchItemContent } from '../../hooks/useHackerNewsApi';
+import { useSettings } from '../../contexts/SettingsContext';
+import { formatComment } from '../../utils/formatComment';
+import { Story } from '../../types/story';
+import { Loader } from '../../components/Loader';
+import { ErrorMessage } from '../../components/ErrorMessage';
+import { Comment } from './Comment';
+import styles from './ItemDetailsPage.module.scss';
+
+export function ItemDetailsPage() {
+    const { id } = useParams<{ id: string }>();
+    const navigate = useNavigate();
+    const settings = useSettings();
+
+    const [item, setItem] = useState<Story | null>(null);
+    const [errorMessage, setErrorMessage] = useState('');
+
+    useEffect(() => {
+        if (!id) return;
+        setItem(null);
+        setErrorMessage('');
+        fetchItemContent(Number(id))
+            .then(setItem)
+            .catch(() => setErrorMessage('Could not load item comments.'));
+        window.scrollTo(0, 0);
+    }, [id]);
+
+    const goBack = () => navigate(-1);
+    const hasUrl = item?.url?.indexOf('http') === 0;
+
+    return (
+        <div className={styles['main-content']}>
+            {!item && !errorMessage && <Loader />}
+            {!item && errorMessage !== '' && <ErrorMessage message={errorMessage} />}
+
+            {item && (
+                <div className={styles.item}>
+                    {/* Mobile header */}
+                    <div className={`${styles.mobile} item-header ${styles['item-header']}`}>
+                        <p className={styles['title-block']}>
+                            <span className={`back-button ${styles['back-button']}`} onClick={goBack}></span>
+                            {hasUrl ? (
+                                <a
+                                    className={styles.title}
+                                    href={item.url}
+                                    target={settings.openLinkInNewTab ? '_blank' : undefined}
+                                    rel={settings.openLinkInNewTab ? 'noopener' : undefined}
+                                >
+                                    {item.title}
+                                </a>
+                            ) : (
+                                <Link className={styles.title} to={`/item/${item.id}`}>
+                                    {item.title}
+                                </Link>
+                            )}
+                        </p>
+                    </div>
+
+                    {/* Desktop header */}
+                    <div
+                        className={`${styles.laptop} ${
+                            item.comments_count > 0 || item.type === 'job'
+                                ? `item-header ${styles['item-header']}`
+                                : ''
+                        } ${item.content ? styles['head-margin'] : ''}`}
+                    >
+                        {hasUrl ? (
+                            <p>
+                                <a
+                                    className={styles.title}
+                                    href={item.url}
+                                    target={settings.openLinkInNewTab ? '_blank' : undefined}
+                                    rel={settings.openLinkInNewTab ? 'noopener' : undefined}
+                                >
+                                    {item.title}
+                                </a>
+                                {item.domain && (
+                                    <span className={`domain ${styles.domain}`}>({item.domain})</span>
+                                )}
+                            </p>
+                        ) : (
+                            <p>
+                                <Link className={styles.title} to={`/item/${item.id}`}>
+                                    {item.title}
+                                </Link>
+                            </p>
+                        )}
+                        <div className={`subtext ${styles.subtext}`}>
+                            {item.type !== 'job' && (
+                                <span>
+                                    {item.points} points by{' '}
+                                    <Link to={`/user/${item.user}`}>{item.user}</Link>
+                                </span>
+                            )}
+                            <span className={item.type !== 'job' ? styles['item-details'] : undefined}>
+                                {item.time_ago}
+                                {item.type !== 'job' && (
+                                    <span>
+                                        {' '}|{' '}
+                                        <Link to={`/item/${item.id}`}>
+                                            {formatComment(item.comments_count)}
+                                        </Link>
+                                    </span>
+                                )}
+                            </span>
+                        </div>
+                    </div>
+
+                    {/* Poll results */}
+                    {item.type === 'poll' && (
+                        <div className={styles.pollResults}>
+                            {item.poll?.map((pollResult, i) => (
+                                <div key={i} className={`pollContent ${styles.pollContent}`}>
+                                    <div dangerouslySetInnerHTML={{ __html: pollResult.content }} />
+                                    <div className={`subtext ${styles.subtext}`}>
+                                        {pollResult.points} points
+                                    </div>
+                                    <div
+                                        className="pollBar"
+                                        style={{
+                                            width: `${(pollResult.points / item.poll_votes_count) * 100}%`,
+                                        }}
+                                    />
+                                </div>
+                            ))}
+                        </div>
+                    )}
+
+                    {/* Content */}
+                    {item.content && (
+                        <p
+                            className={styles.subject}
+                            dangerouslySetInnerHTML={{ __html: item.content }}
+                        />
+                    )}
+
+                    {/* Comments */}
+                    <ul className={styles['comment-list']}>
+                        {item.comments?.map((comment) => (
+                            <li key={comment.id}>
+                                <Comment comment={comment} />
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/types/story.ts
+++ b/src/types/story.ts
@@ -12,6 +12,7 @@ export interface Story {
     type: FeedType;
     url: string;
     domain: string;
+    content: string;
     comments: Comment[];
     comments_count: number;
     poll: PollResult[];


### PR DESCRIPTION
## Summary

Ports the item detail / comment thread page from Angular to React.

**ItemDetailsPage** (`src/features/item-details/ItemDetailsPage.tsx`):
- `useParams()` for `id`, `fetchItemContent(id)` in `useEffect`
- Back button via `useNavigate()` → `navigate(-1)`
- Dual layout: mobile (`.mobile`) with back-arrow + title, desktop (`.laptop`) with full subtext
- Poll results: iterates `item.poll`, renders bar with `width: points/poll_votes_count * 100%`
- Content HTML via `dangerouslySetInnerHTML`, comment list as `<Comment>` components
- `useSettings()` for `openLinkInNewTab`

**Comment** (`src/features/item-details/Comment.tsx`):
- Recursive: renders `comment.comments` as nested `<Comment>` elements
- Collapse/expand via `useState<boolean>` — `[+]`/`[-]` toggle
- Deleted comment handling: shows `[deleted] | Comment Deleted`
- HTML content via `dangerouslySetInnerHTML`

Also adds missing `content: string` field to `Story` interface.

PR 5 of 6. Depends on PR #330.

Link to Devin session: https://app.devin.ai/sessions/4c1a7551837044aaa372dbdc89096cdf
Requested by: @vibhaseshadri-cognition
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/331?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/331" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->