### PR TITLE
Phase 3E: port HackerNews API service to React hooks

### DIFF
--- a/src/shared/hooks/useHackerNewsApi.ts
+++ b/src/shared/hooks/useHackerNewsApi.ts
@@ -13,7 +13,7 @@ export function useFeed(
 ): { items: Story[]; error: string; loading: boolean } {
   const [items, setItems] = useState<Story[]>([]);
   const [error, setError] = useState('');
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -61,7 +61,7 @@ export function useItemDetails(
 ): { item: Story | null; error: string; loading: boolean } {
   const [item, setItem] = useState<Story | null>(null);
   const [error, setError] = useState('');
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -129,7 +129,7 @@ export function useUser(
 ): { user: User | null; error: string; loading: boolean } {
   const [user, setUser] = useState<User | null>(null);
   const [error, setError] = useState('');
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     const controller = new AbortController();

--- a/src/shared/hooks/useHackerNewsApi.ts
+++ b/src/shared/hooks/useHackerNewsApi.ts
@@ -1,0 +1,173 @@
+import { useEffect, useState } from 'react';
+import type { Story, User, PollResult } from '../types';
+
+const baseUrl = 'https://node-hnapi.herokuapp.com';
+
+function isAbortError(err: unknown): boolean {
+  return err instanceof DOMException && err.name === 'AbortError';
+}
+
+export function useFeed(
+  feedType: string,
+  page: number,
+): { items: Story[]; error: string; loading: boolean } {
+  const [items, setItems] = useState<Story[]>([]);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    let active = true;
+
+    const load = async () => {
+      setLoading(true);
+      setError('');
+      try {
+        const res = await fetch(`${baseUrl}/${feedType}?page=${page}`, {
+          signal: controller.signal,
+        });
+        if (!res.ok) {
+          throw new Error(`Request failed with status ${res.status}`);
+        }
+        const data = (await res.json()) as Story[];
+        if (!active) {
+          return;
+        }
+        setItems(data);
+        setLoading(false);
+      } catch (err: unknown) {
+        if (!active || isAbortError(err)) {
+          return;
+        }
+        setItems([]);
+        setError('Could not load the feed. Please try again.');
+        setLoading(false);
+      }
+    };
+
+    void load();
+
+    return () => {
+      active = false;
+      controller.abort();
+    };
+  }, [feedType, page]);
+
+  return { items, error, loading };
+}
+
+export function useItemDetails(
+  id: number,
+): { item: Story | null; error: string; loading: boolean } {
+  const [item, setItem] = useState<Story | null>(null);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    let active = true;
+
+    const load = async () => {
+      setLoading(true);
+      setError('');
+      try {
+        const res = await fetch(`${baseUrl}/item/${id}`, {
+          signal: controller.signal,
+        });
+        if (!res.ok) {
+          throw new Error(`Request failed with status ${res.status}`);
+        }
+        const story = (await res.json()) as Story;
+
+        if (story.type === 'poll') {
+          story.poll_votes_count = 0;
+          const results = await Promise.all(
+            story.poll.map(async (_, index) => {
+              const pollRes = await fetch(`${baseUrl}/item/${story.id + index + 1}`, {
+                signal: controller.signal,
+              });
+              if (!pollRes.ok) {
+                throw new Error(`Request failed with status ${pollRes.status}`);
+              }
+              return (await pollRes.json()) as PollResult;
+            }),
+          );
+          results.forEach((result, index) => {
+            story.poll[index] = result;
+            story.poll_votes_count += result.points;
+          });
+        }
+
+        if (!active) {
+          return;
+        }
+        setItem(story);
+        setLoading(false);
+      } catch (err: unknown) {
+        if (!active || isAbortError(err)) {
+          return;
+        }
+        setItem(null);
+        setError('Could not load this item. Please try again.');
+        setLoading(false);
+      }
+    };
+
+    void load();
+
+    return () => {
+      active = false;
+      controller.abort();
+    };
+  }, [id]);
+
+  return { item, error, loading };
+}
+
+export function useUser(
+  id: string,
+): { user: User | null; error: string; loading: boolean } {
+  const [user, setUser] = useState<User | null>(null);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    let active = true;
+
+    const load = async () => {
+      setLoading(true);
+      setError('');
+      try {
+        const res = await fetch(`${baseUrl}/user/${id}`, {
+          signal: controller.signal,
+        });
+        if (!res.ok) {
+          throw new Error(`Request failed with status ${res.status}`);
+        }
+        const data = (await res.json()) as User;
+        if (!active) {
+          return;
+        }
+        setUser(data);
+        setLoading(false);
+      } catch (err: unknown) {
+        if (!active || isAbortError(err)) {
+          return;
+        }
+        setUser(null);
+        setError('Could not load this user. Please try again.');
+        setLoading(false);
+      }
+    };
+
+    void load();
+
+    return () => {
+      active = false;
+      controller.abort();
+    };
+  }, [id]);
+
+  return { user, error, loading };
+}


