### PR TITLE
feat(vite-migration): port item details to React

### DIFF
--- a/src/components/Comment.scss
+++ b/src/components/Comment.scss
@@ -1,0 +1,85 @@
+@import "../scss/media";
+@import "../scss/theme_variables";
+
+.comment-text {
+  a {
+    font-weight: bold;
+    text-decoration: none;
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}
+
+.meta {
+  font-size: 13px;
+  color: #696969;
+  font-weight: bold;
+  letter-spacing: 0.5px;
+  margin-bottom: 8px;
+  a {
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+  .time {
+    padding-left: 5px;
+  }
+}
+
+@media #{$mobile-only} {
+  .meta {
+    font-size: 14px;
+    margin-bottom: 10px;
+    .time {
+      padding: 0;
+      float: right;
+    }
+  }
+}
+
+.meta-collapse {
+  margin-bottom: 20px;
+}
+
+.deleted-meta {
+  font-size: 12px;
+  font-weight: bold;
+  letter-spacing: 0.5px;
+  margin: 30px 0;
+  a {
+    text-decoration: none;
+  }
+}
+
+.collapse {
+  font-size: 13px;
+  letter-spacing: 2px;
+  cursor: pointer;
+}
+
+.comment-tree {
+  margin-left: 24px;
+}
+
+@media #{$tablet-only} {
+  .comment-tree {
+    margin-left: 8px;
+  }
+}
+
+.comment-text {
+  font-size: 15px;
+  margin-top: 0;
+  margin-bottom: 20px;
+  word-wrap: break-word;
+  line-height: 1.5em;
+}
+
+.subtree {
+  margin-left: 0;
+  padding: 0;
+  list-style-type: none;
+}

