### PR TITLE
Phase 2B: Global styles & theming (Angular SCSS → CSS variables + CSS Modules)

### DIFF
--- a/src/styles/Comment.module.css
+++ b/src/styles/Comment.module.css
@@ -1,0 +1,94 @@
+/* Ported from src/app/item-details/comment/comment.component.scss
+   + .meta / .deleted-meta theme colors from _themes.scss.
+   The Angular `:host >>> a` deep rule maps to anchors inside rendered comment
+   HTML (.comment-text a).
+   mobile-only: max-width: 768px. tablet-only: max-width: 1024px. */
+
+.comment-text a {
+  font-weight: bold;
+  text-decoration: none;
+}
+
+.comment-text a:hover {
+  text-decoration: underline;
+}
+
+.meta {
+  font-size: 13px;
+  font-weight: bold;
+  letter-spacing: 0.5px;
+  margin-bottom: 8px;
+  color: var(--subtext-color);
+}
+
+.meta a {
+  text-decoration: none;
+  color: var(--secondary-color);
+}
+
+.meta a:hover {
+  text-decoration: underline;
+}
+
+.meta .time {
+  padding-left: 5px;
+}
+
+@media only screen and (max-width: 768px) {
+  .meta {
+    font-size: 14px;
+    margin-bottom: 10px;
+  }
+
+  .meta .time {
+    padding: 0;
+    float: right;
+  }
+}
+
+.meta-collapse {
+  margin-bottom: 20px;
+}
+
+.deleted-meta {
+  font-size: 12px;
+  font-weight: bold;
+  letter-spacing: 0.5px;
+  margin: 30px 0;
+  color: var(--subtext-color);
+}
+
+.deleted-meta a {
+  text-decoration: none;
+  color: var(--secondary-color);
+}
+
+.collapse {
+  font-size: 13px;
+  letter-spacing: 2px;
+  cursor: pointer;
+}
+
+.comment-tree {
+  margin-left: 24px;
+}
+
+@media only screen and (max-width: 1024px) {
+  .comment-tree {
+    margin-left: 8px;
+  }
+}
+
+.comment-text {
+  font-size: 15px;
+  margin-top: 0;
+  margin-bottom: 20px;
+  word-wrap: break-word;
+  line-height: 1.5em;
+}
+
+.subtree {
+  margin-left: 0;
+  padding: 0;
+  list-style-type: none;
+}

