### PR TITLE
PR 4/7: Feed pages — story list + pagination

### DIFF
--- a/src/components/Item.scss
+++ b/src/components/Item.scss
@@ -1,0 +1,68 @@
+@import "../scss/media";
+@import "../scss/theme_variables";
+
+p {
+    margin: 2px 0;
+
+    @media #{$mobile-only} {
+      margin-bottom: 5px;
+      margin-top: 0;
+   }
+  }
+
+  a {
+    cursor: pointer;
+    text-decoration: none;
+  }
+
+  .title {
+    font-size: 16px;
+    font-family: Verdana, Geneva, sans-serif;
+  }
+
+  .subtext-laptop {
+    font-size: 12px;
+    font-weight: bold;
+    letter-spacing: 0.5px;
+
+    a {
+      &:hover {
+        text-decoration: underline;
+      };
+    }
+    @media #{$mobile-only} {
+      display: none;
+    }
+  }
+
+  .subtext-palm {
+    font-size: 13px;
+    font-weight: bold;
+    letter-spacing: 0.5px;
+
+    a {
+      &:hover {
+        text-decoration: underline;
+      };
+    }
+
+    .details {
+      margin-top: 5px;
+
+      .right {
+        float: right;
+      }
+    }
+    @media #{$laptop-only} {
+      display: none;
+    }
+  }
+
+  .domain {
+    color: #696969;
+    letter-spacing: 0.5px;
+  }
+
+  .item-details {
+    padding: 10px;
+  }

--- a/src/components/Item.tsx
+++ b/src/components/Item.tsx
@@ -1,0 +1,79 @@
+import { Link } from 'react-router-dom';
+import { Story } from '../models/story';
+import { useSettings } from '../contexts/SettingsContext';
+import { commentPipe } from '../utils/commentPipe';
+import './Item.scss';
+
+interface ItemProps {
+  item: Story;
+}
+
+function Item({ item }: ItemProps) {
+  const { settings } = useSettings();
+  const hasUrl = item.url && item.url.indexOf('http') === 0;
+
+  return (
+    <div style={{ marginBottom: `${settings.listSpacing}px` }}>
+      {hasUrl ? (
+        <p>
+          <a
+            className="title"
+            style={{ fontSize: `${settings.titleFontSize}px` }}
+            href={item.url}
+            target={settings.openLinkInNewTab ? '_blank' : undefined}
+            rel={settings.openLinkInNewTab ? 'noopener' : undefined}
+          >
+            {item.title}
+          </a>
+          {item.domain && <span className="domain">({item.domain})</span>}
+        </p>
+      ) : (
+        <p>
+          <Link
+            className="title"
+            style={{ fontSize: `${settings.titleFontSize}px` }}
+            to={`/item/${item.id}`}
+          >
+            {item.title}
+          </Link>
+        </p>
+      )}
+      <div className="subtext-palm">
+        {item.type !== 'job' && (
+          <div className="details">
+            <span className="name">
+              <Link to={`/user/${item.user}`}>{item.user}</Link>
+            </span>
+            <span className="right">{item.points} ★</span>
+          </div>
+        )}
+        <div className="details">
+          {item.time_ago}
+          {item.type !== 'job' && (
+            <Link to={`/item/${item.id}`} className="comment-number">
+              {' '}• {commentPipe(item.comments_count)}
+            </Link>
+          )}
+        </div>
+      </div>
+      <div className="subtext-laptop">
+        {item.type !== 'job' && (
+          <span>
+            {item.points} points by{' '}
+            <Link to={`/user/${item.user}`}>{item.user}</Link>
+          </span>
+        )}
+        <span className={item.type !== 'job' ? 'item-details' : undefined}>
+          {item.time_ago}
+          {item.type !== 'job' && (
+            <span>
+              {' '}| <Link to={`/item/${item.id}`}>{commentPipe(item.comments_count)}</Link>
+            </span>
+          )}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export default Item;

--- a/src/pages/FeedPage.scss
+++ b/src/pages/FeedPage.scss
@@ -1,0 +1,108 @@
+@import "../scss/media";
+@import "../scss/theme_variables";
+
+a {
+  text-decoration: none;
+  font-weight: bold;
+
+  &:hover {
+    text-decoration: underline;
+  };
+}
+
+ol {
+  padding: 0 40px;
+  margin: 0;
+
+  @media #{$mobile-only} {
+    box-sizing: border-box;
+    list-style: none;
+    padding: 0 10px;
+  }
+
+  li {
+    position: relative;
+    -webkit-transition: background-color .2s ease;
+    transition: background-color .2s ease;
+  }
+}
+
+.list-margin {
+  @media #{$mobile-only} {
+    margin-top: 55px;
+  }
+}
+
+.main-content {
+  position: relative;
+  width: 100%;
+  min-height: 100vh;
+  -webkit-transition: opacity .2s ease;
+  transition: opacity .2s ease;
+  box-sizing: border-box;
+  padding: 8px 0;
+  z-index: 0;
+}
+
+.post {
+  padding: 10px 0 10px 5px;
+  transition: background-color 0.2s ease;
+  border-bottom: 1px solid #CECECB;
+
+  .itemNum {
+    color: #696969;
+    position: absolute;
+    width: 30px;
+    text-align: right;
+    left: 0;
+    top: 4px;
+  }
+}
+
+.item-block {
+  display: block;
+}
+
+
+.nav {
+  padding: 10px 40px;
+  margin-top: 10px;
+  font-size: 17px;
+
+  a {
+    @media #{$mobile-only} {
+      text-decoration: none;
+    }
+  }
+
+  @media #{$mobile-only} {
+    margin: 20px 0;
+    text-align: center;
+    padding: 10px 80px;
+    height: 20px;
+  }
+
+  .prev {
+    padding-right: 20px;
+
+    @media #{$mobile-only} {
+      float: left;
+      padding-right: 0;
+    }
+  }
+
+  .more {
+    @media #{$mobile-only} {
+      float: right;
+    }
+  }
+}
+
+.job-header {
+  font-size: 15px;
+  padding: 0 40px 10px;
+
+  @media #{$mobile-only} {
+    padding: 60px 15px 25px 15px;
+  }
+}

