### PR TITLE
Migrate core chrome (Header + Footer + Settings) to React

### DIFF
--- a/src/core/Footer/Footer.scss
+++ b/src/core/Footer/Footer.scss
@@ -1,0 +1,23 @@
+@import "../../styles/media";
+@import "../../styles/theme_variables";
+
+#footer {
+  position: relative;
+  padding: 10px;
+  height: 60px;
+  letter-spacing: 0.7px;
+  text-align: center;
+
+  a {
+        font-weight: bold;
+        text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  @media #{$mobile-only} {
+    display: none;
+  }
+}

--- a/src/core/Footer/Footer.tsx
+++ b/src/core/Footer/Footer.tsx
@@ -1,4 +1,14 @@
-// PLACEHOLDER — replaced by the core-chrome migration session.
+import './Footer.scss';
+
 export function Footer() {
-  return <footer />;
+  return (
+    <div id="footer">
+      <p>
+        Show this project some ❤ on{' '}
+        <a href="https://github.com/hdjirdeh/angular2-hn" target="_blank" rel="noopener">
+          GitHub
+        </a>
+      </p>
+    </div>
+  );
 }

--- a/src/core/Header/Header.scss
+++ b/src/core/Header/Header.scss
@@ -1,0 +1,149 @@
+@import "../../styles/media";
+@import "../../styles/theme_variables";
+
+#header {
+  color: #fff;
+  padding: 6px 0;
+  line-height: 18px;
+  vertical-align: middle;
+  position: relative;
+  z-index: 1;
+  width: 100%;
+
+  @media #{$mobile-only} {
+    height: 50px;
+    position: fixed;
+    top: 0;
+  }
+
+  a {
+    display: inline;
+  }
+}
+
+.home-link {
+  width: 50px;
+  height: 66px;
+}
+
+.logo-inner {
+  width: 32px;
+  position: absolute;
+  left: 17px;
+  top: 18px;
+  z-index: -1;
+  height: 32px;
+  border-radius: 50%;
+
+  @media #{$mobile-only} {
+    left: 16px;
+    top: 12px;
+  }
+}
+
+.logo {
+  width: 50px;
+  padding: 3px 8px 0;
+
+  @media #{$mobile-only} {
+    width: 45px;
+    padding: 0 0 0 10px;
+  }
+}
+
+h1 {
+  font-weight: normal;
+  display: inline-block;
+  vertical-align:middle;
+  margin: 0;
+  font-size: 16px;
+
+  a {
+    color: #fff;
+    text-decoration: none;
+  }
+}
+
+.name {
+  margin-right: 30px;
+  margin-bottom: 2px;
+
+  @media #{$mobile-only} {
+    display: none;
+  }
+}
+
+.header-text {
+  position: absolute;
+  width: inherit;
+  height: 20px;
+  left: 10px;
+  top: 27px;
+  z-index: -1;
+
+  @media #{$mobile-only} {
+    top: 22px;
+  }
+}
+
+.left {
+  position: absolute;
+  left: 60px;
+  font-size: 16px;
+
+  @media #{$mobile-only} {
+    width: 100%;
+    left: 0;
+  }
+}
+
+.header-nav {
+  display: inline-block;
+  margin-left: 20px;
+
+  @media #{$mobile-only} {
+    margin-left: 60px;
+  }
+
+  a {
+    color: hsla(0,0%,100%,.9);
+    text-decoration: none;
+    margin: 0 5px;
+    letter-spacing: 1.8px;
+
+    &:hover {
+      color: #fff;
+    }
+  }
+
+  .active {
+    color: #fff;
+  }
+}
+
+.info {
+  position: absolute;
+  top: 0;
+  right: 20px;
+  height: 100%;
+
+  @media #{$mobile-only} {
+    right: 10px;
+  }
+
+  img {
+    opacity: 0.8;
+    width: 25px;
+    margin-top: 21.5px;
+    display: block;
+
+    &:hover {
+      opacity: 1;
+      cursor: pointer;
+    }
+
+    @media #{$mobile-only} {
+      margin-top: 15px;
+    }
+  }
+}

