### PR TITLE
feat(components): port Loader and ErrorMessage to React

### DIFF
--- a/src/components/ErrorMessage/ErrorMessage.tsx
+++ b/src/components/ErrorMessage/ErrorMessage.tsx
@@ -5,5 +5,21 @@ interface ErrorMessageProps {
 }
 
 export default function ErrorMessage({ message }: ErrorMessageProps) {
-  return <div className="error-message">{message}</div>;
+  return (
+    <div className="error-section">
+      <div className="skull">
+        <div className="head">
+          <div className="crack"></div>
+        </div>
+        <div className="mouth">
+          <div className="teeth"></div>
+        </div>
+      </div>
+      <p className="strong">{message}</p>
+      <p>
+        If you are offline viewing, you'll need to visit this page with a
+        network connection first before it can work offline.
+      </p>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
Replaces the stub `Loader` and `ErrorMessage` components with faithful React ports of the original Angular templates (part of the Angular 9 → React migration).

- `Loader`: already matched the original (`.loading-section > .loader` with "Loading..." text) — left as-is.
- `ErrorMessage`: ported the full Angular template — the `.error-section` with the `.skull` markup (head/crack, mouth/teeth), `<p class="strong">{message}</p>`, and the offline-viewing note. The Angular `@Input() message` becomes the `message` prop.

Class names are kept identical to the Angular templates so the existing per-component `.scss` (already present and imported) applies. No other files touched.

`npm run build` and `npm run lint` both pass with zero errors/warnings.

Link to Devin session: https://app.devin.ai/sessions/8e8aa00e252e441c9b31b64161fe6290
Requested by: @eashansinha
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| 🟢 Reviewed | [`5478c6b`](https://github.com/cog-gtm/angular2-hn/pull/402/commits/5478c6b7f618ecf78b48d4065df6e2e9284ab966) |

<a href="https://staging.itsdev.in/review/cog-gtm/angular2-hn/pull/402" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->