--- a/src/pages/FeedPage.tsx
+++ b/src/pages/FeedPage.tsx
@@ -1,0 +1,74 @@
+import { useState, useEffect } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { fetchFeed } from '../services/hackerNewsApi';
+import { Story } from '../models/story';
+import Item from '../components/Item';
+import Loader from '../components/Loader';
+import ErrorMessage from '../components/ErrorMessage';
+import './FeedPage.scss';
+
+interface FeedPageProps {
+  feedType: string;
+}
+
+function FeedPage({ feedType }: FeedPageProps) {
+  const { page } = useParams<{ page: string }>();
+  const pageNum = page ? parseInt(page, 10) : 1;
+  const [items, setItems] = useState<Story[] | null>(null);
+  const [errorMessage, setErrorMessage] = useState('');
+
+  useEffect(() => {
+    setItems(null);
+    setErrorMessage('');
+
+    fetchFeed(feedType, pageNum)
+      .then(data => setItems(data))
+      .catch(() => setErrorMessage(`Could not load ${feedType} stories.`));
+
+    window.scrollTo(0, 0);
+  }, [feedType, pageNum]);
+
+  const listStart = (pageNum - 1) * 30 + 1;
+
+  return (
+    <div className="main-content">
+      {!items && !errorMessage && <Loader />}
+      {!items && errorMessage !== '' && <ErrorMessage message={errorMessage} />}
+
+      {items && (
+        <div>
+          {feedType === 'jobs' && (
+            <p className="job-header">
+              These are jobs at startups that were funded by Y Combinator.
+              You can also get a job at a YC startup through{' '}
+              <a href="https://triplebyte.com/?ref=yc_jobs">Triplebyte</a>.
+            </p>
+          )}
+          {feedType !== 'new' && (
+            <ol className={feedType !== 'jobs' ? 'list-margin' : undefined} start={listStart}>
+              {items.map(item => (
+                <li key={item.id} className="post">
+                  <Item item={item} />
+                </li>
+              ))}
+            </ol>
+          )}
+          <div className="nav">
+            {listStart !== 1 && (
+              <Link to={`/${feedType}/${pageNum - 1}`} className="prev">
+                ‹ Prev
+              </Link>
+            )}
+            {items.length === 30 && (
+              <Link to={`/${feedType}/${pageNum + 1}`} className="more">
+                More ›
+              </Link>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default FeedPage;

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,5 +1,6 @@
 import { createBrowserRouter, Navigate } from 'react-router-dom';
 import App from './components/App';
+import FeedPage from './pages/FeedPage';
 
 const router = createBrowserRouter([
   {
@@ -7,11 +8,11 @@ const router = createBrowserRouter([
     element: <App />,
     children: [
       { index: true, element: <Navigate to="/news/1" replace /> },
-      { path: 'news/:page', element: <div>Feed placeholder</div> },
-      { path: 'newest/:page', element: <div>Feed placeholder</div> },
-      { path: 'show/:page', element: <div>Feed placeholder</div> },
-      { path: 'ask/:page', element: <div>Feed placeholder</div> },
-      { path: 'jobs/:page', element: <div>Feed placeholder</div> },
+      { path: 'news/:page', element: <FeedPage feedType="news" /> },
+      { path: 'newest/:page', element: <FeedPage feedType="newest" /> },
+      { path: 'show/:page', element: <FeedPage feedType="show" /> },
+      { path: 'ask/:page', element: <FeedPage feedType="ask" /> },
+      { path: 'jobs/:page', element: <FeedPage feedType="jobs" /> },
       { path: 'item/:id', element: <div>Item details placeholder</div> },
       { path: 'user/:id', element: <div>User placeholder</div> },
     ],


### PR DESCRIPTION
## Summary

Implements the feed listing pages and item component, porting from the Angular `feeds/` module.

**`src/pages/FeedPage.tsx`** — receives `feedType` prop, uses `useParams()` for page number. Calls `fetchFeed()` in `useEffect`, shows `<Loader />` while loading, `<ErrorMessage />` on failure. Renders `<ol start={listStart}>` with `<Item />` per story. Prev/More pagination links. Jobs feed gets a header paragraph.

**`src/components/Item.tsx`** — receives `Story` as prop. External URLs → `<a href>`, internal → `<Link to="/item/:id">`. Renders two responsive variants: `subtext-palm` (mobile) and `subtext-laptop` (desktop). Uses `useSettings()` for `titleFontSize`, `listSpacing`, `openLinkInNewTab`. Calls `commentPipe()` for comment count display.

**`src/router.tsx`** — updated to wire all feed routes (`/news/:page`, `/newest/:page`, `/show/:page`, `/ask/:page`, `/jobs/:page`) to `<FeedPage feedType="..." />`.

Stacks on PR 3 (`devin-06.17.2026-vibha/add-app-shell-components`).

Link to Devin session: https://app.devin.ai/sessions/88a4167085734f5a9012719a02dc7066
Requested by: @vibhaseshadri-cognition
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/344?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/344" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->