### PR TITLE
PR 2/7: API service & Settings context

### DIFF
--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -1,0 +1,89 @@
+import { createContext, useContext, useState, useEffect, useCallback, type ReactNode } from 'react';
+import { Settings } from '../models/settings';
+
+interface SettingsContextValue {
+  settings: Settings;
+  toggleSettings: () => void;
+  toggleOpenLinksInNewTab: () => void;
+  setTheme: (theme: string) => void;
+  setFont: (fontSize: string) => void;
+  setSpacing: (listSpace: string) => void;
+}
+
+const SettingsContext = createContext<SettingsContextValue | null>(null);
+
+function readLocalStorage<T>(key: string, fallback: T): T {
+  const stored = localStorage.getItem(key);
+  if (stored === null) return fallback;
+  try {
+    return JSON.parse(stored) as T;
+  } catch {
+    return stored as unknown as T;
+  }
+}
+
+export function SettingsProvider({ children }: { children: ReactNode }) {
+  const [settings, setSettings] = useState<Settings>(() => ({
+    showSettings: false,
+    openLinkInNewTab: readLocalStorage<boolean>('openLinkInNewTab', false),
+    theme: localStorage.getItem('theme') || 'default',
+    titleFontSize: localStorage.getItem('titleFontSize') || '16',
+    listSpacing: localStorage.getItem('listSpacing') || '0',
+  }));
+
+  useEffect(() => {
+    if (localStorage.getItem('theme')) return;
+
+    const darkMedia = window.matchMedia('(prefers-color-scheme: dark)');
+    const handler = (e: MediaQueryListEvent) => {
+      setSettings(prev => ({ ...prev, theme: e.matches ? 'night' : 'default' }));
+    };
+
+    // Set initial theme based on system preference
+    if (darkMedia.matches) {
+      setSettings(prev => ({ ...prev, theme: 'night' }));
+    }
+
+    darkMedia.addEventListener('change', handler);
+    return () => darkMedia.removeEventListener('change', handler);
+  }, []);
+
+  const toggleSettings = useCallback(() => {
+    setSettings(prev => ({ ...prev, showSettings: !prev.showSettings }));
+  }, []);
+
+  const toggleOpenLinksInNewTab = useCallback(() => {
+    setSettings(prev => {
+      const next = !prev.openLinkInNewTab;
+      localStorage.setItem('openLinkInNewTab', JSON.stringify(next));
+      return { ...prev, openLinkInNewTab: next };
+    });
+  }, []);
+
+  const setTheme = useCallback((theme: string) => {
+    localStorage.setItem('theme', theme);
+    setSettings(prev => ({ ...prev, theme }));
+  }, []);
+
+  const setFont = useCallback((fontSize: string) => {
+    localStorage.setItem('titleFontSize', fontSize);
+    setSettings(prev => ({ ...prev, titleFontSize: fontSize }));
+  }, []);
+
+  const setSpacing = useCallback((listSpace: string) => {
+    localStorage.setItem('listSpacing', listSpace);
+    setSettings(prev => ({ ...prev, listSpacing: listSpace }));
+  }, []);
+
+  return (
+    <SettingsContext.Provider value={{ settings, toggleSettings, toggleOpenLinksInNewTab, setTheme, setFont, setSpacing }}>
+      {children}
+    </SettingsContext.Provider>
+  );
+}
+
+export function useSettings(): SettingsContextValue {
+  const ctx = useContext(SettingsContext);
+  if (!ctx) throw new Error('useSettings must be used within a SettingsProvider');
+  return ctx;
+}

--- a/src/services/hackerNewsApi.ts
+++ b/src/services/hackerNewsApi.ts
@@ -1,0 +1,46 @@
+import { Story } from '../models/story';
+import { User } from '../models/user';
+import { PollResult } from '../models/poll-result';
+
+const BASE_URL = 'https://node-hnapi.herokuapp.com';
+
+export async function fetchFeed(feedType: string, page: number): Promise<Story[]> {
+  const res = await fetch(`${BASE_URL}/${feedType}?page=${page}`);
+  if (!res.ok) throw new Error(`Failed to fetch ${feedType} feed`);
+  return res.json();
+}
+
+export async function fetchItemContent(id: number): Promise<Story> {
+  const res = await fetch(`${BASE_URL}/item/${id}`);
+  if (!res.ok) throw new Error(`Failed to fetch item ${id}`);
+  const story: Story = await res.json();
+
+  if (story.type === 'poll' && story.poll) {
+    const numberOfPollOptions = story.poll.length;
+    story.poll_votes_count = 0;
+
+    const pollPromises = Array.from({ length: numberOfPollOptions }, (_, i) =>
+      fetchPollContent(story.id + i + 1)
+    );
+    const pollResults = await Promise.all(pollPromises);
+
+    pollResults.forEach((result, i) => {
+      story.poll[i] = result;
+      story.poll_votes_count += result.points;
+    });
+  }
+
+  return story;
+}
+
+export async function fetchPollContent(id: number): Promise<PollResult> {
+  const res = await fetch(`${BASE_URL}/item/${id}`);
+  if (!res.ok) throw new Error(`Failed to fetch poll ${id}`);
+  return res.json();
+}
+
+export async function fetchUser(id: string): Promise<User> {
+  const res = await fetch(`${BASE_URL}/user/${id}`);
+  if (!res.ok) throw new Error(`Failed to fetch user ${id}`);
+  return res.json();
+}

--- a/src/utils/commentPipe.ts
+++ b/src/utils/commentPipe.ts
@@ -1,0 +1,7 @@
+export function commentPipe(count: number): string {
+  if (count > 0) {
+    const label = count === 1 ? 'comment' : 'comments';
+    return `${count} ${label}`;
+  }
+  return 'discuss';
+}


### PR DESCRIPTION
## Summary

Ports the data-fetching layer and global settings state from Angular services to React-idiomatic patterns.

**`src/services/hackerNewsApi.ts`** — replaces `HackerNewsAPIService` + RxJS `Observable`/`lazyFetch`:
- All methods now `async/await` + native `fetch` returning `Promise<T>`
- `fetchItemContent` fetches poll options with `Promise.all` instead of nested subscribes
- Base URL: `https://node-hnapi.herokuapp.com`

**`src/contexts/SettingsContext.tsx`** — replaces `SettingsService`:
- `SettingsProvider` wraps the app; `useSettings()` hook gives access to settings + mutators
- Replicates all `localStorage` read/write logic for `theme`, `openLinkInNewTab`, `titleFontSize`, `listSpacing`
- `prefers-color-scheme: dark` media query listener via `useEffect` (sets `night` theme when no saved preference)

**`src/utils/commentPipe.ts`** — replaces Angular `CommentPipe`:
- Plain function `commentPipe(count) → "N comments" | "discuss"`

Stacks on PR 1 (`devin-06.17.2026-vibha/scaffold-react-vite-project`).

Link to Devin session: https://app.devin.ai/sessions/88a4167085734f5a9012719a02dc7066
Requested by: @vibhaseshadri-cognition
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/342?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/342" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->