### PR DESCRIPTION
## Summary
Ports the data-fetching logic from the legacy Angular `HackerNewsAPIService` (`src/app/shared/services/hackernews-api.service.ts`) into React hooks, replacing RxJS `Observable`/`lazyFetch` with `fetch` + `AbortController` inside `useEffect`. Adds a single new file `src/shared/hooks/useHackerNewsApi.ts` exporting three hooks. No existing files are modified.

Base URL `https://node-hnapi.herokuapp.com`. Each hook returns `{ ..., error, loading }`:

- `useFeed(feedType, page)` → `{ items: Story[]; error; loading }` — `GET /${feedType}?page=${page}`, effect keyed on `[feedType, page]`. Replaces `fetchFeed`.
- `useItemDetails(id)` → `{ item: Story | null; error; loading }` — `GET /item/${id}`, effect keyed on `[id]`. Replaces `fetchItemContent` + `fetchPollContent`. Poll handling ported faithfully: when `story.type === 'poll'`, fetch each option in parallel and assign back:
  ```ts
  story.poll_votes_count = 0;
  const results = await Promise.all(
    story.poll.map((_, i) =>
      fetch(`${baseUrl}/item/${story.id + i + 1}`, { signal }) /* -> PollResult */
    ),
  );
  results.forEach((r, i) => { story.poll[i] = r; story.poll_votes_count += r.points; });
  ```
  (loop index `i` 0-based maps to Angular's `1..length`: id `story.id + i + 1`, assigned to `story.poll[i]`.)
- `useUser(id)` → `{ user: User | null; error; loading }` — `GET /user/${id}`, effect keyed on `[id]`. Replaces `fetchUser`.

Behavior details:
- Loading set true before fetch, false after; `error` is a human-readable string on HTTP/network failure (and the data field reset to its empty value).
- Each effect uses its own `AbortController`, aborted in cleanup. `AbortError` is ignored (no error set on abort), and an `active` flag guards against setting state after unmount/abort.
- `setLoading`/`setError` are invoked inside the async callback (not synchronously in the effect body) to satisfy the `react-hooks/set-state-in-effect` lint rule.
- JSON responses are cast to `Story[]` / `Story` / `PollResult` / `User`; types imported type-only per `verbatimModuleSyntax` (`import type { Story, User, PollResult } from '../types'`).

## Validation
`npm run lint` and `npm run build` (`tsc -b && vite build`) both pass with zero errors.

Link to Devin session: https://app.devin.ai/sessions/81db9b54314c488a824bd4e6e73656f9
Requested by: @eashansinha
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| 🟢 Reviewed | [`b7511f4`](https://github.com/cog-gtm/angular2-hn/pull/356/commits/b7511f4ac67d0502b2b5de2a080e7a3ca3fede26) |

<a href="https://staging.itsdev.in/review/cog-gtm/angular2-hn/pull/356" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->