--- a/src/styles/FeedItem.module.css
+++ b/src/styles/FeedItem.module.css
@@ -1,0 +1,83 @@
+/* Ported from src/app/feeds/item/item.component.scss
+   + .subtext-* / .domain theme colors from _themes.scss.
+   mobile-only: max-width: 768px. laptop-only: min-width: 769px. */
+
+p {
+  margin: 2px 0;
+}
+
+@media only screen and (max-width: 768px) {
+  p {
+    margin-bottom: 5px;
+    margin-top: 0;
+  }
+}
+
+a {
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.title {
+  font-size: 16px;
+  font-family: Verdana, Geneva, sans-serif;
+}
+
+.subtext-laptop {
+  font-size: 12px;
+  font-weight: bold;
+  letter-spacing: 0.5px;
+  color: var(--subtext-color);
+}
+
+.subtext-laptop a {
+  color: var(--secondary-color);
+}
+
+.subtext-laptop a:hover {
+  text-decoration: underline;
+}
+
+@media only screen and (max-width: 768px) {
+  .subtext-laptop {
+    display: none;
+  }
+}
+
+.subtext-palm {
+  font-size: 13px;
+  font-weight: bold;
+  letter-spacing: 0.5px;
+  color: var(--subtext-color);
+}
+
+.subtext-palm a {
+  color: var(--secondary-color);
+}
+
+.subtext-palm a:hover {
+  text-decoration: underline;
+}
+
+.subtext-palm .details {
+  margin-top: 5px;
+}
+
+.subtext-palm .details .right {
+  float: right;
+}
+
+@media only screen and (min-width: 769px) {
+  .subtext-palm {
+    display: none;
+  }
+}
+
+.domain {
+  color: var(--subtext-color);
+  letter-spacing: 0.5px;
+}
+
+.item-details {
+  padding: 10px;
+}

--- a/src/styles/FeedPage.module.css
+++ b/src/styles/FeedPage.module.css
@@ -1,0 +1,117 @@
+/* Ported from src/app/feeds/feed/feed.component.scss
+   + .job-header theme rule from _themes.scss.
+   mobile-only breakpoint: max-width: 768px. */
+
+a {
+  text-decoration: none;
+  font-weight: bold;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+ol {
+  padding: 0 40px;
+  margin: 0;
+}
+
+@media only screen and (max-width: 768px) {
+  ol {
+    box-sizing: border-box;
+    list-style: none;
+    padding: 0 10px;
+  }
+}
+
+ol li {
+  position: relative;
+  -webkit-transition: background-color 0.2s ease;
+  transition: background-color 0.2s ease;
+}
+
+@media only screen and (max-width: 768px) {
+  .list-margin {
+    margin-top: 55px;
+  }
+}
+
+.main-content {
+  position: relative;
+  width: 100%;
+  min-height: 100vh;
+  -webkit-transition: opacity 0.2s ease;
+  transition: opacity 0.2s ease;
+  box-sizing: border-box;
+  padding: 8px 0;
+  z-index: 0;
+}
+
+.post {
+  padding: 10px 0 10px 5px;
+  transition: background-color 0.2s ease;
+  border-bottom: 1px solid #cececb;
+}
+
+.post .itemNum {
+  color: #696969;
+  position: absolute;
+  width: 30px;
+  text-align: right;
+  left: 0;
+  top: 4px;
+}
+
+.item-block {
+  display: block;
+}
+
+.nav {
+  padding: 10px 40px;
+  margin-top: 10px;
+  font-size: 17px;
+}
+
+@media only screen and (max-width: 768px) {
+  .nav a {
+    text-decoration: none;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .nav {
+    margin: 20px 0;
+    text-align: center;
+    padding: 10px 80px;
+    height: 20px;
+  }
+}
+
+.nav .prev {
+  padding-right: 20px;
+}
+
+@media only screen and (max-width: 768px) {
+  .nav .prev {
+    float: left;
+    padding-right: 0;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .nav .more {
+    float: right;
+  }
+}
+
+.job-header {
+  font-size: 15px;
+  padding: 0 40px 10px;
+}
+
+@media only screen and (max-width: 768px) {
+  .job-header {
+    padding: 60px 15px 25px 15px;
+    border-bottom: var(--border);
+  }
+}

--- a/src/styles/FeedPage.module.css
+++ b/src/styles/FeedPage.module.css
@@ -72,6 +72,10 @@ ol li {
   font-size: 17px;
 }
 
+.nav a {
+  color: var(--secondary-color);
+}
+
 @media only screen and (max-width: 768px) {
   .nav a {
     text-decoration: none;

--- a/src/styles/Footer.module.css
+++ b/src/styles/Footer.module.css
@@ -1,0 +1,28 @@
+/* Ported from src/app/core/footer/footer.component.scss
+   + #footer theme rules from _themes.scss.
+   #footer -> .footer. mobile-only breakpoint: max-width: 768px. */
+
+.footer {
+  position: relative;
+  padding: 10px;
+  height: 60px;
+  letter-spacing: 0.7px;
+  text-align: center;
+  border-top: var(--border);
+}
+
+.footer a {
+  font-weight: bold;
+  text-decoration: none;
+  color: var(--secondary-color);
+}
+
+.footer a:hover {
+  text-decoration: underline;
+}
+
+@media only screen and (max-width: 768px) {
+  .footer {
+    display: none;
+  }
+}

--- a/src/styles/Header.module.css
+++ b/src/styles/Header.module.css
@@ -1,0 +1,171 @@
+/* Ported from src/app/core/header/header.component.scss
+   + #header / .logo-inner theme rules from _themes.scss.
+   #header -> .header. mobile-only breakpoint: max-width: 768px. */
+
+.header {
+  color: #fff;
+  padding: 6px 0;
+  line-height: 18px;
+  vertical-align: middle;
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  background: var(--header-background-color);
+  border-bottom: var(--border);
+}
+
+@media only screen and (max-width: 768px) {
+  .header {
+    height: 50px;
+    position: fixed;
+    top: 0;
+  }
+}
+
+.header a {
+  display: inline;
+}
+
+.home-link {
+  width: 50px;
+  height: 66px;
+}
+
+.logo-inner {
+  width: 32px;
+  position: absolute;
+  left: 17px;
+  top: 18px;
+  z-index: -1;
+  height: 32px;
+  border-radius: 50%;
+  background: var(--logo-inner-color);
+}
+
+@media only screen and (max-width: 768px) {
+  .logo-inner {
+    left: 16px;
+    top: 12px;
+  }
+}
+
+.logo {
+  width: 50px;
+  padding: 3px 8px 0;
+}
+
+@media only screen and (max-width: 768px) {
+  .logo {
+    width: 45px;
+    padding: 0 0 0 10px;
+  }
+}
+
+.header h1 {
+  font-weight: normal;
+  display: inline-block;
+  vertical-align: middle;
+  margin: 0;
+  font-size: 16px;
+}
+
+.header h1 a {
+  color: #fff;
+  text-decoration: none;
+}
+
+.name {
+  margin-right: 30px;
+  margin-bottom: 2px;
+}
+
+@media only screen and (max-width: 768px) {
+  .name {
+    display: none;
+  }
+}
+
+.header-text {
+  position: absolute;
+  width: inherit;
+  height: 20px;
+  left: 10px;
+  top: 27px;
+  z-index: -1;
+}
+
+@media only screen and (max-width: 768px) {
+  .header-text {
+    top: 22px;
+  }
+}
+
+.left {
+  position: absolute;
+  left: 60px;
+  font-size: 16px;
+}
+
+@media only screen and (max-width: 768px) {
+  .left {
+    width: 100%;
+    left: 0;
+  }
+}
+
+.header-nav {
+  display: inline-block;
+  margin-left: 20px;
+}
+
+@media only screen and (max-width: 768px) {
+  .header-nav {
+    margin-left: 60px;
+  }
+}
+
+.header-nav a {
+  color: hsla(0, 0%, 100%, 0.9);
+  text-decoration: none;
+  margin: 0 5px;
+  letter-spacing: 1.8px;
+}
+
+.header-nav a:hover {
+  color: #fff;
+}
+
+.header-nav .active {
+  color: #fff;
+}
+
+.info {
+  position: absolute;
+  top: 0;
+  right: 20px;
+  height: 100%;
+}
+
+@media only screen and (max-width: 768px) {
+  .info {
+    right: 10px;
+  }
+}
+
+.info img {
+  opacity: 0.8;
+  width: 25px;
+  margin-top: 21.5px;
+  display: block;
+}
+
+.info img:hover {
+  opacity: 1;
+  cursor: pointer;
+}
+
+@media only screen and (max-width: 768px) {
+  .info img {
+    margin-top: 15px;
+  }
+}

--- a/src/styles/ItemDetailsPage.module.css
+++ b/src/styles/ItemDetailsPage.module.css
@@ -1,0 +1,163 @@
+/* Ported from src/app/item-details/item-details.component.scss
+   + .item-header / .subtext / .domain / .pollBar / .back-button theme rules
+   from _themes.scss.
+   mobile-only: max-width: 768px. laptop-only: min-width: 769px.
+   tablet-only: max-width: 1024px. */
+
+.main-content {
+  position: relative;
+  width: 100%;
+  min-height: 100vh;
+  -webkit-transition: opacity 0.2s ease;
+  transition: opacity 0.2s ease;
+  box-sizing: border-box;
+  padding: 8px 0;
+  z-index: 0;
+}
+
+.item {
+  box-sizing: border-box;
+  padding: 10px 40px 0 40px;
+  z-index: 0;
+}
+
+@media only screen and (max-width: 1024px) {
+  .item {
+    padding: 10px 20px 0 40px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .item {
+    box-sizing: border-box;
+    padding: 110px 15px 0 15px;
+  }
+}
+
+.head-margin {
+  margin-bottom: 15px;
+}
+
+p {
+  margin: 2px 0;
+}
+
+.subject {
+  word-wrap: break-word;
+  margin-top: 20px;
+}
+
+a {
+  cursor: pointer;
+  text-decoration: none;
+}
+
+@media only screen and (max-width: 768px) {
+  .laptop {
+    display: none;
+  }
+}
+
+@media only screen and (min-width: 769px) {
+  .mobile {
+    display: none;
+  }
+}
+
+.title {
+  font-size: 16px;
+  font-family: Verdana, Geneva, sans-serif;
+}
+
+.title-block {
+  text-align: center;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  margin: 0 75px;
+}
+
+@media only screen and (max-width: 768px) {
+  .title {
+    font-size: 15px;
+  }
+
+  .back-button {
+    position: absolute;
+    top: 52%;
+    width: 0.6rem;
+    height: 0.6rem;
+    background: transparent;
+    box-shadow: 0 0 0 lightgray;
+    transition: all 200ms ease;
+    left: 4%;
+    transform: translate3d(0, -50%, 0) rotate(-135deg);
+    border-top: 0.3rem solid var(--secondary-color);
+    border-right: 0.3rem solid var(--secondary-color);
+  }
+}
+
+.subtext {
+  font-size: 12px;
+  font-weight: bold;
+  letter-spacing: 0.5px;
+  color: var(--subtext-color);
+}
+
+.domain {
+  letter-spacing: 0.5px;
+  color: var(--subtext-color);
+}
+
+.subtext a {
+  color: var(--secondary-color);
+}
+
+.subtext a:hover {
+  text-decoration: underline;
+}
+
+.item-details {
+  padding: 10px;
+}
+
+.item-header {
+  padding-bottom: 10px;
+  border-bottom: var(--border);
+}
+
+@media only screen and (max-width: 768px) {
+  .item-header {
+    padding: 10px 0 10px 0;
+    position: fixed;
+    width: 100%;
+    left: 0;
+    top: 62px;
+    background: var(--wrapper-mobile-background-color);
+  }
+}
+
+.pollResults {
+  margin-bottom: 1em;
+}
+
+.pollContent * {
+  padding-bottom: 0;
+  margin-bottom: -1em;
+  margin-top: 1em;
+}
+
+.pollContent .pollBar {
+  height: 10px;
+  margin-bottom: 1em;
+  background: var(--secondary-color);
+}
+
+ul {
+  list-style-type: none;
+  padding: 10px 0;
+}
+
+li {
+  display: list-item;
+}

--- a/src/styles/Settings.module.css
+++ b/src/styles/Settings.module.css
@@ -1,0 +1,83 @@
+/* Ported from src/app/core/settings/settings.component.scss
+   + .popup theme rule from _themes.scss. */
+
+.overlay {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: rgba(0, 0, 0, 0.7);
+  opacity: 1;
+  z-index: 1;
+}
+
+.popup {
+  margin: 70px auto;
+  padding: 30px;
+  border-radius: 5px;
+  width: 30%;
+  position: relative;
+  background: var(--header-background-color);
+}
+
+.popup h1 {
+  margin-top: 0;
+  margin-bottom: 0px;
+  color: #fff;
+  text-align: center;
+  letter-spacing: 1px;
+}
+
+.popup h2 {
+  padding-top: 10px;
+}
+
+.popup hr {
+  width: 40%;
+  margin-bottom: 20px;
+}
+
+.popup .close {
+  position: absolute;
+  top: 12px;
+  right: 20px;
+  font-size: 30px;
+  font-weight: bold;
+  text-decoration: none;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.popup .close:hover {
+  color: #fff;
+  cursor: pointer;
+}
+
+.popup .content {
+  max-height: 30%;
+  color: #fff;
+  letter-spacing: 1px;
+  overflow: auto;
+}
+
+.popup input[type="number"] {
+  display: block;
+  width: 80%;
+  height: 20px;
+  margin-bottom: 15px;
+  border-radius: 5px;
+  padding: 2px;
+}
+
+.control-section {
+  margin-bottom: 15px;
+  padding-bottom: 15px;
+  border-bottom: 1px solid white;
+}
+
+@media screen and (max-width: 700px) {
+  .box,
+  .popup {
+    width: 70%;
+  }
+}

--- a/src/styles/UserPage.module.css
+++ b/src/styles/UserPage.module.css
@@ -1,0 +1,100 @@
+/* Ported from src/app/user/user.component.scss
+   + .main-details / .item-header / .back-button theme rules from _themes.scss.
+   The Angular `:host >>> pre` deep rule maps to .other-details pre.
+   mobile-only: max-width: 768px. laptop-only: min-width: 769px. */
+
+.other-details pre {
+  white-space: pre-wrap;
+}
+
+.profile {
+  padding: 30px;
+}
+
+@media only screen and (max-width: 768px) {
+  .profile {
+    padding: 110px 15px 0 15px;
+  }
+
+  .title-block {
+    font-size: 15px;
+    text-align: center;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    margin: 0 75px;
+  }
+
+  .back-button {
+    position: absolute;
+    top: 52%;
+    width: 0.6rem;
+    height: 0.6rem;
+    background: transparent;
+    box-shadow: 0 0 0 lightgray;
+    transition: all 200ms ease;
+    left: 4%;
+    transform: translate3d(0, -50%, 0) rotate(-135deg);
+    border-top: 0.3rem solid var(--secondary-color);
+    border-right: 0.3rem solid var(--secondary-color);
+  }
+
+  .item-header {
+    padding-bottom: 10px;
+    padding: 10px 0 10px 0;
+    position: fixed;
+    width: 100%;
+    left: 0;
+    top: 62px;
+    height: 20px;
+    background-color: var(--wrapper-mobile-background-color);
+    border-bottom: var(--border);
+  }
+}
+
+@media only screen and (min-width: 769px) {
+  .mobile {
+    display: none;
+  }
+}
+
+.main-details .name {
+  font-weight: bold;
+  font-size: 32px;
+  letter-spacing: 2px;
+  color: var(--secondary-color);
+}
+
+.main-details .age {
+  font-weight: bold;
+  color: #696969;
+  padding-bottom: 0;
+}
+
+.main-details .right {
+  float: right;
+  font-weight: bold;
+  font-size: 32px;
+  letter-spacing: 2px;
+  color: var(--secondary-color);
+}
+
+@media only screen and (max-width: 768px) {
+  .main-details {
+    margin-top: 20px;
+  }
+
+  .main-details .name {
+    font-size: 18px;
+  }
+}
+
+@media only screen and (max-width: 768px) {
+  .main-details .right {
+    font-size: 18px;
+  }
+}
+
+.other-details {
+  word-wrap: break-word;
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -89,7 +89,7 @@ pre {
 }
 
 .wrapper a:visited {
-  color: var(--text-color);
+  color: var(--subtext-color);
 }
 
 /* Pagination / secondary nav link color (structural .nav lives in

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,0 +1,99 @@
+/* ----------------------------------------------------------------------------
+   Global structural styles + global theme application
+
+   Ported from:
+     src/styles.scss
+     src/app/app.component.scss
+     global/layout theme rules from src/app/shared/scss/_themes.scss
+
+   Themed colors are consumed via var(--…) defined in themes.css.
+   mobile-only breakpoint: max-width: 768px (see media.css)
+---------------------------------------------------------------------------- */
+
+html {
+  height: 100%;
+  width: 100%;
+}
+
+body {
+  margin: 0;
+  height: 100%;
+  width: 100%;
+}
+
+pre {
+  white-space: pre-wrap;
+}
+
+/* Initial app-shell loader */
+.app-loader {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  position: fixed;
+  height: 100%;
+  width: 100%;
+  top: 0;
+  left: 0;
+  z-index: -1;
+}
+
+@media screen and (max-width: 768px) {
+  .app-loader {
+    background-color: #fff;
+  }
+}
+
+.app-loader .logo {
+  width: 20vh;
+}
+
+/* App shell layout (app.component.scss) + theming (_themes.scss) */
+.body-cover {
+  width: 100%;
+  z-index: 0;
+  position: fixed;
+  height: 100%;
+  background: var(--body-background-color);
+}
+
+@media only screen and (max-width: 768px) {
+  .body-cover {
+    background: var(--wrapper-mobile-background-color);
+  }
+}
+
+.wrapper {
+  position: relative;
+  width: 85%;
+  min-height: 80px;
+  margin: 0 auto;
+  font-family: "HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
+  font-size: 15px;
+  height: 100%;
+  line-height: 1.3;
+  background: var(--wrapper-background-color);
+  color: var(--text-color);
+}
+
+@media only screen and (max-width: 768px) {
+  .wrapper {
+    width: 100%;
+    background: var(--wrapper-mobile-background-color);
+  }
+}
+
+.wrapper a {
+  color: var(--text-color);
+}
+
+.wrapper a:visited {
+  color: var(--text-color);
+}
+
+/* Pagination / secondary nav link color (structural .nav lives in
+   FeedPage.module.css) */
+.nav a {
+  color: var(--secondary-color);
+}

--- a/src/styles/media.css
+++ b/src/styles/media.css
@@ -1,0 +1,11 @@
+/* ----------------------------------------------------------------------------
+   Responsive breakpoints
+
+   Ported from src/app/shared/scss/_media.scss. Plain CSS has no SCSS
+   variables, so the literal pixel values are documented here. Use these exact
+   values in @media (...) blocks across the app so breakpoints stay consistent.
+
+     mobile-only:  @media only screen and (max-width: 768px)
+     laptop-only:  @media only screen and (min-width: 769px)
+     tablet-only:  @media only screen and (max-width: 1024px)
+---------------------------------------------------------------------------- */

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -1,0 +1,47 @@
+/* ----------------------------------------------------------------------------
+   Theme engine — CSS custom properties
+
+   Ported from:
+     src/app/shared/scss/_theme_variables.scss
+     src/app/shared/scss/_themes.scss
+
+   The default (day) theme lives under :root and applies when <App> renders its
+   wrapper as <div className="default">. The .night and .amoled selectors
+   override the same variables. All other CSS consumes colors via var(--…).
+---------------------------------------------------------------------------- */
+
+:root {
+  --body-background-color: #fff;
+  --wrapper-background-color: #f5f5f5;
+  --wrapper-mobile-background-color: #fff;
+  --text-color: #000;
+  --subtext-color: #696969;
+  --secondary-color: #b92b27;
+  --header-background-color: #b92b27;
+  --logo-inner-color: #fff;
+  --border: 2px solid #b92b27;
+}
+
+.night {
+  --body-background-color: #37474f;
+  --wrapper-background-color: #263238;
+  --wrapper-mobile-background-color: #263238;
+  --text-color: rgba(255, 255, 255, 0.7);
+  --subtext-color: #999;
+  --secondary-color: #00c0ff;
+  --header-background-color: #263238;
+  --logo-inner-color: #263238;
+  --border: 2px solid #00c0ff;
+}
+
+.amoled {
+  --body-background-color: #000;
+  --wrapper-background-color: #000;
+  --wrapper-mobile-background-color: #000;
+  --text-color: rgba(255, 255, 255, 0.75);
+  --subtext-color: rgba(255, 255, 255, 0.5);
+  --secondary-color: rgba(255, 255, 255, 0.6);
+  --header-background-color: #000;
+  --logo-inner-color: #000;
+  --border: 2px solid rgba(255, 255, 255, 0.6);
+}


### PR DESCRIPTION
## Summary
Ports the legacy Angular SCSS (`src/app/shared/scss/*` + the per-component `*.component.scss`) into plain CSS for the React app, with no changes to any shared config or other sessions' files. The Angular theming model (descendant `.night .wrapper {…}` rules generated by a SCSS `@mixin`) is replaced by **CSS custom properties** so components consume colors via `var(--…)` regardless of the active theme.

**Theme contract** (`src/styles/themes.css`): `<App>` renders `<div className={theme}>` where `theme` is `'default' | 'night' | 'amoled'`. Default lives under `:root` (no `.default` class needed); `.night` / `.amoled` override the same vars:

```
:root   { --secondary-color:#b92b27; --header-background-color:#b92b27; --border:2px solid #b92b27; … }
.night  { --secondary-color:#00c0ff; --header-background-color:#263238; --border:2px solid #00c0ff; … }
.amoled { --secondary-color:rgba(255,255,255,.6); --header-background-color:#000; --border:2px solid rgba(255,255,255,.6); … }
```

Variable scheme: `--body-background-color`, `--wrapper-background-color`, `--wrapper-mobile-background-color`, `--text-color`, `--subtext-color`, `--secondary-color`, `--header-background-color`, `--logo-inner-color`, `--border`.

**Files created** (all new, under `src/styles/`):
- `themes.css` — the custom-property theme engine above.
- `media.css` — breakpoints from `_media.scss` documented as comments (literal values: `mobile-only max-width:768px`, `laptop-only min-width:769px`, `tablet-only max-width:1024px`) so other sessions reuse identical `@media` values.
- `global.css` — app-shell structural + global theme rules from `styles.scss` / `app.component.scss` / `_themes.scss` (`html/body` resets, `.app-loader`, `.body-cover`, `.wrapper` + links, `.nav a`).
- 8 component CSS Modules: `Header`, `Footer`, `Settings`, `FeedPage`, `FeedItem`, `ItemDetailsPage`, `Comment`, `UserPage`.

**Porting conventions applied:**
- SCSS nesting / `&` flattened to valid CSS; `@media #{$mobile-only}` etc. expanded to literal `@media only screen and (max-width: …)`.
- id selectors → class selectors (`#header` → `.header`, `#footer` → `.footer`) for CSS-module use.
- Original Angular kebab-case class names preserved (e.g. `.subtext-laptop`, `.comment-tree`, `.logo-inner`) so Phase 4 components reference them via `styles['kebab-name']`.
- Per-component themed colors from `_themes.scss` folded into the matching module as `var(--…)` (e.g. `.header { background: var(--header-background-color); border-bottom: var(--border) }`, `.popup { background: var(--header-background-color) }`, `.pollBar { background: var(--secondary-color) }`).
- Angular `:host >>>` deep selectors mapped to the rendered-HTML container (`.comment-text a`, `.other-details pre`) instead of leaking globally.
- Did **not** create `Loader.module.css` / `ErrorMessage.module.css` (owned by Child C), and skipped the `.loader` / `.error-section .skull` theme rules (and their `$skull-size` math) accordingly.

The legacy Angular source under `src/app/**` is untouched (read-only reference). These CSS files aren't imported by any TS yet, which is expected for this phase.

## Validation
- `npm run lint` — passes (0 errors).
- `npm run build` (`tsc -b && vite build`) — passes; Vite emits the bundled CSS.

Link to Devin session: https://app.devin.ai/sessions/ac2b2d50a9bc487081d0ef97d0a108d8
Requested by: @eashansinha
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| 🟢 Reviewed | [`b2b536f`](https://github.com/cog-gtm/angular2-hn/pull/355/commits/b2b536f21655b7e7c30745f861515216f0c67a9c) |

<a href="https://staging.itsdev.in/review/cog-gtm/angular2-hn/pull/355" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->