### PR TITLE
feat(user): port User profile page to React

### DIFF
--- a/src/pages/User/User.tsx
+++ b/src/pages/User/User.tsx
@@ -1,6 +1,53 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+
+import Loader from '../../components/Loader/Loader';
+import ErrorMessage from '../../components/ErrorMessage/ErrorMessage';
+import { fetchUser } from '../../services/hackernews-api';
+import type { User as HNUser } from '../../models/user';
 import './User.scss';
 
-// TODO(child-session): port UserComponent (fetch user, profile details).
 export default function User() {
-  return <div className="profile" />;
+  const { id } = useParams();
+  const userID = id ?? '';
+  const navigate = useNavigate();
+
+  const [user, setUser] = useState<HNUser | undefined>(undefined);
+  const [errorMessage, setErrorMessage] = useState('');
+
+  useEffect(() => {
+    fetchUser(userID)
+      .then((data) => setUser(data))
+      .catch(() => setErrorMessage('Could not load user ' + userID + '.'));
+  }, [userID]);
+
+  const goBack = () => navigate(-1);
+
+  return (
+    <>
+      {!user && !errorMessage && <Loader />}
+      {!user && errorMessage !== '' && <ErrorMessage message={errorMessage} />}
+
+      {user && (
+        <div className="profile">
+          <div className="mobile item-header">
+            <p className="title-block">
+              <span className="back-button" onClick={() => goBack()}></span>
+              Profile: {user.id}
+            </p>
+          </div>
+          <div className="main-details">
+            <span className="name">{user.id}</span>
+            <span className="right">{user.karma} &#9733;</span>
+            <p className="age">Created {user.created}</p>
+          </div>
+          {user.about && (
+            <div className="other-details">
+              <p dangerouslySetInnerHTML={{ __html: user.about }}></p>
+            </div>
+          )}
+        </div>
+      )}
+    </>
+  );
 }

--- a/src/pages/User/User.tsx
+++ b/src/pages/User/User.tsx
@@ -16,9 +16,19 @@ export default function User() {
   const [errorMessage, setErrorMessage] = useState('');
 
   useEffect(() => {
+    let ignore = false;
+    setUser(undefined);
+    setErrorMessage('');
     fetchUser(userID)
-      .then((data) => setUser(data))
-      .catch(() => setErrorMessage('Could not load user ' + userID + '.'));
+      .then((data) => {
+        if (!ignore) setUser(data);
+      })
+      .catch(() => {
+        if (!ignore) setErrorMessage('Could not load user ' + userID + '.');
+      });
+    return () => {
+      ignore = true;
+    };
   }, [userID]);
 
   const goBack = () => navigate(-1);


### PR DESCRIPTION
## Summary
Replaces the `src/pages/User/User.tsx` stub with the real React port of the Angular `UserComponent`, completing the user profile route.

- Reads the route param via `useParams()` (`const userID = id ?? ''`).
- `useEffect` keyed on `[userID]` calls `fetchUser(userID)`, setting `user` on success and `errorMessage = 'Could not load user ' + userID + '.'` on failure.
- `goBack` uses `useNavigate()` → `navigate(-1)`, wired to the `.back-button` span's `onClick`.
- Faithful template port preserving all original class names (`profile`, `item-header`, `title-block`, `main-details`, `name`, `right`, `age`, `other-details`); `★` rendered via `&#9733;`, and `user.about` via `dangerouslySetInnerHTML`.
- Model type imported under alias `HNUser` to avoid clashing with the `User` default export.

Build (`npm run build`) and lint (`npm run lint --max-warnings=0`) both pass with zero errors/warnings. Only `src/pages/User/User.tsx` is modified.


Link to Devin session: https://app.devin.ai/sessions/1dda81b21ee143a893b639ba9b7d18a1
Requested by: @eashansinha
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| 🟢 Reviewed | [`6aef105`](https://github.com/cog-gtm/angular2-hn/pull/403/commits/6aef1059a3942d90df166f2676020e87709f7f45) |

<a href="https://staging.itsdev.in/review/cog-gtm/angular2-hn/pull/403" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->