--- a/src/components/Comment.tsx
+++ b/src/components/Comment.tsx
@@ -38,7 +38,7 @@ function Comment({ comment }: CommentProps) {
             dangerouslySetInnerHTML={{ __html: comment.content }}
           />
           <ul className="subtree">
-            {comment.comments.map(subComment => (
+            {comment.comments?.map(subComment => (
               <li key={subComment.id}>
                 <Comment comment={subComment} />
               </li>

--- a/src/components/Comment.tsx
+++ b/src/components/Comment.tsx
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+
+import { Comment as CommentModel } from '../models/comment';
+
+import './Comment.scss';
+
+interface CommentProps {
+  comment: CommentModel;
+}
+
+function Comment({ comment }: CommentProps) {
+  const [collapse, setCollapse] = useState(false);
+
+  if (comment.deleted) {
+    return (
+      <div>
+        <div className="deleted-meta">
+          <span className="collapse">[deleted]</span> | Comment Deleted
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className={`meta${collapse ? ' meta-collapse' : ''}`}>
+        <span className="collapse" onClick={() => setCollapse(!collapse)}>
+          [{collapse ? '+' : '-'}]
+        </span>{' '}
+        <Link to={`/user/${comment.user}`}>{comment.user}</Link>
+        <span className="time">{comment.time_ago}</span>
+      </div>
+      <div className="comment-tree">
+        <div hidden={collapse}>
+          <p
+            className="comment-text"
+            dangerouslySetInnerHTML={{ __html: comment.content }}
+          />
+          <ul className="subtree">
+            {comment.comments.map(subComment => (
+              <li key={subComment.id}>
+                <Comment comment={subComment} />
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default Comment;

--- a/src/pages/ItemDetails.scss
+++ b/src/pages/ItemDetails.scss
@@ -1,0 +1,151 @@
+@import "../scss/media";
+@import "../scss/theme_variables";
+
+.main-content {
+  position: relative;
+  width: 100%;
+  min-height: 100vh;
+  -webkit-transition: opacity .2s ease;
+  transition: opacity .2s ease;
+  box-sizing: border-box;
+  padding: 8px 0;
+  z-index: 0;
+}
+
+.item {
+  box-sizing: border-box;
+  padding: 10px 40px 0 40px;
+  z-index: 0;
+}
+
+@media #{$tablet-only} {
+  .item {
+    padding: 10px 20px 0 40px;
+  }
+}
+
+@media #{$mobile-only} {
+  .item {
+    box-sizing: border-box;
+    padding: 110px 15px 0 15px;
+  }
+}
+
+.head-margin {
+  margin-bottom: 15px;
+}
+
+p {
+  margin: 2px 0;
+}
+
+.subject {
+  word-wrap: break-word;
+  margin-top: 20px;
+}
+
+a {
+  cursor: pointer;
+  text-decoration: none;
+}
+
+@media #{$mobile-only} {
+  .laptop {
+    display: none;
+  }
+}
+
+@media #{$laptop-only} {
+  .mobile {
+    display: none;
+  }
+}
+
+.title {
+  font-size: 16px;
+  font-family: Verdana, Geneva, sans-serif;
+}
+
+.title-block {
+  text-align: center;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  margin: 0 75px;
+}
+
+@media #{$mobile-only} {
+  .title {
+    font-size: 15px;
+  }
+  .back-button {
+    position: absolute;
+    top: 52%;
+    width: 0.6rem;
+    height: 0.6rem;
+    background: transparent;
+    box-shadow: 0 0 0 lightgray;
+    transition: all 200ms ease;
+    left: 4%;
+    transform: translate3d(0, -50%, 0) rotate(-135deg);
+  }
+}
+
+.subtext {
+  font-size: 12px;
+  font-weight: bold;
+  letter-spacing: 0.5px;
+}
+
+.domain {
+  letter-spacing: 0.5px;
+}
+
+.subtext a {
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.item-details {
+  padding: 10px;
+}
+
+.item-header {
+  padding-bottom: 10px;
+}
+
+@media #{$mobile-only} {
+  .item-header {
+    padding: 10px 0 10px 0;
+    position: fixed;
+    width: 100%;
+    left: 0;
+    top: 62px;
+  }
+}
+
+.pollResults {
+  margin-bottom: 1em;
+}
+
+.pollContent {
+  * {
+    padding-bottom: 0;
+    margin-bottom: -1em;
+    margin-top: 1em;
+  }
+  .pollBar {
+    height: 10px;
+    margin-bottom: 1em;
+  }
+}
+
+ul {
+  list-style-type: none;
+  padding: 10px 0;
+}
+
+li {
+  display: list-item;
+}

--- a/src/pages/ItemDetails.tsx
+++ b/src/pages/ItemDetails.tsx
@@ -23,12 +23,20 @@ function ItemDetails() {
   const [errorMessage, setErrorMessage] = useState('');
 
   useEffect(() => {
+    let cancelled = false;
     setItem(null);
     setErrorMessage('');
     fetchItemContent(Number(id))
-      .then(setItem)
-      .catch(() => setErrorMessage('Could not load item comments.'));
+      .then(data => {
+        if (!cancelled) setItem(data);
+      })
+      .catch(() => {
+        if (!cancelled) setErrorMessage('Could not load item comments.');
+      });
     window.scrollTo(0, 0);
+    return () => {
+      cancelled = true;
+    };
   }, [id]);
 
   if (!item && !errorMessage) {
@@ -111,7 +119,7 @@ function ItemDetails() {
             </span>
           </div>
         </div>
-        {item.type === 'poll' && (
+        {item.type === 'poll' && item.poll && (
           <div className="pollResults">
             {item.poll.map((pollResult, i) => (
               <div key={i} className="pollContent">

--- a/src/pages/ItemDetails.tsx
+++ b/src/pages/ItemDetails.tsx
@@ -1,5 +1,146 @@
-// STUB — to be implemented by the "item-details" migration session.
-// Owns: src/pages/ItemDetails.tsx, src/pages/ItemDetails.scss, src/components/Comment.tsx, src/components/Comment.scss
-export default function ItemDetails() {
-    return <div className="item-view">Item details stub</div>;
+import { useEffect, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+
+import Loader from '../components/Loader';
+import ErrorMessage from '../components/ErrorMessage';
+import Comment from '../components/Comment';
+
+import { fetchItemContent } from '../services/hackerNewsApi';
+import { useSettings } from '../contexts/SettingsContext';
+import { commentPipe } from '../utils/commentPipe';
+import { Story } from '../models/story';
+
+import './ItemDetails.scss';
+
+type StoryWithContent = Story & { content?: string };
+
+function ItemDetails() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const { settings } = useSettings();
+
+  const [item, setItem] = useState<StoryWithContent | null>(null);
+  const [errorMessage, setErrorMessage] = useState('');
+
+  useEffect(() => {
+    setItem(null);
+    setErrorMessage('');
+    fetchItemContent(Number(id))
+      .then(setItem)
+      .catch(() => setErrorMessage('Could not load item comments.'));
+    window.scrollTo(0, 0);
+  }, [id]);
+
+  if (!item && !errorMessage) {
+    return (
+      <div className="main-content">
+        <Loader />
+      </div>
+    );
+  }
+
+  if (!item && errorMessage) {
+    return (
+      <div className="main-content">
+        <ErrorMessage message={errorMessage} />
+      </div>
+    );
+  }
+
+  if (!item) {
+    return <div className="main-content" />;
+  }
+
+  const hasUrl = item.url ? item.url.indexOf('http') === 0 : false;
+  const target = settings.openLinkInNewTab ? '_blank' : undefined;
+  const rel = settings.openLinkInNewTab ? 'noopener' : undefined;
+
+  const laptopHeader = item.comments_count > 0 || item.type === 'job';
+
+  return (
+    <div className="main-content">
+      <div className="item">
+        <div className="mobile item-header">
+          <p className="title-block">
+            <span className="back-button" onClick={() => navigate(-1)}></span>
+            {hasUrl ? (
+              <a className="title" href={item.url} target={target} rel={rel}>
+                {item.title}
+              </a>
+            ) : (
+              <Link className="title" to={`/item/${item.id}`}>
+                {item.title}
+              </Link>
+            )}
+          </p>
+        </div>
+        <div
+          className={`laptop${laptopHeader ? ' item-header' : ''}${item.content ? ' head-margin' : ''}`}
+        >
+          {hasUrl ? (
+            <p>
+              <a className="title" href={item.url} target={target} rel={rel}>
+                {item.title}
+              </a>
+              {item.domain && <span className="domain">({item.domain})</span>}
+            </p>
+          ) : (
+            <p>
+              <Link className="title" to={`/item/${item.id}`}>
+                {item.title}
+              </Link>
+            </p>
+          )}
+          <div className="subtext">
+            {item.type !== 'job' && (
+              <span>
+                {item.points} points by{' '}
+                <Link to={`/user/${item.user}`}>{item.user}</Link>
+              </span>
+            )}
+            <span className={item.type !== 'job' ? 'item-details' : undefined}>
+              {item.time_ago}
+              {item.type !== 'job' && (
+                <span>
+                  {' '}|{' '}
+                  <Link to={`/item/${item.id}`}>
+                    {commentPipe(item.comments_count)}
+                  </Link>
+                </span>
+              )}
+            </span>
+          </div>
+        </div>
+        {item.type === 'poll' && (
+          <div className="pollResults">
+            {item.poll.map((pollResult, i) => (
+              <div key={i} className="pollContent">
+                <div dangerouslySetInnerHTML={{ __html: pollResult.content }} />
+                <div className="subtext">{pollResult.points} points</div>
+                <div
+                  className="pollBar"
+                  style={{
+                    width: `${(pollResult.points / item.poll_votes_count) * 100}%`,
+                  }}
+                />
+              </div>
+            ))}
+          </div>
+        )}
+        <p
+          className="subject"
+          dangerouslySetInnerHTML={{ __html: item.content || '' }}
+        />
+        <ul className="comment-list">
+          {item.comments.map(comment => (
+            <li key={comment.id}>
+              <Comment comment={comment} />
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
 }
+
+export default ItemDetails;

--- a/src/pages/ItemDetails.tsx
+++ b/src/pages/ItemDetails.tsx
@@ -140,7 +140,7 @@ function ItemDetails() {
           dangerouslySetInnerHTML={{ __html: item.content || '' }}
         />
         <ul className="comment-list">
-          {item.comments.map(comment => (
+          {item.comments?.map(comment => (
             <li key={comment.id}>
               <Comment comment={comment} />
             </li>


### PR DESCRIPTION
## Summary
Ports the **Item Details** feature (story page + recursive comments) from Angular 9 to React 18, replacing the stub in `src/pages/ItemDetails.tsx` and adding `src/components/Comment.tsx`. SCSS is copied verbatim from the Angular components with `@import` paths fixed to `../scss/...`; original class names are preserved so shared theming keeps working.

Files (only these were touched):
- `src/pages/ItemDetails.tsx` / `ItemDetails.scss`
- `src/components/Comment.tsx` / `Comment.scss`

`ItemDetails` (default export, no props):
- Reads `:id` via `useParams()`, fetches `fetchItemContent(Number(id))` in `useEffect` (re-runs on id change, `window.scrollTo(0,0)`); `<Loader/>` while loading, `<ErrorMessage message="Could not load item comments."/>` on error — mirroring the Angular subscribe semantics.
- Renders both mobile and laptop header variants. Title is an external `<a href>` when `url` starts with `http`, else internal `<Link to={/item/:id}>`. Domain, points, user `<Link>`, `time_ago`, and comment count via `commentPipe` are rendered as in the original; `target`/`rel` driven by `settings.openLinkInNewTab`.
- Back button uses `useNavigate()` → `navigate(-1)`.
- Poll support: when `type === 'poll'`, maps `item.poll` with `dangerouslySetInnerHTML` for `content`, points, and a `.pollBar` with `width: points / poll_votes_count * 100 + '%'`.
- Body via `dangerouslySetInnerHTML` (class `subject`); top-level comments rendered as `<Comment comment={c} />` inside `<ul class="comment-list">`.

`Comment` (default export, prop `{ comment: Comment }`):
- Replicates `comment.component`: local `collapse` state toggled via the `[+]/[-]` span, user `<Link>`, `time_ago`, content via `dangerouslySetInnerHTML`, deleted-comment branch, and recursive rendering of `comment.comments` preserving indentation/level styling.

Note: the foundation `Story` model (owned by the base branch, not edited here) does not declare the API's `content` field, so `ItemDetails` uses a local `type StoryWithContent = Story & { content?: string }` to render the story body without touching shared models.

## Validation
- `npm install`, `npm run typecheck`, and `npm run build` all pass.


Link to Devin session: https://app.devin.ai/sessions/62b02659671041df9d44fd1bb7774782
Requested by: @eashansinha
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| 🟢 Reviewed | [`8f85dd4`](https://github.com/cog-gtm/angular2-hn/pull/401/commits/8f85dd43913a584c0de78cf3fa0bbb99eb58f3c9) |

<a href="https://staging.itsdev.in/review/cog-gtm/angular2-hn/pull/401" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->