### PR TITLE
feat(vite-migration): port user profile to React

### DIFF
--- a/src/pages/User.scss
+++ b/src/pages/User.scss
@@ -1,0 +1,89 @@
+@import "../scss/media";
+@import "../scss/theme_variables";
+
+.profile pre {
+  white-space: pre-wrap;
+}
+
+.profile {
+  padding: 30px;
+}
+
+@media #{$mobile-only} {
+  .profile {
+    padding: 110px 15px 0 15px;
+  }
+  .title-block {
+    font-size: 15px;
+    text-align: center;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    margin: 0 75px;
+  }
+  .back-button {
+    position: absolute;
+    top: 52%;
+    width: 0.6rem;
+    height: 0.6rem;
+    background: transparent;
+    box-shadow: 0 0 0 lightgray;
+    transition: all 200ms ease;
+    left: 4%;
+    transform: translate3d(0, -50%, 0) rotate(-135deg);
+  }
+  .item-header {
+    padding-bottom: 10px;
+    background-color: #fff;
+    padding: 10px 0 10px 0;
+    position: fixed;
+    width: 100%;
+    left: 0;
+    top: 62px;
+    height: 20px;
+  }
+}
+
+@media #{$laptop-only} {
+  .mobile {
+    display: none;
+  }
+}
+
+.main-details {
+  .name {
+    font-weight: bold;
+    font-size: 32px;
+    letter-spacing: 2px;
+  }
+  .age {
+    font-weight: bold;
+    color: #696969;
+    padding-bottom: 0;
+  }
+  .right {
+    float: right;
+    font-weight: bold;
+    font-size: 32px;
+    letter-spacing: 2px;
+  }
+}
+
+@media #{$mobile-only} {
+  .main-details {
+    margin-top: 20px;
+    .name {
+      font-size: 18px;
+    }
+  }
+}
+
+@media #{$mobile-only} {
+  .main-details .right {
+    font-size: 18px;
+  }
+}
+
+.other-details {
+  word-wrap: break-word;
+}

--- a/src/pages/User.tsx
+++ b/src/pages/User.tsx
@@ -1,5 +1,61 @@
-// STUB — to be implemented by the "user" migration session.
-// Owns: src/pages/User.tsx, src/pages/User.scss
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+
+import { fetchUser } from '../services/hackerNewsApi';
+import { User as UserModel } from '../models/user';
+import Loader from '../components/Loader';
+import ErrorMessage from '../components/ErrorMessage';
+import './User.scss';
+
 export default function User() {
-    return <div className="user-view">User stub</div>;
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const [user, setUser] = useState<UserModel | null>(null);
+  const [errorMessage, setErrorMessage] = useState('');
+
+  useEffect(() => {
+    if (!id) {
+      return;
+    }
+    setUser(null);
+    setErrorMessage('');
+    fetchUser(id)
+      .then((data) => setUser(data))
+      .catch(() => setErrorMessage('Could not load user ' + id + '.'));
+  }, [id]);
+
+  const goBack = () => navigate(-1);
+
+  if (!user && !errorMessage) {
+    return <Loader />;
+  }
+
+  if (!user && errorMessage !== '') {
+    return <ErrorMessage message={errorMessage} />;
+  }
+
+  if (!user) {
+    return null;
+  }
+
+  return (
+    <div className="profile">
+      <div className="mobile item-header">
+        <p className="title-block">
+          <span className="back-button" onClick={goBack}></span>
+          Profile: {user.id}
+        </p>
+      </div>
+      <div className="main-details">
+        <span className="name">{user.id}</span>
+        <span className="right">{user.karma} ★</span>
+        <p className="age">Created {user.created}</p>
+      </div>
+      {user.about && (
+        <div className="other-details">
+          <p dangerouslySetInnerHTML={{ __html: user.about }}></p>
+        </div>
+      )}
+    </div>
+  );
 }

--- a/src/pages/User.tsx
+++ b/src/pages/User.tsx
@@ -17,11 +17,19 @@ export default function User() {
     if (!id) {
       return;
     }
+    let ignore = false;
     setUser(null);
     setErrorMessage('');
     fetchUser(id)
-      .then((data) => setUser(data))
-      .catch(() => setErrorMessage('Could not load user ' + id + '.'));
+      .then((data) => {
+        if (!ignore) setUser(data);
+      })
+      .catch(() => {
+        if (!ignore) setErrorMessage('Could not load user ' + id + '.');
+      });
+    return () => {
+      ignore = true;
+    };
   }, [id]);
 
   const goBack = () => navigate(-1);


### PR DESCRIPTION
## Summary
Ports the User Profile feature from the Angular `UserComponent` to a React function component, replacing the stub `src/pages/User.tsx` and adding `src/pages/User.scss`.

- Default export `User()` (no props); reads `:id` via `useParams()` and fetches with `fetchUser(id)` inside `useEffect` (re-fetches on `id` change).
- Mirrors the Angular subscribe semantics: `<Loader/>` while loading, `<ErrorMessage message="Could not load user <id>."/>` on error.
- Renders id, karma (`★`), `Created <created>`, and `about` via `dangerouslySetInnerHTML` — preserving the original class names (`.profile`, `.main-details`, `.other-details`, etc.).
- `goBack()` (mobile back button) → `useNavigate()(-1)` (replaces Angular `Location.back()`).
- SCSS copied from `user.component.scss` with `@import` paths fixed to `../scss/...`; Angular's `:host >>> pre` rewritten as `.profile pre`.

`npm run build` and `npm run typecheck` both pass.


Link to Devin session: https://app.devin.ai/sessions/11f69a5645694b88b86d7a75111fc604
Requested by: @eashansinha
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| 🟢 Reviewed | [`6291fb8`](https://github.com/cog-gtm/angular2-hn/pull/398/commits/6291fb86d9f8c8bb7f3bf7bd9bd93154a343b9f8) |

<a href="https://staging.itsdev.in/review/cog-gtm/angular2-hn/pull/398" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->