### PR TITLE
feat(app-shell): App shell + routing (Phase 5J)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,41 @@
-import './App.css'
+import { useEffect } from 'react';
+import { BrowserRouter, useLocation } from 'react-router-dom';
+import { SettingsProvider, useSettings } from './shared/context/SettingsContext';
+import Header from './components/layout/Header';
+import Footer from './components/layout/Footer';
+import AppRoutes from './routes';
 
-function App() {
-  return (
-    <div className="app-shell">
-      <h1>React HN</h1>
-      <p>Migration scaffold — feature work in progress.</p>
-    </div>
-  )
+declare global {
+  interface Window { ga?: (...args: unknown[]) => void; }
 }
 
-export default App
+function AppShell() {
+  const { settings } = useSettings();
+  const location = useLocation();
+  useEffect(() => {
+    if (typeof window.ga === 'function') {
+      window.ga('set', 'page', location.pathname);
+      window.ga('send', 'pageview');
+    }
+  }, [location]);
+  return (
+    <div className={settings.theme}>
+      <div className="body-cover"></div>
+      <div className="wrapper">
+        <Header />
+        <AppRoutes />
+        <Footer />
+      </div>
+    </div>
+  );
+}
+
+export default function App() {
+  return (
+    <BrowserRouter>
+      <SettingsProvider>
+        <AppShell />
+      </SettingsProvider>
+    </BrowserRouter>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,8 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import './index.css'
+import './styles/themes.css'
+import './styles/global.css'
+import './styles/media.css'
 import App from './App.tsx'
 
 createRoot(document.getElementById('root')!).render(

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,0 +1,33 @@
+import { lazy, Suspense } from 'react';
+import { Navigate, Route, Routes } from 'react-router-dom';
+import FeedPage from './components/feed/FeedPage';
+import { Loader } from './shared/components';
+
+const ItemDetailsPage = lazy(() => import('./components/item-details/ItemDetailsPage'));
+const UserPage = lazy(() => import('./components/user/UserPage'));
+
+export default function AppRoutes() {
+  return (
+    <Routes>
+      <Route path="/" element={<Navigate to="/news/1" replace />} />
+      <Route
+        path="/item/:id"
+        element={
+          <Suspense fallback={<Loader />}>
+            <ItemDetailsPage />
+          </Suspense>
+        }
+      />
+      <Route
+        path="/user/:id"
+        element={
+          <Suspense fallback={<Loader />}>
+            <UserPage />
+          </Suspense>
+        }
+      />
+      <Route path="/:feedType" element={<FeedPage />} />
+      <Route path="/:feedType/:page" element={<FeedPage />} />
+    </Routes>
+  );
+}


### PR DESCRIPTION
## Summary
Phase 5J wires the previously-ported feature components into a working SPA: a router (`src/routes.tsx`), the app shell that replicates `app.component.html` (`src/App.tsx`), and the real global stylesheets (`src/main.tsx`). This replaces the migration scaffold with a navigable app.

**Routing** (`AppRoutes`, default export) mirrors `app.routes.ts`. `FeedPage` is eager; the two leaf pages are `lazy`-loaded (build confirms they split into separate chunks). The optional `:page?` segment is implemented as two explicit routes since `FeedPage` already defaults `page` to 1:
```
"/"              -> <Navigate to="/news/1" replace />
"/item/:id"      -> <Suspense fallback={<Loader/>}><ItemDetailsPage/></Suspense>
"/user/:id"      -> <Suspense fallback={<Loader/>}><UserPage/></Suspense>
"/:feedType"     -> <FeedPage/>
"/:feedType/:page" -> <FeedPage/>
```

**App shell** (`App`, default export) replicates `app.component.html` lines 1–8: `<div class={settings.theme}>` → `.body-cover` + `.wrapper` (Header / Routes / Footer), with the GA `NavigationEnd` pageview from `app.component.ts` (lines 24–29) reimplemented as a `useLocation` effect, guarded by `typeof window.ga === 'function'`. `window.ga` is typed via an erasable `declare global`. Provider order: `BrowserRouter > SettingsProvider > AppShell`.

**Styles** (`main.tsx`): swapped `./index.css` for `./styles/themes.css`, `./styles/global.css`, `./styles/media.css` (themes first so its CSS custom properties resolve). `index.css`/`App.css` are left on disk (no longer imported); Phase 6 removes the scaffold leftovers.

Validation: `npm run lint` and `npm run build` (`tsc -b && vite build`) both green.

Link to Devin session: https://app.devin.ai/sessions/2dfbe72811014d548b9f5cbf7d1b161f
Requested by: @eashansinha
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| 🟢 Reviewed | [`003cecb`](https://github.com/cog-gtm/angular2-hn/pull/363/commits/003cecb23b827dddc73fd1698174bf7222773a7e) |

<a href="https://staging.itsdev.in/review/cog-gtm/angular2-hn/pull/363" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->