### PR TITLE
feat(feed): port FeedPage + FeedItem to React

### DIFF
--- a/src/components/feed/FeedItem.tsx
+++ b/src/components/feed/FeedItem.tsx
@@ -1,0 +1,83 @@
+import type { Story } from '../../shared/types';
+import { Link } from 'react-router-dom';
+import { useSettings } from '../../shared/context/SettingsContext';
+import styles from '../../styles/FeedItem.module.css';
+
+function formatComments(count: number): string {
+  if (count > 0) return `${count} ${count === 1 ? 'comment' : 'comments'}`;
+  return 'discuss';
+}
+
+interface FeedItemProps {
+  item: Story;
+}
+
+export default function FeedItem({ item }: FeedItemProps) {
+  const { settings } = useSettings();
+  const hasUrl = item.url ? item.url.startsWith('http') : false;
+
+  return (
+    <div style={{ marginBottom: `${settings.listSpacing}px` }}>
+      {hasUrl ? (
+        <p>
+          <a
+            className={styles.title}
+            style={{ fontSize: `${settings.titleFontSize}px` }}
+            href={item.url}
+            target={settings.openLinkInNewTab ? '_blank' : undefined}
+            rel={settings.openLinkInNewTab ? 'noopener' : undefined}
+          >
+            {item.title}
+          </a>
+          {item.domain && <span className={styles.domain}>({item.domain})</span>}
+        </p>
+      ) : (
+        <p>
+          <Link
+            className={styles.title}
+            style={{ fontSize: `${settings.titleFontSize}px` }}
+            to={`/item/${item.id}`}
+          >
+            {item.title}
+          </Link>
+        </p>
+      )}
+      <div className={styles['subtext-palm']}>
+        {item.type !== 'job' && (
+          <div className={styles.details}>
+            <span className={styles.name}>
+              <Link to={`/user/${item.user}`}>{item.user}</Link>
+            </span>
+            <span className={styles.right}>{item.points} ★</span>
+          </div>
+        )}
+        <div className={styles.details}>
+          {item.time_ago}
+          {item.type !== 'job' && (
+            <Link to={`/item/${item.id}`} className={styles['comment-number']}>
+              {' • '}
+              {formatComments(item.comments_count)}
+            </Link>
+          )}
+        </div>
+      </div>
+      <div className={styles['subtext-laptop']}>
+        {item.type !== 'job' && (
+          <span>
+            {item.points} points by{' '}
+            <Link to={`/user/${item.user}`}>{item.user}</Link>
+          </span>
+        )}
+        <span className={item.type !== 'job' ? styles['item-details'] : undefined}>
+          {item.time_ago}
+          {item.type !== 'job' && (
+            <span>
+              {' | '}
+              <Link to={`/item/${item.id}`}>{formatComments(item.comments_count)}</Link>
+            </span>
+          )}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/feed/FeedPage.tsx
+++ b/src/components/feed/FeedPage.tsx
@@ -1,0 +1,61 @@
+import { useEffect } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { useFeed } from '../../shared/hooks/useHackerNewsApi';
+import { Loader, ErrorMessage } from '../../shared/components';
+import FeedItem from './FeedItem';
+import styles from '../../styles/FeedPage.module.css';
+
+export default function FeedPage() {
+  const { feedType = '', page: pageParam } = useParams();
+  const page = pageParam ? Number(pageParam) : 1;
+  const { items, error, loading } = useFeed(feedType, page);
+  const listStart = (page - 1) * 30 + 1;
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [page]);
+
+  return (
+    <div className={styles['main-content']}>
+      {loading ? (
+        <Loader />
+      ) : error ? (
+        <ErrorMessage errorMessage={error} />
+      ) : (
+        <div>
+          {feedType === 'jobs' && (
+            <p className={styles['job-header']}>
+              These are jobs at startups that were funded by Y Combinator. You can also
+              get a job at a YC startup through{' '}
+              <a href="https://triplebyte.com/?ref=yc_jobs">Triplebyte</a>.
+            </p>
+          )}
+          {feedType !== 'new' && (
+            <ol
+              className={feedType !== 'jobs' ? styles['list-margin'] : undefined}
+              start={listStart}
+            >
+              {items.map((item) => (
+                <li key={item.id} className={styles.post}>
+                  <FeedItem item={item} />
+                </li>
+              ))}
+            </ol>
+          )}
+          <nav className={styles.nav}>
+            {listStart !== 1 && (
+              <Link to={`/${feedType}/${page - 1}`} className={styles.prev}>
+                ‹ Prev
+              </Link>
+            )}
+            {items.length === 30 && (
+              <Link to={`/${feedType}/${page + 1}`} className={styles.more}>
+                More ›
+              </Link>
+            )}
+          </nav>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Phase 4, Child G: ports the Angular feed list (`feeds/feed`) and story card (`feeds/item`) to React function components. Adds only `src/components/feed/FeedPage.tsx` and `src/components/feed/FeedItem.tsx`; no shared/config files touched.

**`FeedPage`** — reads `feedType`/`page` from the route (`/:feedType/:page?`) instead of Angular route data, drives the feed via the shared hook, and renders inside `main-content`:
```tsx
const { feedType = '', page: pageParam } = useParams();
const page = pageParam ? Number(pageParam) : 1;
const { items, error, loading } = useFeed(feedType, page);
const listStart = (page - 1) * 30 + 1;
useEffect(() => { window.scrollTo(0, 0); }, [page]);
// loading -> <Loader/>, error -> <ErrorMessage errorMessage={error}/>, else the <ol>/nav list
```
Preserves the Angular guards: jobs header only when `feedType === 'jobs'`, `<ol>` rendered only when `feedType !== 'new'` with `list-margin` applied when `feedType !== 'jobs'` and `start={listStart}`, and pagination links gated on `listStart !== 1` / `items.length === 30`.

**`FeedItem`** (`{ item: Story }`) — ports `item.component.html` faithfully:
- `hasUrl = item.url ? item.url.startsWith('http') : false` switches the title between an external `<a>` (with `target`/`rel` driven by `settings.openLinkInNewTab`) and an internal `<Link to={/item/:id}>`.
- `[ngStyle]` → inline `style` (`marginBottom`, `fontSize` from `settings`); the `subtext-palm`/`subtext-laptop` blocks keep every `item.type !== 'job'` guard.
- The Angular `comment` pipe is inlined as a local `formatComments(count)` helper (not a shared file, per the migration contract).

Routerless nav links use plain `<Link>` since neither CSS module defines an `.active` class. `npm run lint` and `npm run build` (`tsc -b && vite build`) both pass.

Link to Devin session: https://app.devin.ai/sessions/9e67540b426f4d6e8ae3c78739c4b5c1
Requested by: @eashansinha
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| 🟢 Reviewed | [`4d2fde8`](https://github.com/cog-gtm/angular2-hn/pull/361/commits/4d2fde85f37dc19c9ce3bcdc5237e207d1af1b08) |

<a href="https://staging.itsdev.in/review/cog-gtm/angular2-hn/pull/361" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->