### PR TITLE
PR 6/7: User profile page

### DIFF
--- a/src/pages/UserPage.scss
+++ b/src/pages/UserPage.scss
@@ -1,0 +1,89 @@
+@import "../scss/media";
+@import "../scss/theme_variables";
+
+pre {
+  white-space: pre-wrap;
+}
+
+.profile {
+  padding: 30px;
+}
+
+@media #{$mobile-only} {
+  .profile {
+    padding: 110px 15px 0 15px;
+  }
+  .title-block {
+    font-size: 15px;
+    text-align: center;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    margin: 0 75px;
+  }
+  .back-button {
+    position: absolute;
+    top: 52%;
+    width: 0.6rem;
+    height: 0.6rem;
+    background: transparent;
+    box-shadow: 0 0 0 lightgray;
+    transition: all 200ms ease;
+    left: 4%;
+    transform: translate3d(0, -50%, 0) rotate(-135deg);
+  }
+  .item-header {
+    padding-bottom: 10px;
+    background-color: #fff;
+    padding: 10px 0 10px 0;
+    position: fixed;
+    width: 100%;
+    left: 0;
+    top: 62px;
+    height: 20px;
+  }
+}
+
+@media #{$laptop-only} {
+  .mobile {
+    display: none;
+  }
+}
+
+.main-details {
+  .name {
+    font-weight: bold;
+    font-size: 32px;
+    letter-spacing: 2px;
+  }
+  .age {
+    font-weight: bold;
+    color: #696969;
+    padding-bottom: 0;
+  }
+  .right {
+    float: right;
+    font-weight: bold;
+    font-size: 32px;
+    letter-spacing: 2px;
+  }
+}
+
+@media #{$mobile-only} {
+  .main-details {
+    margin-top: 20px;
+    .name {
+      font-size: 18px;
+    }
+  }
+}
+
+@media #{$mobile-only} {
+  .main-details .right {
+    font-size: 18px;
+  }
+}
+
+.other-details {
+  word-wrap: break-word;
+}

--- a/src/pages/UserPage.tsx
+++ b/src/pages/UserPage.tsx
@@ -1,0 +1,57 @@
+import { useState, useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { fetchUser } from '../services/hackerNewsApi';
+import { User } from '../models/user';
+import Loader from '../components/Loader';
+import ErrorMessage from '../components/ErrorMessage';
+import './UserPage.scss';
+
+function UserPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const [user, setUser] = useState<User | null>(null);
+  const [errorMessage, setErrorMessage] = useState('');
+
+  useEffect(() => {
+    setUser(null);
+    setErrorMessage('');
+
+    if (id) {
+      fetchUser(id)
+        .then(data => setUser(data))
+        .catch(() => setErrorMessage(`Could not load user ${id}.`));
+    }
+  }, [id]);
+
+  const goBack = () => navigate(-1);
+
+  return (
+    <>
+      {!user && !errorMessage && <Loader />}
+      {!user && errorMessage !== '' && <ErrorMessage message={errorMessage} />}
+
+      {user && (
+        <div className="profile">
+          <div className="mobile item-header">
+            <p className="title-block">
+              <span className="back-button" onClick={goBack}></span>
+              Profile: {user.id}
+            </p>
+          </div>
+          <div className="main-details">
+            <span className="name">{user.id}</span>
+            <span className="right">{user.karma} ★</span>
+            <p className="age">Created {user.created}</p>
+          </div>
+          {user.about && (
+            <div className="other-details">
+              <p dangerouslySetInnerHTML={{ __html: user.about }} />
+            </div>
+          )}
+        </div>
+      )}
+    </>
+  );
+}
+
+export default UserPage;

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -5,6 +5,7 @@ import FeedPage from './pages/FeedPage';
 import Loader from './components/Loader';
 
 const ItemDetailsPage = lazy(() => import('./pages/ItemDetailsPage'));
+const UserPage = lazy(() => import('./pages/UserPage'));
 
 const router = createBrowserRouter([
   {
@@ -25,7 +26,14 @@ const router = createBrowserRouter([
           </Suspense>
         ),
       },
-      { path: 'user/:id', element: <div>User placeholder</div> },
+      {
+        path: 'user/:id',
+        element: (
+          <Suspense fallback={<Loader />}>
+            <UserPage />
+          </Suspense>
+        ),
+      },
     ],
   },
 ]);


### PR DESCRIPTION
## Summary

Implements the user profile page, porting from the Angular `user/` module.

**`src/pages/UserPage.tsx`** — fetches user via `fetchUser(id)` in `useEffect`. Renders mobile header with back button, username, karma score, creation date, and `about` HTML content via `dangerouslySetInnerHTML`. `goBack()` via `useNavigate(-1)`.

**`src/pages/UserPage.scss`** — ported from Angular `user.component.scss` with responsive mobile/laptop layouts, fixed mobile header positioning, and back-button arrow styling.

**`src/router.tsx`** — `/user/:id` route now lazy-loads `UserPage` with `<Suspense fallback={<Loader />}>`.

Stacks on PR 5 (`devin-06.17.2026-vibha/add-item-details-comments`).

Link to Devin session: https://app.devin.ai/sessions/88a4167085734f5a9012719a02dc7066
Requested by: @vibhaseshadri-cognition
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/346?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/346" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->