### PR TITLE
PR 5/7: Item details & recursive comments

### DIFF
--- a/src/components/Comment.scss
+++ b/src/components/Comment.scss
@@ -1,0 +1,83 @@
+@import "../scss/media";
+@import "../scss/theme_variables";
+
+.comment-tree a {
+  font-weight: bold;
+  text-decoration: none;
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.meta {
+  font-size: 13px;
+  color: #696969;
+  font-weight: bold;
+  letter-spacing: 0.5px;
+  margin-bottom: 8px;
+  a {
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+  .time {
+    padding-left: 5px;
+  }
+}
+
+@media #{$mobile-only} {
+  .meta {
+    font-size: 14px;
+    margin-bottom: 10px;
+    .time {
+      padding: 0;
+      float: right;
+    }
+  }
+}
+
+.meta-collapse {
+  margin-bottom: 20px;
+}
+
+.deleted-meta {
+  font-size: 12px;
+  font-weight: bold;
+  letter-spacing: 0.5px;
+  margin: 30px 0;
+  a {
+    text-decoration: none;
+  }
+}
+
+.collapse-toggle {
+  font-size: 13px;
+  letter-spacing: 2px;
+  cursor: pointer;
+}
+
+.comment-tree {
+  margin-left: 24px;
+}
+
+@media #{$tablet-only} {
+  .comment-tree {
+    margin-left: 8px;
+  }
+}
+
+.comment-text {
+  font-size: 15px;
+  margin-top: 0;
+  margin-bottom: 20px;
+  word-wrap: break-word;
+  line-height: 1.5em;
+}
+
+.subtree {
+  margin-left: 0;
+  padding: 0;
+  list-style-type: none;
+}