--- a/src/core/Header/Header.tsx
+++ b/src/core/Header/Header.tsx
@@ -1,4 +1,45 @@
-// PLACEHOLDER — replaced by the core-chrome migration session.
+import { NavLink } from 'react-router-dom';
+import { useSettings } from '../../context/SettingsContext';
+import { Settings } from '../Settings/Settings';
+import './Header.scss';
+
 export function Header() {
-  return <header />;
+  const { settings, toggleSettings } = useSettings();
+
+  const scrollTop = () => {
+    window.scrollTo(0, 0);
+  };
+
+  return (
+    <header>
+      <div id="header">
+        <NavLink className="home-link" to="/news/1" onClick={scrollTop}>
+          <div className="logo-inner"></div>
+          <img className="logo" src="/assets/images/logo.svg" alt="React HN" />
+        </NavLink>
+        <div className="header-text">
+          <div className="left">
+            <span className="header-nav">
+              <NavLink to="/newest/1" onClick={scrollTop}>new</NavLink>
+              {' '}|{' '}
+              <NavLink to="/show/1" onClick={scrollTop}>show</NavLink>
+              {' '}|{' '}
+              <NavLink to="/ask/1" onClick={scrollTop}>ask</NavLink>
+              {' '}|{' '}
+              <NavLink to="/jobs/1" onClick={scrollTop}>jobs</NavLink>
+            </span>
+          </div>
+        </div>
+        <div className="info">
+          <img
+            className="settings"
+            src="/assets/images/cog.svg"
+            alt="Settings"
+            onClick={toggleSettings}
+          />
+        </div>
+      </div>
+      {settings.showSettings && <Settings />}
+    </header>
+  );
 }

--- a/src/core/Settings/Settings.scss
+++ b/src/core/Settings/Settings.scss
@@ -1,0 +1,74 @@
+@import "../../styles/media";
+@import "../../styles/theme_variables";
+
+.overlay {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: rgba(0, 0, 0, 0.7);
+  opacity: 1;
+  z-index: 1;
+}
+
+.popup {
+  margin: 70px auto;
+  padding: 30px;
+  border-radius: 5px;
+  width: 30%;
+  position: relative;
+  h1 {
+    margin-top: 0;
+    margin-bottom: 0px;
+    color: #fff;
+    text-align: center;
+    letter-spacing: 1px;
+  }
+  h2 {
+    padding-top: 10px;
+  }
+  hr {
+    width: 40%;
+    margin-bottom: 20px;
+  }
+  .close {
+    position: absolute;
+    top: 12px;
+    right: 20px;
+    font-size: 30px;
+    font-weight: bold;
+    text-decoration: none;
+    color: rgba(255,255,255,0.8);
+    &:hover {
+      color: #fff;
+      cursor: pointer;
+    }
+  }
+  .content {
+    max-height: 30%;
+    color: #fff;
+    letter-spacing: 1px;
+    overflow: auto;
+  }
+  input[type=number] {
+      display: block;
+      width: 80%;
+      height: 20px;
+      margin-bottom: 15px;
+      border-radius: 5px;
+      padding: 2px;
+  }
+}
+
+.control-section {
+    margin-bottom: 15px;
+    padding-bottom: 15px;
+    border-bottom: 1px solid white;
+}
+
+@media screen and (max-width: 700px) {
+  .box, .popup {
+    width: 70%;
+  }
+}

