### PR TITLE
feat(feeds): port Feed list + story Item card to React

### DIFF
--- a/src/features/feeds/Feed.scss
+++ b/src/features/feeds/Feed.scss
@@ -1,0 +1,108 @@
+@import "../../styles/media";
+@import "../../styles/theme_variables";
+
+a {
+  text-decoration: none;
+  font-weight: bold;
+
+  &:hover {
+    text-decoration: underline;
+  };
+}
+
+ol {
+  padding: 0 40px;
+  margin: 0;
+
+  @media #{$mobile-only} {
+    box-sizing: border-box;
+    list-style: none;
+    padding: 0 10px;
+  }
+
+  li {
+    position: relative;
+    -webkit-transition: background-color .2s ease;
+    transition: background-color .2s ease;
+  }
+}
+
+.list-margin {
+  @media #{$mobile-only} {
+    margin-top: 55px;
+  }
+}
+
+.main-content {
+  position: relative;
+  width: 100%;
+  min-height: 100vh;
+  -webkit-transition: opacity .2s ease;
+  transition: opacity .2s ease;
+  box-sizing: border-box;
+  padding: 8px 0;
+  z-index: 0;
+}
+
+.post {
+  padding: 10px 0 10px 5px;
+  transition: background-color 0.2s ease;
+  border-bottom: 1px solid #CECECB;
+
+  .itemNum {
+    color: #696969;
+    position: absolute;
+    width: 30px;
+    text-align: right;
+    left: 0;
+    top: 4px;
+  }
+}
+
+.item-block {
+  display: block;
+}
+
+
+.nav {
+  padding: 10px 40px;
+  margin-top: 10px;
+  font-size: 17px;
+
+  a {
+    @media #{$mobile-only} {
+      text-decoration: none;
+    }
+  }
+
+  @media #{$mobile-only} {
+    margin: 20px 0;
+    text-align: center;
+    padding: 10px 80px;
+    height: 20px;
+  }
+
+  .prev {
+    padding-right: 20px;
+
+    @media #{$mobile-only} {
+      float: left;
+      padding-right: 0;
+    }
+  }
+
+  .more {
+    @media #{$mobile-only} {
+      float: right;
+    }
+  }
+}
+
+.job-header {
+  font-size: 15px;
+  padding: 0 40px 10px;
+
+  @media #{$mobile-only} {
+    padding: 60px 15px 25px 15px;
+  }
+}

