### PR TITLE
refactor: use startsWith instead of indexOf for URL check

### DIFF
--- a/src/app/item-details/item-details.component.ts
+++ b/src/app/item-details/item-details.component.ts
@@ -44,7 +44,7 @@ export class ItemDetailsComponent implements OnInit {
   }
 
   get hasUrl(): boolean {
-    return this.item.url.indexOf('http') === 0;
+    return this.item.url.startsWith('http');
   }
 
 }


### PR DESCRIPTION
## Summary

Replace `this.item.url.indexOf('http') === 0` with `this.item.url.startsWith('http')` in the `hasUrl` getter of `ItemDetailsComponent`. 

`startsWith` expresses the intent directly — "does this string begin with 'http'?" — whereas the `indexOf === 0` idiom requires the reader to mentally decode the pattern.

Link to Devin session: https://app.devin.ai/sessions/92287c6490544fc0b3e43de89a892cde
Requested by: @vibhaseshadri-cognition
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/367?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/367" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->