### PR TITLE
Phase 2A: Port Angular shared models to React/TS types

### DIFF
--- a/src/shared/types/comment.ts
+++ b/src/shared/types/comment.ts
@@ -1,0 +1,10 @@
+export interface Comment {
+  id: number;
+  level: number;
+  user: string;
+  time: number;
+  time_ago: string;
+  content: string;
+  deleted: boolean;
+  comments: Comment[];
+}

--- a/src/shared/types/feed-type.ts
+++ b/src/shared/types/feed-type.ts
@@ -1,0 +1,1 @@
+export type FeedType = 'poll' | 'story' | 'job';

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -1,0 +1,6 @@
+export type { Comment } from './comment';
+export type { PollResult } from './poll-result';
+export type { User } from './user';
+export type { Settings } from './settings';
+export type { FeedType } from './feed-type';
+export type { Story } from './story';

--- a/src/shared/types/poll-result.ts
+++ b/src/shared/types/poll-result.ts
@@ -1,0 +1,4 @@
+export interface PollResult {
+  points: number;
+  content: string;
+}

--- a/src/shared/types/settings.ts
+++ b/src/shared/types/settings.ts
@@ -1,0 +1,7 @@
+export interface Settings {
+  showSettings: boolean;
+  openLinkInNewTab: boolean;
+  theme: string;
+  titleFontSize: string;
+  listSpacing: string;
+}

--- a/src/shared/types/story.ts
+++ b/src/shared/types/story.ts
@@ -1,0 +1,21 @@
+import type { Comment } from './comment';
+import type { FeedType } from './feed-type';
+import type { PollResult } from './poll-result';
+
+export interface Story {
+  id: number;
+  title: string;
+  points: number;
+  user: string;
+  time: number;
+  time_ago: number;
+  type: FeedType;
+  url: string;
+  domain: string;
+  comments: Comment[];
+  comments_count: number;
+  poll: PollResult[];
+  poll_votes_count: number;
+  deleted: boolean;
+  dead: boolean;
+}

--- a/src/shared/types/user.ts
+++ b/src/shared/types/user.ts
@@ -1,0 +1,8 @@
+export interface User {
+  id: string;
+  crated_time: number;
+  created: string;
+  karma: number;
+  avg: number;
+  about: string;
+}


### PR DESCRIPTION
## Summary
Ports the Angular data models from `src/app/shared/models/` into fresh, framework-free TypeScript under `src/shared/types/`, as part of the Angular 9 → React migration. These are pure data shapes, so each Angular model `class` becomes an exported `interface` (the existing `Settings` interface and the `FeedType` union are carried over as-is). Field names and types are preserved exactly — including the original `crated_time` spelling in `User` — since downstream ports depend on them.

Cross-file references use type-only imports to satisfy `verbatimModuleSyntax`, and the barrel re-exports with `export type` for the same reason:

```ts
// story.ts
import type { Comment } from './comment';
import type { FeedType } from './feed-type';
import type { PollResult } from './poll-result';

export interface Story { /* id, title, ..., poll: PollResult[], ... */ }

// index.ts
export type { Comment } from './comment';
export type { Story } from './story';
// ...one line per module
```

No enums, classes, or decorators are introduced (`erasableSyntaxOnly`). The legacy Angular sources were read for reference only and left untouched.

Files created:
- `src/shared/types/comment.ts`
- `src/shared/types/poll-result.ts`
- `src/shared/types/user.ts`
- `src/shared/types/settings.ts`
- `src/shared/types/feed-type.ts`
- `src/shared/types/story.ts`
- `src/shared/types/index.ts` (barrel)

## Validation
- `npm run lint` — passes, 0 errors
- `npm run build` (`tsc -b && vite build`) — passes, 0 errors

Link to Devin session: https://app.devin.ai/sessions/9c700eaf02d948c3a578986ca86ab2e6
Requested by: @eashansinha
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| 🟢 Reviewed | [`59dbdb3`](https://github.com/cog-gtm/angular2-hn/pull/352/commits/59dbdb3fcadfd7889e15d298b4552ac0b993df9f) |

<a href="https://staging.itsdev.in/review/cog-gtm/angular2-hn/pull/352" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->