### PR TITLE
Migrate item details slice (item page + recursive comments + polls) to React

### DIFF
--- a/src/features/item/Comment.scss
+++ b/src/features/item/Comment.scss
@@ -1,0 +1,86 @@
+@import "../../styles/media";
+@import "../../styles/theme_variables";
+
+.meta,
+.comment-tree {
+  a {
+    font-weight: bold;
+    text-decoration: none;
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}
+
+.meta {
+  font-size: 13px;
+  color: #696969;
+  font-weight: bold;
+  letter-spacing: 0.5px;
+  margin-bottom: 8px;
+  a {
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+  .time {
+    padding-left: 5px;
+  }
+}
+
+@media #{$mobile-only} {
+  .meta {
+    font-size: 14px;
+    margin-bottom: 10px;
+    .time {
+      padding: 0;
+      float: right;
+    }
+  }
+}
+
+.meta-collapse {
+  margin-bottom: 20px;
+}
+
+.deleted-meta {
+  font-size: 12px;
+  font-weight: bold;
+  letter-spacing: 0.5px;
+  margin: 30px 0;
+  a {
+    text-decoration: none;
+  }
+}
+
+.collapse {
+  font-size: 13px;
+  letter-spacing: 2px;
+  cursor: pointer;
+}
+
+.comment-tree {
+  margin-left: 24px;
+}
+
+@media #{$tablet-only} {
+  .comment-tree {
+    margin-left: 8px;
+  }
+}
+
+.comment-text {
+  font-size: 15px;
+  margin-top: 0;
+  margin-bottom: 20px;
+  word-wrap: break-word;
+  line-height: 1.5em;
+}
+
+.subtree {
+  margin-left: 0;
+  padding: 0;
+  list-style-type: none;
+}

