### PR TITLE
Migrate user profile page to React

### DIFF
--- a/src/features/user/User.scss
+++ b/src/features/user/User.scss
@@ -1,0 +1,89 @@
+@import "../../styles/media";
+@import "../../styles/theme_variables";
+
+.profile pre {
+  white-space: pre-wrap;
+}
+
+.profile {
+  padding: 30px;
+}
+
+@media #{$mobile-only} {
+  .profile {
+    padding: 110px 15px 0 15px;
+  }
+  .title-block {
+    font-size: 15px;
+    text-align: center;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    margin: 0 75px;
+  }
+  .back-button {
+    position: absolute;
+    top: 52%;
+    width: 0.6rem;
+    height: 0.6rem;
+    background: transparent;
+    box-shadow: 0 0 0 lightgray;
+    transition: all 200ms ease;
+    left: 4%;
+    transform: translate3d(0, -50%, 0) rotate(-135deg);
+  }
+  .item-header {
+    padding-bottom: 10px;
+    background-color: #fff;
+    padding: 10px 0 10px 0;
+    position: fixed;
+    width: 100%;
+    left: 0;
+    top: 62px;
+    height: 20px;
+  }
+}
+
+@media #{$laptop-only} {
+  .mobile {
+    display: none;
+  }
+}
+
+.main-details {
+  .name {
+    font-weight: bold;
+    font-size: 32px;
+    letter-spacing: 2px;
+  }
+  .age {
+    font-weight: bold;
+    color: #696969;
+    padding-bottom: 0;
+  }
+  .right {
+    float: right;
+    font-weight: bold;
+    font-size: 32px;
+    letter-spacing: 2px;
+  }
+}
+
+@media #{$mobile-only} {
+  .main-details {
+    margin-top: 20px;
+    .name {
+      font-size: 18px;
+    }
+  }
+}
+
+@media #{$mobile-only} {
+  .main-details .right {
+    font-size: 18px;
+  }
+}
+
+.other-details {
+  word-wrap: break-word;
+}

--- a/src/features/user/User.tsx
+++ b/src/features/user/User.tsx
@@ -1,4 +1,77 @@
-// PLACEHOLDER — replaced by the user-profile migration session.
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import type { User as HNUser } from '../../types';
+import { fetchUser } from '../../services/hackerNewsApi';
+import { Loader } from '../../components/Loader/Loader';
+import { ErrorMessage } from '../../components/ErrorMessage/ErrorMessage';
+import './User.scss';
+
 export function User() {
-  return <div className="profile" />;
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const [user, setUser] = useState<HNUser | null>(null);
+  const [errorMessage, setErrorMessage] = useState('');
+
+  useEffect(() => {
+    if (!id) {
+      return;
+    }
+
+    let cancelled = false;
+    setUser(null);
+    setErrorMessage('');
+
+    fetchUser(id)
+      .then((data) => {
+        if (!cancelled) {
+          setUser(data);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setErrorMessage(`Could not load user ${id}.`);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  const goBack = () => {
+    navigate(-1);
+  };
+
+  if (!user && !errorMessage) {
+    return <Loader />;
+  }
+
+  if (!user && errorMessage !== '') {
+    return <ErrorMessage message={errorMessage} />;
+  }
+
+  if (!user) {
+    return null;
+  }
+
+  return (
+    <div className="profile">
+      <div className="mobile item-header">
+        <p className="title-block">
+          <span className="back-button" onClick={goBack}></span>
+          Profile: {user.id}
+        </p>
+      </div>
+      <div className="main-details">
+        <span className="name">{user.id}</span>
+        <span className="right">{user.karma} ★</span>
+        <p className="age">Created {user.created}</p>
+      </div>
+      {user.about && (
+        <div className="other-details">
+          <p dangerouslySetInnerHTML={{ __html: user.about }}></p>
+        </div>
+      )}
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
Ports the Angular `UserComponent` (`/user/:id`) to React in `src/features/user/`, building on the foundation branch. Behavior and markup mirror the original: fetch the user by username, show `<Loader />` while pending, `<ErrorMessage />` on failure, then render the profile.

`User.tsx` — replaces the placeholder:
- `id = useParams<{ id: string }>().id`; fetch in `useEffect` keyed on `id` with a `cancelled` flag so stale/unmounted responses don't set state.
- Error text matches the original verbatim: `` `Could not load user ${id}.` ``.
- Render states mirror the Angular `*ngIf`s: `!user && !error → Loader`, `!user && error → ErrorMessage`, else the `.profile` markup.
- `about` is raw HTML → `dangerouslySetInnerHTML={{ __html: user.about }}` (the Angular `[innerHTML]`).
- The mobile back button's `goBack()` (Angular `Location.back()`) maps to `useNavigate()` → `navigate(-1)`.
- The `User` type is imported aliased (`User as HNUser`) to avoid colliding with the component name.

`User.scss` — original SCSS body copied verbatim, with two changes required to leave Angular-isms behind:
- The two `@import`s repointed to `../../styles/media` and `../../styles/theme_variables`.
- Angular's `:host >>> pre { white-space: pre-wrap; }` (ViewEncapsulation deep selector, invalid in plain Sass) rewritten as `.profile pre { ... }` — scoped to this feature so it doesn't leak globally.

All original class names (`profile`, `mobile`, `item-header`, `title-block`, `back-button`, `main-details`, `name`, `right`, `age`, `other-details`) are preserved so the global theme engine in `src/styles/_themes.scss` still targets them.

No files outside `src/features/user/` were touched; no new dependencies. `npm run lint`, `npm run typecheck`, and `npm run build` all pass (Dart Sass `@import`/division deprecation warnings are pre-existing and non-fatal).

Link to Devin session: https://app.devin.ai/sessions/390ddf5a08b241a8967a18745a0ea1d9
Requested by: @eashansinha
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| 🟢 Reviewed | [`e6236b7`](https://github.com/cog-gtm/angular2-hn/pull/349/commits/e6236b7b85269ce8ecd681cd61895ffa71eff8d6) |

<a href="https://staging.itsdev.in/review/cog-gtm/angular2-hn/pull/349" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->