--- a/src/core/Settings/Settings.tsx
+++ b/src/core/Settings/Settings.tsx
@@ -1,0 +1,102 @@
+import { useSettings } from '../../context/SettingsContext';
+import './Settings.scss';
+
+export function Settings() {
+  const {
+    settings,
+    toggleSettings,
+    toggleOpenLinksInNewTab,
+    setTheme,
+    setFont,
+    setSpacing,
+  } = useSettings();
+
+  return (
+    <div id="popup1" className="overlay">
+      <div className="popup">
+        <h1>Settings</h1>
+        <hr />
+        <span className="close" onClick={toggleSettings}>&times;</span>
+        <div className="content">
+          <div className="control-section">
+            <h2>Links</h2>
+            <input
+              type="checkbox"
+              checked={settings.openLinkInNewTab}
+              onChange={toggleOpenLinksInNewTab}
+            />
+            Open links in a new tab
+          </div>
+          <div className="theme-controls">
+            <div className="control-section">
+              <h2>Select a theme</h2>
+              <div>
+                <label>
+                  <input
+                    name="theme"
+                    type="radio"
+                    value="default"
+                    checked={settings.theme === 'default'}
+                    onChange={() => setTheme('default')}
+                  />
+                  Default
+                </label>
+              </div>
+              <div>
+                <label>
+                  <input
+                    name="theme"
+                    type="radio"
+                    value="night"
+                    checked={settings.theme === 'night'}
+                    onChange={() => setTheme('night')}
+                  />
+                  Night
+                </label>
+              </div>
+              <div>
+                <label>
+                  <input
+                    name="theme"
+                    type="radio"
+                    value="amoledblack"
+                    checked={settings.theme === 'amoledblack'}
+                    onChange={() => setTheme('amoledblack')}
+                  />
+                  Black (AMOLED)
+                </label>
+              </div>
+            </div>
+            <div className="control-section">
+              <h2>Change Font</h2>
+              <div>
+                <label>
+                  Font size:
+                  <input
+                    min="1"
+                    value={settings.titleFontSize}
+                    name="theme"
+                    type="number"
+                    onChange={(event) => setFont(event.target.value)}
+                  />
+                </label>
+              </div>
+              <div>
+                <label>
+                  List spacing:
+                  <input
+                    min="0"
+                    value={settings.listSpacing}
+                    name="theme"
+                    type="number"
+                    onChange={(event) => setSpacing(event.target.value)}
+                  />
+                </label>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Ports the Angular `HeaderComponent`, `FooterComponent`, and `SettingsComponent` to React 18 + TS on top of the migration foundation branch. These three components are the app's persistent chrome — `App.tsx` already renders `<Header />`/`<Footer />` around the routed pages, so this fills in the previous placeholders.

All markup/classes/SCSS are ported verbatim from `master` (only the two SCSS `@import` paths are rewritten to `../../styles/...`) so the global theme engine in `src/styles/_themes.scss`, which targets the literal class names (`#header`, `.logo-inner`, `#footer`, `.popup`, …), keeps working. Visible branding updated to **React HN** (the logo `alt` text; see note — neither component had a literal "Angular 2 HN" text node).

Key Angular → React mappings:
- `SettingsService` → `useSettings()` from the shared `SettingsContext`. `Settings` panel wires `toggleOpenLinksInNewTab` / `setTheme(default|night|amoledblack)` / `setFont` / `setSpacing` / `toggleSettings`; controls are React-controlled and reflect `settings`.
- `routerLink` + `routerLinkActive="active"` → `<NavLink to=…>` (v6 NavLink applies the `active` class by default, matching the original CSS `.header-nav .active`). `scrollTop()` preserved as an `onClick`.
- `*ngIf="settings.showSettings"` → `{settings.showSettings && <Settings />}` rendered by `Header`.
- Footer GitHub link keeps the original unconditional `target="_blank" rel="noopener"` (the Angular footer did not consult settings).

Files: `src/core/{Header,Footer,Settings}/*.{tsx,scss}` (6 files; Header/Footer overwrite placeholders, Settings is new). No files outside `src/core/` touched; no new deps.

`npm run lint` (max-warnings 0), `npm run typecheck`, and `npm run build` all pass (only the expected Dart Sass `@import`/legacy-API deprecation warnings).

### Note
Neither the Angular header nor footer rendered a literal "Angular 2 HN" text node (the brand is the logo image; the footer reads "Show this project some ❤ on GitHub"). There was therefore no visible brand string to rename; I set the logo `alt` to "React HN" to reflect the rebrand and left the rest faithful.


Link to Devin session: https://app.devin.ai/sessions/b1fa87a6ade340838759e9e2c39305f6
Requested by: @eashansinha
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| 🟢 Reviewed | [`8beebd0`](https://github.com/cog-gtm/angular2-hn/pull/350/commits/8beebd025681e27f8e7fcf634070cdfbe19a9828) |

<a href="https://staging.itsdev.in/review/cog-gtm/angular2-hn/pull/350" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->