### PR TITLE
Phase 3D: port SettingsService to React SettingsContext

### DIFF
--- a/src/shared/context/SettingsContext.tsx
+++ b/src/shared/context/SettingsContext.tsx
@@ -1,0 +1,101 @@
+import { createContext, useContext, useEffect, useState } from 'react';
+import type { ReactNode } from 'react';
+import type { Settings } from '../types';
+
+interface SettingsContextValue {
+  settings: Settings;
+  toggleSettings: () => void;
+  toggleOpenLinksInNewTab: () => void;
+  setTheme: (theme: string) => void;
+  setFont: (fontSize: string) => void;
+  setSpacing: (listSpace: string) => void;
+}
+
+const DARK_COLOR_SCHEME_QUERY = '(prefers-color-scheme: dark)';
+
+function getInitialTheme(): string {
+  const savedTheme = localStorage.getItem('theme');
+  if (savedTheme) {
+    return savedTheme;
+  }
+  return window.matchMedia(DARK_COLOR_SCHEME_QUERY).matches ? 'night' : 'default';
+}
+
+function getInitialSettings(): Settings {
+  const storedOpenLink = localStorage.getItem('openLinkInNewTab');
+  return {
+    showSettings: false,
+    openLinkInNewTab: storedOpenLink ? (JSON.parse(storedOpenLink) as boolean) : false,
+    theme: getInitialTheme(),
+    titleFontSize: localStorage.getItem('titleFontSize') ?? '16',
+    listSpacing: localStorage.getItem('listSpacing') ?? '0',
+  };
+}
+
+const SettingsContext = createContext<SettingsContextValue | undefined>(undefined);
+
+export function SettingsProvider({ children }: { children: ReactNode }) {
+  const [settings, setSettings] = useState<Settings>(getInitialSettings);
+
+  useEffect(() => {
+    const darkColorSchemeMedia = window.matchMedia(DARK_COLOR_SCHEME_QUERY);
+
+    const handleSystemPreferredColorSchemeChange = (event: MediaQueryListEvent) => {
+      const theme = event.matches ? 'night' : 'default';
+      localStorage.setItem('theme', theme);
+      setSettings((prev) => ({ ...prev, theme }));
+    };
+
+    darkColorSchemeMedia.addEventListener('change', handleSystemPreferredColorSchemeChange);
+    return () => {
+      darkColorSchemeMedia.removeEventListener('change', handleSystemPreferredColorSchemeChange);
+    };
+  }, []);
+
+  const toggleSettings = () => {
+    setSettings((prev) => ({ ...prev, showSettings: !prev.showSettings }));
+  };
+
+  const toggleOpenLinksInNewTab = () => {
+    setSettings((prev) => {
+      const openLinkInNewTab = !prev.openLinkInNewTab;
+      localStorage.setItem('openLinkInNewTab', JSON.stringify(openLinkInNewTab));
+      return { ...prev, openLinkInNewTab };
+    });
+  };
+
+  const setTheme = (theme: string) => {
+    localStorage.setItem('theme', theme);
+    setSettings((prev) => ({ ...prev, theme }));
+  };
+
+  const setFont = (fontSize: string) => {
+    localStorage.setItem('titleFontSize', fontSize);
+    setSettings((prev) => ({ ...prev, titleFontSize: fontSize }));
+  };
+
+  const setSpacing = (listSpace: string) => {
+    localStorage.setItem('listSpacing', listSpace);
+    setSettings((prev) => ({ ...prev, listSpacing: listSpace }));
+  };
+
+  const value: SettingsContextValue = {
+    settings,
+    toggleSettings,
+    toggleOpenLinksInNewTab,
+    setTheme,
+    setFont,
+    setSpacing,
+  };
+
+  return <SettingsContext.Provider value={value}>{children}</SettingsContext.Provider>;
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useSettings(): SettingsContextValue {
+  const context = useContext(SettingsContext);
+  if (context === undefined) {
+    throw new Error('useSettings must be used within a SettingsProvider');
+  }
+  return context;
+}


### PR DESCRIPTION
## Summary
Ports `src/app/shared/services/settings.service.ts` (Angular `SettingsService`) into a single React context file: `src/shared/context/SettingsContext.tsx`. Exposes `SettingsProvider` + `useSettings()` and reproduces the service's state, persistence, and system-theme behavior. No existing files touched.

State seeding matches the Angular field initializers (read from `localStorage` on first render via a lazy `useState` initializer):
```
showSettings:     false
openLinkInNewTab: ls("openLinkInNewTab") ? JSON.parse(it) : false
theme:            ls("theme") ?? (matchMedia(dark).matches ? 'night' : 'default')
titleFontSize:    ls("titleFontSize") ?? '16'
listSpacing:      ls("listSpacing") ?? '0'
```

Methods update state immutably and persist exactly where the Angular service did:
- `toggleSettings()` — flips `showSettings`, no persistence
- `toggleOpenLinksInNewTab()` — persists `JSON.stringify(...)`
- `setTheme/setFont/setSpacing` — persist `theme` / `titleFontSize` / `listSpacing`

System color-scheme tracking (ports `subscribeToSystemPreferredColorScheme` + `handleSystemPreferredColorSchemeChange` + `ngOnDestroy`): a mount-only `useEffect` adds a `matchMedia('(prefers-color-scheme: dark)')` `'change'` listener that sets `'night'`/`'default'` and persists, and removes it on cleanup.

### Notes on the port (strict-TS / React 19 lint)
- The project's `react-hooks/set-state-in-effect` rule forbids synchronous `setState` inside an effect body, so the Angular `initTheme()` derivation (saved theme, else derive from the media query's current `matches`) is computed in the lazy `useState` initializer rather than via a synchronous in-effect `setState`. This preserves the observable result (initial theme = saved or system-derived) without a cascading re-render. Per the task's Init spec, the derived initial theme is not persisted; persistence happens only on actual `'change'` events and explicit setter calls (matching Angular's `setTheme`).
- `react-refresh/only-export-components` necessarily fires when a provider component and a hook live in one file (the task requires exactly one file), so the `useSettings` export carries a single targeted `// eslint-disable-next-line`.
- Type-only imports (`ReactNode`, `Settings`) use `import type` per `verbatimModuleSyntax`; no enums/namespaces per `erasableSyntaxOnly`.

`npm run lint` and `npm run build` both pass with zero errors.

Link to Devin session: https://app.devin.ai/sessions/f564c83e574d4d4199913ff7650e8d97
Requested by: @eashansinha
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| 🟢 Reviewed | [`34b6ec2`](https://github.com/cog-gtm/angular2-hn/pull/358/commits/34b6ec2194a26ba29d0ff158773e30f9f45536b3) |

<a href="https://staging.itsdev.in/review/cog-gtm/angular2-hn/pull/358" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->