--- a/src/components/Comment.tsx
+++ b/src/components/Comment.tsx
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { Comment as CommentType } from '../models/comment';
+import './Comment.scss';
+
+interface CommentProps {
+  comment: CommentType;
+}
+
+function Comment({ comment }: CommentProps) {
+  const [collapsed, setCollapsed] = useState(false);
+
+  if (comment.deleted) {
+    return (
+      <div>
+        <div className="deleted-meta">
+          <span className="collapse-toggle">[deleted]</span> | Comment Deleted
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className={`meta${collapsed ? ' meta-collapse' : ''}`}>
+        <span className="collapse-toggle" onClick={() => setCollapsed(c => !c)}>
+          [{collapsed ? '+' : '-'}]
+        </span>{' '}
+        <Link to={`/user/${comment.user}`}>{comment.user}</Link>
+        <span className="time">{comment.time_ago}</span>
+      </div>
+      <div className="comment-tree">
+        {!collapsed && (
+          <div>
+            <p className="comment-text" dangerouslySetInnerHTML={{ __html: comment.content }} />
+            <ul className="subtree">
+              {comment.comments &&
+                comment.comments.map(subComment => (
+                  <li key={subComment.id}>
+                    <Comment comment={subComment} />
+                  </li>
+                ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default Comment;

--- a/src/models/story.ts
+++ b/src/models/story.ts
@@ -16,6 +16,7 @@ export interface Story {
   comments_count: number;
   poll: PollResult[];
   poll_votes_count: number;
+  content: string;
   deleted: boolean;
   dead: boolean;
 }

--- a/src/pages/ItemDetailsPage.scss
+++ b/src/pages/ItemDetailsPage.scss
@@ -1,0 +1,151 @@
+@import "../scss/media";
+@import "../scss/theme_variables";
+
+.main-content {
+  position: relative;
+  width: 100%;
+  min-height: 100vh;
+  -webkit-transition: opacity .2s ease;
+  transition: opacity .2s ease;
+  box-sizing: border-box;
+  padding: 8px 0;
+  z-index: 0;
+}
+
+.item {
+  box-sizing: border-box;
+  padding: 10px 40px 0 40px;
+  z-index: 0;
+}
+
+@media #{$tablet-only} {
+  .item {
+    padding: 10px 20px 0 40px;
+  }
+}
+
+@media #{$mobile-only} {
+  .item {
+    box-sizing: border-box;
+    padding: 110px 15px 0 15px;
+  }
+}
+
+.head-margin {
+  margin-bottom: 15px;
+}
+
+p {
+  margin: 2px 0;
+}
+
+.subject {
+  word-wrap: break-word;
+  margin-top: 20px;
+}
+
+a {
+  cursor: pointer;
+  text-decoration: none;
+}
+
+@media #{$mobile-only} {
+  .laptop {
+    display: none;
+  }
+}
+
+@media #{$laptop-only} {
+  .mobile {
+    display: none;
+  }
+}
+
+.title {
+  font-size: 16px;
+  font-family: Verdana, Geneva, sans-serif;
+}
+
+.title-block {
+  text-align: center;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  margin: 0 75px;
+}
+
+@media #{$mobile-only} {
+  .title {
+    font-size: 15px;
+  }
+  .back-button {
+    position: absolute;
+    top: 52%;
+    width: 0.6rem;
+    height: 0.6rem;
+    background: transparent;
+    box-shadow: 0 0 0 lightgray;
+    transition: all 200ms ease;
+    left: 4%;
+    transform: translate3d(0, -50%, 0) rotate(-135deg);
+  }
+}
+
+.subtext {
+  font-size: 12px;
+  font-weight: bold;
+  letter-spacing: 0.5px;
+}
+
+.domain {
+  letter-spacing: 0.5px;
+}
+
+.subtext a {
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.item-details {
+  padding: 10px;
+}
+
+.item-header {
+  padding-bottom: 10px;
+}
+
+@media #{$mobile-only} {
+  .item-header {
+    padding: 10px 0 10px 0;
+    position: fixed;
+    width: 100%;
+    left: 0;
+    top: 62px;
+  }
+}
+
+.pollResults {
+  margin-bottom: 1em;
+}
+
+.pollContent {
+  * {
+    padding-bottom: 0;
+    margin-bottom: -1em;
+    margin-top: 1em;
+  }
+  .pollBar {
+    height: 10px;
+    margin-bottom: 1em;
+  }
+}
+
+ul {
+  list-style-type: none;
+  padding: 10px 0;
+}
+
+li {
+  display: list-item;
+}

--- a/src/pages/ItemDetailsPage.tsx
+++ b/src/pages/ItemDetailsPage.tsx
@@ -1,0 +1,132 @@
+import { useState, useEffect } from 'react';
+import { useParams, useNavigate, Link } from 'react-router-dom';
+import { fetchItemContent } from '../services/hackerNewsApi';
+import { useSettings } from '../contexts/SettingsContext';
+import { commentPipe } from '../utils/commentPipe';
+import { Story } from '../models/story';
+import Comment from '../components/Comment';
+import Loader from '../components/Loader';
+import ErrorMessage from '../components/ErrorMessage';
+import './ItemDetailsPage.scss';
+
+function ItemDetailsPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const { settings } = useSettings();
+  const [item, setItem] = useState<Story | null>(null);
+  const [errorMessage, setErrorMessage] = useState('');
+
+  useEffect(() => {
+    setItem(null);
+    setErrorMessage('');
+
+    if (id) {
+      fetchItemContent(parseInt(id, 10))
+        .then(data => setItem(data))
+        .catch(() => setErrorMessage('Could not load item comments.'));
+    }
+
+    window.scrollTo(0, 0);
+  }, [id]);
+
+  const goBack = () => navigate(-1);
+
+  const hasUrl = item ? item.url && item.url.indexOf('http') === 0 : false;
+
+  return (
+    <div className="main-content">
+      {!item && !errorMessage && <Loader />}
+      {!item && errorMessage !== '' && <ErrorMessage message={errorMessage} />}
+
+      {item && (
+        <div className="item">
+          <div className="mobile item-header">
+            <p className="title-block">
+              <span className="back-button" onClick={goBack}></span>
+              {hasUrl ? (
+                <a
+                  className="title"
+                  href={item.url}
+                  target={settings.openLinkInNewTab ? '_blank' : undefined}
+                  rel={settings.openLinkInNewTab ? 'noopener' : undefined}
+                >
+                  {item.title}
+                </a>
+              ) : (
+                <Link className="title" to={`/item/${item.id}`}>
+                  {item.title}
+                </Link>
+              )}
+            </p>
+          </div>
+          <div
+            className={`laptop${item.comments_count > 0 || item.type === 'job' ? ' item-header' : ''}${item.content ? ' head-margin' : ''}`}
+          >
+            {hasUrl ? (
+              <p>
+                <a
+                  className="title"
+                  href={item.url}
+                  target={settings.openLinkInNewTab ? '_blank' : undefined}
+                  rel={settings.openLinkInNewTab ? 'noopener' : undefined}
+                >
+                  {item.title}
+                </a>
+                {item.domain && <span className="domain">({item.domain})</span>}
+              </p>
+            ) : (
+              <p>
+                <Link className="title" to={`/item/${item.id}`}>
+                  {item.title}
+                </Link>
+              </p>
+            )}
+            <div className="subtext">
+              {item.type !== 'job' && (
+                <span>
+                  {item.points} points by{' '}
+                  <Link to={`/user/${item.user}`}>{item.user}</Link>
+                </span>
+              )}
+              <span className={item.type !== 'job' ? 'item-details' : undefined}>
+                {item.time_ago}
+                {item.type !== 'job' && (
+                  <span>
+                    {' '}| <Link to={`/item/${item.id}`}>{commentPipe(item.comments_count)}</Link>
+                  </span>
+                )}
+              </span>
+            </div>
+          </div>
+          {item.type === 'poll' && item.poll && (
+            <div className="pollResults">
+              {item.poll.map((pollResult, i) => (
+                <div key={i} className="pollContent">
+                  <div dangerouslySetInnerHTML={{ __html: pollResult.content }} />
+                  <div className="subtext">{pollResult.points} points</div>
+                  <div
+                    className="pollBar"
+                    style={{ width: `${(pollResult.points / item.poll_votes_count) * 100}%` }}
+                  />
+                </div>
+              ))}
+            </div>
+          )}
+          {item.content && (
+            <p className="subject" dangerouslySetInnerHTML={{ __html: item.content }} />
+          )}
+          <ul className="comment-list">
+            {item.comments &&
+              item.comments.map(comment => (
+                <li key={comment.id}>
+                  <Comment comment={comment} />
+                </li>
+              ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default ItemDetailsPage;

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,6 +1,10 @@
+import { lazy, Suspense } from 'react';
 import { createBrowserRouter, Navigate } from 'react-router-dom';
 import App from './components/App';
 import FeedPage from './pages/FeedPage';
+import Loader from './components/Loader';
+
+const ItemDetailsPage = lazy(() => import('./pages/ItemDetailsPage'));
 
 const router = createBrowserRouter([
   {
@@ -13,7 +17,14 @@ const router = createBrowserRouter([
       { path: 'show/:page', element: <FeedPage feedType="show" /> },
       { path: 'ask/:page', element: <FeedPage feedType="ask" /> },
       { path: 'jobs/:page', element: <FeedPage feedType="jobs" /> },
-      { path: 'item/:id', element: <div>Item details placeholder</div> },
+      {
+        path: 'item/:id',
+        element: (
+          <Suspense fallback={<Loader />}>
+            <ItemDetailsPage />
+          </Suspense>
+        ),
+      },
       { path: 'user/:id', element: <div>User placeholder</div> },
     ],
   },


### PR DESCRIPTION
## Summary

Implements the item details page and recursive comment tree, porting from the Angular `item-details/` module.

**`src/pages/ItemDetailsPage.tsx`** — fetches item via `fetchItemContent(id)` in `useEffect`. Renders mobile (`item-header` with back button) and laptop views with title, subtext, poll results (percentage-width bars), HTML content, and comment list. Uses `React.lazy()` for code splitting. `goBack()` via `useNavigate(-1)`.

**`src/components/Comment.tsx`** — recursive component: renders `comment.content` via `dangerouslySetInnerHTML`, author link, time, collapse `[+/-]` toggle, and recursively renders `comment.comments`. Deleted comments show `[deleted] | Comment Deleted`.

**`src/models/story.ts`** — added missing `content: string` field (used for item text/HTML body in the API response).

**`src/router.tsx`** — `/item/:id` route now lazy-loads `ItemDetailsPage` with `<Suspense fallback={<Loader />}>`.

Stacks on PR 4 (`devin-06.17.2026-vibha/add-feed-pages`).

Link to Devin session: https://app.devin.ai/sessions/88a4167085734f5a9012719a02dc7066
Requested by: @vibhaseshadri-cognition
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/345?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/345" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->