### PR TITLE
feat(item-details): port ItemDetailsPage + Comment to React

### DIFF
--- a/src/components/item-details/Comment.tsx
+++ b/src/components/item-details/Comment.tsx
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+
+import type { Comment as CommentModel } from '../../shared/types';
+import styles from '../../styles/Comment.module.css';
+
+export default function Comment({ comment }: { comment: CommentModel }) {
+  const [collapse, setCollapse] = useState(false);
+
+  if (comment.deleted) {
+    return (
+      <div>
+        <div className={styles['deleted-meta']}>
+          <span className={styles.collapse}>[deleted]</span> | Comment Deleted
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div
+        className={`${styles.meta}${collapse ? ` ${styles['meta-collapse']}` : ''}`}
+      >
+        <span className={styles.collapse} onClick={() => setCollapse(!collapse)}>
+          [{collapse ? '+' : '-'}]
+        </span>
+        <Link to={`/user/${comment.user}`}>{comment.user}</Link>
+        <span className={styles.time}>{comment.time_ago}</span>
+      </div>
+      <div className={styles['comment-tree']}>
+        <div hidden={collapse}>
+          <p
+            className={styles['comment-text']}
+            dangerouslySetInnerHTML={{ __html: comment.content }}
+          />
+          <ul className={styles.subtree}>
+            {comment.comments.map((sub) => (
+              <li key={sub.id}>
+                <Comment comment={sub} />
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/item-details/ItemDetailsPage.tsx
+++ b/src/components/item-details/ItemDetailsPage.tsx
@@ -1,0 +1,147 @@
+import { useEffect } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+
+import { useItemDetails } from '../../shared/hooks/useHackerNewsApi';
+import { useSettings } from '../../shared/context/SettingsContext';
+import { Loader, ErrorMessage } from '../../shared/components';
+import styles from '../../styles/ItemDetailsPage.module.css';
+import Comment from './Comment';
+
+function formatComments(count: number): string {
+  if (count > 0) {
+    return `${count} ${count === 1 ? 'comment' : 'comments'}`;
+  }
+  return 'discuss';
+}
+
+export default function ItemDetailsPage() {
+  const { id: idParam } = useParams();
+  const id = Number(idParam);
+  const { item, error, loading } = useItemDetails(id);
+  const { settings } = useSettings();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [id]);
+
+  const goBack = () => navigate(-1);
+
+  const hasUrl = item?.url ? item.url.startsWith('http') : false;
+
+  const laptopClassName = [
+    styles.laptop,
+    item && (item.comments_count > 0 || item.type === 'job')
+      ? styles['item-header']
+      : undefined,
+    item?.text ? styles['head-margin'] : undefined,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div className={styles['main-content']}>
+      {loading ? (
+        <Loader />
+      ) : error ? (
+        <ErrorMessage errorMessage={error} />
+      ) : item ? (
+        <div className={styles.item}>
+          <div className={`${styles.mobile} ${styles['item-header']}`}>
+            <p className={styles['title-block']}>
+              <span className={styles['back-button']} onClick={goBack}></span>
+              {hasUrl ? (
+                <a
+                  className={styles.title}
+                  href={item.url}
+                  target={settings.openLinkInNewTab ? '_blank' : undefined}
+                  rel={settings.openLinkInNewTab ? 'noopener' : undefined}
+                >
+                  {item.title}
+                </a>
+              ) : (
+                <Link className={styles.title} to={`/item/${item.id}`}>
+                  {item.title}
+                </Link>
+              )}
+            </p>
+          </div>
+          <div className={laptopClassName}>
+            {hasUrl ? (
+              <p>
+                <a
+                  className={styles.title}
+                  href={item.url}
+                  target={settings.openLinkInNewTab ? '_blank' : undefined}
+                  rel={settings.openLinkInNewTab ? 'noopener' : undefined}
+                >
+                  {item.title}
+                </a>
+                {item.domain && (
+                  <span className={styles.domain}>({item.domain})</span>
+                )}
+              </p>
+            ) : (
+              <p>
+                <Link className={styles.title} to={`/item/${item.id}`}>
+                  {item.title}
+                </Link>
+              </p>
+            )}
+            <div className={styles.subtext}>
+              {item.type !== 'job' && (
+                <span>
+                  {item.points} points by{' '}
+                  <Link to={`/user/${item.user}`}>{item.user}</Link>
+                </span>
+              )}
+              <span
+                className={item.type !== 'job' ? styles['item-details'] : undefined}
+              >
+                {item.time_ago}
+                {item.type !== 'job' && (
+                  <span>
+                    {' '}
+                    |{' '}
+                    <Link to={`/item/${item.id}`}>
+                      {formatComments(item.comments_count)}
+                    </Link>
+                  </span>
+                )}
+              </span>
+            </div>
+          </div>
+          {item.type === 'poll' && (
+            <div className={styles.pollResults}>
+              {item.poll.map((pollResult, index) => (
+                <div key={index} className={styles.pollContent}>
+                  <div
+                    dangerouslySetInnerHTML={{ __html: pollResult.content }}
+                  />
+                  <div className={styles.subtext}>{pollResult.points} points</div>
+                  <div
+                    className={styles.pollBar}
+                    style={{
+                      width: `${(pollResult.points / item.poll_votes_count) * 100}%`,
+                    }}
+                  />
+                </div>
+              ))}
+            </div>
+          )}
+          <p
+            className={styles.subject}
+            dangerouslySetInnerHTML={{ __html: item.content ?? '' }}
+          />
+          <ul>
+            {item.comments.map((comment) => (
+              <li key={comment.id}>
+                <Comment comment={comment} />
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Phase 4, Child H of the Angular→React migration: ports the item-details view to React. Adds two new components under `src/components/item-details/`, faithfully porting `src/app/item-details/{item-details,comment/comment}.component.{ts,html}`. No shared/styles/config files were touched.

**`ItemDetailsPage.tsx`** — route page driven by the migration's shared hooks/context:
- `const { id } = Number(useParams().id)`, `useItemDetails(id)`, `useSettings()`, `useNavigate()`; `useEffect(() => window.scrollTo(0,0), [id])`; `goBack = () => navigate(-1)`.
- Renders `<Loader/>` while loading, `<ErrorMessage errorMessage={error}/>` on error, else the item block.
- Replicates the Angular conditional classes on the laptop block — `item-header` when `comments_count > 0 || type === 'job'`, `head-margin` when `item.text` — and the `item-details` class on the time span. Keeps all `type !== 'job'` guards.
- `hasUrl` switches the title between an external `<a target/rel>` (gated on `settings.openLinkInNewTab`) and an internal `<Link to={'/item/'+id}>`.
- Poll branch maps `item.poll` into `pollContent` blocks with a `pollBar` width of `points / poll_votes_count * 100%`.
- Comment list maps `item.comments` to `<Comment comment={c}/>`.

**`Comment.tsx`** — recursive comment node. The component name collides with the `Comment` type, so the type is aliased: `import type { Comment as CommentModel }`. Local `collapse` state toggles the `meta-collapse` class and hides the `comment-tree` inner block (`hidden={collapse}`); child comments recurse via `comment.comments.map(...)`. Deleted comments render the `[deleted] | Comment Deleted` block.

Porting notes following the migration contract:
- `[innerHTML]` → `dangerouslySetInnerHTML` (`item.content ?? ''`, `pollResult.content`, `comment.content`).
- `routerLink` → `<Link>`; plain `<Link>` (not `NavLink`) used because neither module CSS defines an `.active` class.
- The Angular `comment` pipe is inlined as `formatComments(count)` in `ItemDetailsPage.tsx` per the contract (no shared file).
- Module classes applied per the actual `.module.css` files (the `<ul>` comment list has no class in the module, so it relies on the module's global `ul` rule).

Validation: `npm run lint` and `npm run build` (`tsc -b && vite build`) both pass.


Link to Devin session: https://app.devin.ai/sessions/49b7594b61b948b68cc3be91005b9991
Requested by: @eashansinha
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| 🟢 Reviewed | [`1936330`](https://github.com/cog-gtm/angular2-hn/pull/362/commits/193633004e57d8ee56b68ff6be8892fc2fc64512) |

<a href="https://staging.itsdev.in/review/cog-gtm/angular2-hn/pull/362" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->