--- a/src/features/feeds/Feed.tsx
+++ b/src/features/feeds/Feed.tsx
@@ -1,4 +1,83 @@
-// PLACEHOLDER — replaced by the feeds migration session.
+import { useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import type { Story } from '../../types';
+import { fetchFeed } from '../../services/hackerNewsApi';
+import { Loader } from '../../components/Loader/Loader';
+import { ErrorMessage } from '../../components/ErrorMessage/ErrorMessage';
+import { Item } from './Item';
+import './Feed.scss';
+
 export function Feed() {
-  return <div className="main-content" />;
+  const { feedType = '', page } = useParams<{ feedType: string; page: string }>();
+  const pageNum = page ? +page : 1;
+
+  const [items, setItems] = useState<Story[] | null>(null);
+  const [listStart, setListStart] = useState(1);
+  const [errorMessage, setErrorMessage] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    setItems(null);
+    setErrorMessage('');
+
+    fetchFeed(feedType, pageNum)
+      .then((stories) => {
+        if (cancelled) {
+          return;
+        }
+        setItems(stories);
+        setListStart((pageNum - 1) * 30 + 1);
+        window.scrollTo(0, 0);
+      })
+      .catch(() => {
+        if (cancelled) {
+          return;
+        }
+        setErrorMessage(`Could not load ${feedType} stories.`);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [feedType, pageNum]);
+
+  return (
+    <div className="main-content">
+      {!items && !errorMessage && <Loader />}
+      {!items && errorMessage !== '' && <ErrorMessage message={errorMessage} />}
+
+      {items && (
+        <div>
+          {feedType === 'jobs' && (
+            <p className="job-header">
+              These are jobs at startups that were funded by Y Combinator. You can also get a job at
+              a YC startup through{' '}
+              <a href="https://triplebyte.com/?ref=yc_jobs">Triplebyte</a>.
+            </p>
+          )}
+          {feedType !== 'new' && (
+            <ol className={feedType !== 'jobs' ? 'list-margin' : undefined} start={listStart}>
+              {items.map((item, i) => (
+                <li key={item.id} className="post">
+                  <Item item={item} index={listStart + i} />
+                </li>
+              ))}
+            </ol>
+          )}
+          <div className="nav">
+            {listStart !== 1 && (
+              <Link to={`/${feedType}/${pageNum - 1}`} className="prev">
+                ‹ Prev
+              </Link>
+            )}
+            {items.length === 30 && (
+              <Link to={`/${feedType}/${pageNum + 1}`} className="more">
+                More ›
+              </Link>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
 }

--- a/src/features/feeds/Feed.tsx
+++ b/src/features/feeds/Feed.tsx
@@ -55,15 +55,13 @@ export function Feed() {
               <a href="https://triplebyte.com/?ref=yc_jobs">Triplebyte</a>.
             </p>
           )}
-          {feedType !== 'new' && (
-            <ol className={feedType !== 'jobs' ? 'list-margin' : undefined} start={listStart}>
-              {items.map((item, i) => (
-                <li key={item.id} className="post">
-                  <Item item={item} index={listStart + i} />
-                </li>
-              ))}
-            </ol>
-          )}
+          <ol className={feedType !== 'jobs' ? 'list-margin' : undefined} start={listStart}>
+            {items.map((item, i) => (
+              <li key={item.id} className="post">
+                <Item item={item} index={listStart + i} />
+              </li>
+            ))}
+          </ol>
           <div className="nav">
             {listStart !== 1 && (
               <Link to={`/${feedType}/${pageNum - 1}`} className="prev">

--- a/src/features/feeds/Item.scss
+++ b/src/features/feeds/Item.scss
@@ -1,0 +1,68 @@
+@import "../../styles/media";
+@import "../../styles/theme_variables";
+
+p {
+    margin: 2px 0;
+
+    @media #{$mobile-only} {
+      margin-bottom: 5px;
+      margin-top: 0;
+   }
+  }
+
+  a {
+    cursor: pointer;
+    text-decoration: none;
+  }
+
+  .title {
+    font-size: 16px;
+    font-family: Verdana, Geneva, sans-serif;
+  }
+
+  .subtext-laptop {
+    font-size: 12px;
+    font-weight: bold;
+    letter-spacing: 0.5px;
+
+    a {
+      &:hover {
+        text-decoration: underline;
+      };
+    }
+    @media #{$mobile-only} {
+      display: none;
+    }
+  }
+
+  .subtext-palm {
+    font-size: 13px;
+    font-weight: bold;
+    letter-spacing: 0.5px;
+
+    a {
+      &:hover {
+        text-decoration: underline;
+      };
+    }
+
+    .details {
+      margin-top: 5px;
+
+      .right {
+        float: right;
+      }
+    }
+    @media #{$laptop-only} {
+      display: none;
+    }
+  }
+
+  .domain {
+    color: #696969;
+    letter-spacing: 0.5px;
+  }
+
+  .item-details {
+    padding: 10px;
+  }

--- a/src/features/feeds/Item.tsx
+++ b/src/features/feeds/Item.tsx
@@ -1,0 +1,82 @@
+import { Link } from 'react-router-dom';
+import type { AnchorHTMLAttributes } from 'react';
+import type { Story } from '../../types';
+import { useSettings } from '../../context/SettingsContext';
+import { commentLabel } from '../../utils/comment';
+import './Item.scss';
+
+interface ItemProps {
+  item: Story;
+  index: number;
+}
+
+export function Item({ item }: ItemProps) {
+  const { settings } = useSettings();
+  const hasUrl = item.url.indexOf('http') === 0;
+  const externalLinkAttrs: AnchorHTMLAttributes<HTMLAnchorElement> = settings.openLinkInNewTab
+    ? { target: '_blank', rel: 'noopener noreferrer' }
+    : {};
+
+  return (
+    <div className="item-block" style={{ marginBottom: `${settings.listSpacing}px` }}>
+      {hasUrl ? (
+        <p>
+          <a
+            className="title"
+            style={{ fontSize: `${settings.titleFontSize}px` }}
+            href={item.url}
+            {...externalLinkAttrs}
+          >
+            {item.title}
+          </a>
+          {item.domain && <span className="domain">({item.domain})</span>}
+        </p>
+      ) : (
+        <p>
+          <Link
+            className="title"
+            style={{ fontSize: `${settings.titleFontSize}px` }}
+            to={`/item/${item.id}`}
+          >
+            {item.title}
+          </Link>
+        </p>
+      )}
+      <div className="subtext-palm">
+        {item.type !== 'job' && (
+          <div className="details">
+            <span className="name">
+              <Link to={`/user/${item.user}`}>{item.user}</Link>
+            </span>
+            <span className="right">{item.points} ★</span>
+          </div>
+        )}
+        <div className="details">
+          {item.time_ago}
+          {item.type !== 'job' && (
+            <Link to={`/item/${item.id}`} className="comment-number">
+              {' '}
+              • {commentLabel(item.comments_count)}
+            </Link>
+          )}
+        </div>
+      </div>
+      <div className="subtext-laptop">
+        {item.type !== 'job' && (
+          <span>
+            {item.points} points by <Link to={`/user/${item.user}`}>{item.user}</Link>
+          </span>
+        )}
+        <span className={item.type !== 'job' ? 'item-details' : undefined}>
+          {item.time_ago}
+          {item.type !== 'job' && (
+            <span>
+              {' '}
+              | <Link to={`/item/${item.id}`}>{commentLabel(item.comments_count)}</Link>
+            </span>
+          )}
+        </span>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Ports the **feeds slice** (`FeedComponent` + `ItemComponent`) from Angular 9 to React 18 + React Router v6, building on the foundation branch. Two components: `Feed` (the paginated story list page at `/:feedType/:page`) and `Item` (a single story row). Markup, class names, and styles are ported faithfully so the global SCSS theme engine in `src/styles/_themes.scss` (which targets exact class names like `.subtext-palm`, `.subtext-laptop`, `.domain`, `.nav a`, `.job-header`) keeps working unchanged.

Files: `Feed.tsx`, `Feed.scss`, `Item.tsx`, `Item.scss` under `src/features/feeds/`. No other files touched; no new dependencies.

### `Feed.tsx` (port of `FeedComponent`)
RxJS subscriptions → `useEffect` + `useState`, with a `cancelled` flag to drop stale/unmounted responses:
```tsx
const { feedType = '', page } = useParams<{ feedType: string; page: string }>();
const pageNum = page ? +page : 1;
useEffect(() => {
  let cancelled = false;
  setItems(null); setErrorMessage('');            // show <Loader/> while pending
  fetchFeed(feedType, pageNum)
    .then(s => { if (!cancelled) { setItems(s); setListStart((pageNum-1)*30+1); window.scrollTo(0,0); } })
    .catch(() => { if (!cancelled) setErrorMessage(`Could not load ${feedType} stories.`); });
  return () => { cancelled = true; };
}, [feedType, pageNum]);
```
Rendering mirrors `feed.component.html`: `<Loader/>` while pending, `<ErrorMessage/>` on error, then the `jobs` header, the `<ol start={listStart}>` (with `list-margin` when `feedType !== 'jobs'`) of `<li class="post">` rows, and the `‹ Prev` / `More ›` nav (prev when `listStart !== 1`, more when `items.length === 30`).

### `Item.tsx` (port of `ItemComponent`)
Props `{ item: Story; index: number }`. Reads prefs via `useSettings()` and applies them exactly where the Angular template did — `marginBottom: listSpacing` on the row, `fontSize: titleFontSize` on `.title`, and `target="_blank" rel="noopener noreferrer"` on external links when `openLinkInNewTab`. `hasUrl = item.url.indexOf('http') === 0` picks an external `<a href>` vs. an internal `<Link to="/item/:id">`; subtext renders points / `by user` (`<Link to="/user/:id">`) / `time_ago` / comments (`commentLabel(...)`), with the `subtext-palm` and `subtext-laptop` variants and the `item.type === 'job'` omissions preserved.

### Note on rank numbering
The original renders rank numbers via the native ordered list (`<ol start="{{listStart}}">`), hidden on mobile by `list-style: none` — the `.itemNum` class in `feed.component.scss` is never emitted by either template. I preserved this exactly (native `<ol start>`), so `Feed` passes `index={listStart + i}` to satisfy `Item`'s documented interface while the visible numbering stays delegated to the list element, matching the original on both desktop and mobile.

## Testing
- `npm run lint` — clean (eslint, `--max-warnings 0`)
- `npm run typecheck` — clean (`tsc -b`, strict, no `any`)
- `npm run build` — succeeds (only expected Dart Sass `@import`/`slash-div` deprecation warnings from shared partials)


Link to Devin session: https://app.devin.ai/sessions/4b9a6be3263445e2b3bdb55df41a0027
Requested by: @eashansinha
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| 🟢 Reviewed | [`7332783`](https://github.com/cog-gtm/angular2-hn/pull/354/commits/73327837f1b717f67d2a12697a2b25eceb33a539) |

<a href="https://staging.itsdev.in/review/cog-gtm/angular2-hn/pull/354" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->