--- a/src/features/item/Comment.tsx
+++ b/src/features/item/Comment.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import type { Comment as CommentModel } from '../../types';
+import './Comment.scss';
+
+interface CommentProps {
+  comment: CommentModel;
+}
+
+export function Comment({ comment }: CommentProps) {
+  const [collapse, setCollapse] = useState(false);
+
+  if (comment.deleted) {
+    return (
+      <div>
+        <div className="deleted-meta">
+          <span className="collapse">[deleted]</span> | Comment Deleted
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className={collapse ? 'meta meta-collapse' : 'meta'}>
+        <span className="collapse" onClick={() => setCollapse(!collapse)}>
+          [{collapse ? '+' : '-'}]
+        </span>
+        <Link to={`/user/${comment.user}`}>{comment.user}</Link>
+        <span className="time">{comment.time_ago}</span>
+      </div>
+      <div className="comment-tree">
+        <div hidden={collapse}>
+          <p className="comment-text" dangerouslySetInnerHTML={{ __html: comment.content }}></p>
+          <ul className="subtree">
+            {comment.comments.map((subComment) => (
+              <li key={subComment.id}>
+                <Comment comment={subComment} />
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/item/ItemDetails.scss
+++ b/src/features/item/ItemDetails.scss
@@ -1,0 +1,151 @@
+@import "../../styles/media";
+@import "../../styles/theme_variables";
+
+.main-content {
+  position: relative;
+  width: 100%;
+  min-height: 100vh;
+  -webkit-transition: opacity .2s ease;
+  transition: opacity .2s ease;
+  box-sizing: border-box;
+  padding: 8px 0;
+  z-index: 0;
+}
+
+.item {
+  box-sizing: border-box;
+  padding: 10px 40px 0 40px;
+  z-index: 0;
+}
+
+@media #{$tablet-only} {
+  .item {
+    padding: 10px 20px 0 40px;
+  }
+}
+
+@media #{$mobile-only} {
+  .item {
+    box-sizing: border-box;
+    padding: 110px 15px 0 15px;
+  }
+}
+
+.head-margin {
+  margin-bottom: 15px;
+}
+
+p {
+  margin: 2px 0;
+}
+
+.subject {
+  word-wrap: break-word;
+  margin-top: 20px;
+}
+
+a {
+  cursor: pointer;
+  text-decoration: none;
+}
+
+@media #{$mobile-only} {
+  .laptop {
+    display: none;
+  }
+}
+
+@media #{$laptop-only} {
+  .mobile {
+    display: none;
+  }
+}
+
+.title {
+  font-size: 16px;
+  font-family: Verdana, Geneva, sans-serif;
+}
+
+.title-block {
+  text-align: center;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  margin: 0 75px;
+}
+
+@media #{$mobile-only} {
+  .title {
+    font-size: 15px;
+  }
+  .back-button {
+    position: absolute;
+    top: 52%;
+    width: 0.6rem;
+    height: 0.6rem;
+    background: transparent;
+    box-shadow: 0 0 0 lightgray;
+    transition: all 200ms ease;
+    left: 4%;
+    transform: translate3d(0, -50%, 0) rotate(-135deg);
+  }
+}
+
+.subtext {
+  font-size: 12px;
+  font-weight: bold;
+  letter-spacing: 0.5px;
+}
+
+.domain {
+  letter-spacing: 0.5px;
+}
+
+.subtext a {
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.item-details {
+  padding: 10px;
+}
+
+.item-header {
+  padding-bottom: 10px;
+}
+
+@media #{$mobile-only} {
+  .item-header {
+    padding: 10px 0 10px 0;
+    position: fixed;
+    width: 100%;
+    left: 0;
+    top: 62px;
+  }
+}
+
+.pollResults {
+  margin-bottom: 1em;
+}
+
+.pollContent {
+  * {
+    padding-bottom: 0;
+    margin-bottom: -1em;
+    margin-top: 1em;
+  }
+  .pollBar {
+    height: 10px;
+    margin-bottom: 1em;
+  }
+}
+
+ul {
+  list-style-type: none;
+  padding: 10px 0;
+}
+
+li {
+  display: list-item;
+}

--- a/src/features/item/ItemDetails.tsx
+++ b/src/features/item/ItemDetails.tsx
@@ -1,4 +1,151 @@
-// PLACEHOLDER — replaced by the item-details migration session.
+import { useEffect, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import type { Story } from '../../types';
+import { fetchItemContent } from '../../services/hackerNewsApi';
+import { useSettings } from '../../context/SettingsContext';
+import { Loader } from '../../components/Loader/Loader';
+import { ErrorMessage } from '../../components/ErrorMessage/ErrorMessage';
+import { commentLabel } from '../../utils/comment';
+import { Comment } from './Comment';
+import './ItemDetails.scss';
+
+// The node-hnapi item response carries an HTML `content` body that the shared
+// `Story` type does not declare; augment locally rather than editing shared types.
+type ItemStory = Story & { content?: string };
+
 export function ItemDetails() {
-  return <div className="main-content" />;
+  const params = useParams<{ id: string }>();
+  const id = Number(params.id);
+  const navigate = useNavigate();
+  const { settings } = useSettings();
+
+  const [item, setItem] = useState<ItemStory | null>(null);
+  const [errorMessage, setErrorMessage] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    setItem(null);
+    setErrorMessage('');
+
+    fetchItemContent(id)
+      .then((story) => {
+        if (!cancelled) {
+          setItem(story);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setErrorMessage('Could not load item comments.');
+        }
+      });
+
+    window.scrollTo(0, 0);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  if (!item && errorMessage) {
+    return (
+      <div className="main-content">
+        <ErrorMessage message={errorMessage} />
+      </div>
+    );
+  }
+
+  if (!item) {
+    return (
+      <div className="main-content">
+        <Loader />
+      </div>
+    );
+  }
+
+  const hasUrl = item.url.indexOf('http') === 0;
+  const linkTarget = settings.openLinkInNewTab ? '_blank' : undefined;
+  const linkRel = settings.openLinkInNewTab ? 'noopener' : undefined;
+  const laptopClassName = [
+    'laptop',
+    item.comments_count > 0 || item.type === 'job' ? 'item-header' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div className="main-content">
+      <div className="item">
+        <div className="mobile item-header">
+          <p className="title-block">
+            <span className="back-button" onClick={() => navigate(-1)}></span>
+            {hasUrl ? (
+              <a className="title" href={item.url} target={linkTarget} rel={linkRel}>
+                {item.title}
+              </a>
+            ) : (
+              <Link className="title" to={`/item/${item.id}`}>
+                {item.title}
+              </Link>
+            )}
+          </p>
+        </div>
+        <div className={laptopClassName}>
+          {hasUrl ? (
+            <p>
+              <a className="title" href={item.url} target={linkTarget} rel={linkRel}>
+                {item.title}
+              </a>
+              {item.domain && <span className="domain">({item.domain})</span>}
+            </p>
+          ) : (
+            <p>
+              <Link className="title" to={`/item/${item.id}`}>
+                {item.title}
+              </Link>
+            </p>
+          )}
+          <div className="subtext">
+            {item.type !== 'job' && (
+              <span>
+                {item.points} points by{' '}
+                <Link to={`/user/${item.user}`}>{item.user}</Link>
+              </span>
+            )}
+            <span className={item.type !== 'job' ? 'item-details' : undefined}>
+              {item.time_ago}
+              {item.type !== 'job' && (
+                <span>
+                  {' '}
+                  |{' '}
+                  <Link to={`/item/${item.id}`}>{commentLabel(item.comments_count)}</Link>
+                </span>
+              )}
+            </span>
+          </div>
+        </div>
+        {item.type === 'poll' && (
+          <div className="pollResults">
+            {item.poll.map((pollResult, index) => (
+              <div key={index} className="pollContent">
+                <div dangerouslySetInnerHTML={{ __html: pollResult.content }}></div>
+                <div className="subtext">{pollResult.points} points</div>
+                <div
+                  className="pollBar"
+                  style={{ width: `${(pollResult.points / item.poll_votes_count) * 100}%` }}
+                ></div>
+              </div>
+            ))}
+          </div>
+        )}
+        <p className="subject" dangerouslySetInnerHTML={{ __html: item.content ?? '' }}></p>
+        <ul className="comment-list">
+          {item.comments.map((comment) => (
+            <li key={comment.id}>
+              <Comment comment={comment} />
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
 }

--- a/src/features/item/ItemDetails.tsx
+++ b/src/features/item/ItemDetails.tsx
@@ -123,7 +123,7 @@ export function ItemDetails() {
             </span>
           </div>
         </div>
-        {item.type === 'poll' && (
+        {item.type === 'poll' && Array.isArray(item.poll) && (
           <div className="pollResults">
             {item.poll.map((pollResult, index) => (
               <div key={index} className="pollContent">
@@ -131,7 +131,13 @@ export function ItemDetails() {
                 <div className="subtext">{pollResult.points} points</div>
                 <div
                   className="pollBar"
-                  style={{ width: `${(pollResult.points / item.poll_votes_count) * 100}%` }}
+                  style={{
+                    width: `${
+                      item.poll_votes_count > 0
+                        ? (pollResult.points / item.poll_votes_count) * 100
+                        : 0
+                    }%`,
+                  }}
                 ></div>
               </div>
             ))}


### PR DESCRIPTION
## Summary
Ports the Angular `ItemDetailsComponent` + `CommentComponent` to React for the `/item/:id` route, building on the foundation branch (`devin/1781803206-react-migration-base`). Adds the four files for the item slice; touches nothing outside `src/features/item/`.

- `ItemDetails.tsx` — story/poll detail page. Fetches via `fetchItemContent(id)` in a `useEffect` keyed on `id`, with a `cancelled` flag to drop stale/unmounted updates; `<Loader />` while pending, `<ErrorMessage />` on failure. Renders the mobile + laptop headers, poll bars, the HTML body, and the top-level comment list.
- `Comment.tsx` — recursive comment node with local collapse state; renders the body via `dangerouslySetInnerHTML` and maps `comment.comments` to nested `<Comment />`. Handles the `deleted` branch.
- `ItemDetails.scss` / `Comment.scss` — original component SCSS, verbatim except the two shared `@import` paths.

All original class names preserved verbatim so the global theme engine in `src/styles/_themes.scss` (`.subtext`, `.domain`, `.meta`, `.deleted-meta`, `.pollContent .pollBar`, `.item-header`, `.back-button`, …) keeps styling them.

### Faithful-port decisions worth calling out
- **Item body (`content`)**: the original template binds `item.content` / `item.text`, but *neither* the shared React `Story` type *nor* the original Angular `Story` model declares them — they were untyped runtime fields off the node-hnapi response. Since I must not edit `src/types`, I augment locally:
  ```ts
  type ItemStory = Story & { content?: string };
  ```
  and render `<p className="subject" dangerouslySetInnerHTML={{ __html: item.content ?? '' }} />`. `Story` is assignable to `ItemStory` (the extra member is optional), so no cast/`any` is needed.
- **`head-margin` dropped**: the Angular laptop header used `[class.head-margin]="item.text"`, but node-hnapi never returns `text`, so the class never actually applied. To preserve real behavior I omit it. The (now-unused) `.head-margin` rule is kept verbatim in the SCSS.
- **Error text**: original set `'Could not load item comments.'`; the task brief quoted `"Could not load the item."` but annotated it "match the original error text", so I used the true original string.
- **`:host >>>` in `Comment.scss`**: Angular ViewEncapsulation has no React/global-SCSS equivalent (and `>>>` is invalid CSS), so the bold-link rule is reattached to the comment's link descendants (`.meta, .comment-tree { a { font-weight: bold; … } }`), reproducing the original visual.

### Behavior mapping
- `goBack()` → `useNavigate()` + `navigate(-1)` on the mobile back button.
- `routerLink` → `<Link to>`, external title link keeps `target`/`rel` driven by `settings.openLinkInNewTab` (`undefined` instead of Angular's `null` to omit the attrs).
- `comments_count | comment` → `commentLabel(item.comments_count)`.
- poll bar width → inline `style={{ width: `${points / poll_votes_count * 100}%` }}`.

## Verification
`npm run lint` (max-warnings 0), `npm run typecheck`, and `npm run build` all pass. The only build warnings are the expected Dart Sass `@import` / `slash-div` deprecations from shared partials.

Link to Devin session: https://app.devin.ai/sessions/14f8ba91093b4561ba2720dd3cd4d932
Requested by: @eashansinha
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| 🟢 Reviewed | [`9f6652d`](https://github.com/cog-gtm/angular2-hn/pull/351/commits/9f6652d4e34f2a68f5924106973aea0f071853c3) |

<a href="https://staging.itsdev.in/review/cog-gtm/angular2-hn/pull/351" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->