### PR TITLE
feat(item): port Item feed list component to React

### DIFF
--- a/src/components/Item/Item.tsx
+++ b/src/components/Item/Item.tsx
@@ -1,11 +1,75 @@
+import { Link } from 'react-router-dom';
 import type { Story } from '../../models/story';
+import { useSettings } from '../../context/SettingsContext';
+import { commentLabel } from '../../utils/comment';
 import './Item.scss';
 
-interface ItemProps {
-  item: Story;
-}
+export default function Item({ item }: { item: Story }) {
+  const { settings } = useSettings();
+  const hasUrl = item.url.indexOf('http') === 0;
 
-// TODO(child-session): port ItemComponent template.
-export default function Item({ item }: ItemProps) {
-  return <div className="item-block">{item.title}</div>;
+  return (
+    <div style={{ marginBottom: `${settings.listSpacing}px` }}>
+      {hasUrl ? (
+        <p>
+          <a
+            className="title"
+            style={{ fontSize: `${settings.titleFontSize}px` }}
+            href={item.url}
+            target={settings.openLinkInNewTab ? '_blank' : undefined}
+            rel={settings.openLinkInNewTab ? 'noopener' : undefined}
+          >
+            {item.title}
+          </a>
+          {item.domain && <span className="domain">({item.domain})</span>}
+        </p>
+      ) : (
+        <p>
+          <Link
+            className="title"
+            style={{ fontSize: `${settings.titleFontSize}px` }}
+            to={`/item/${item.id}`}
+          >
+            {item.title}
+          </Link>
+        </p>
+      )}
+      <div className="subtext-palm">
+        {item.type !== 'job' && (
+          <div className="details">
+            <span className="name">
+              <Link to={`/user/${item.user}`}>{item.user}</Link>
+            </span>
+            <span className="right">{item.points} &#9733;</span>
+          </div>
+        )}
+        <div className="details">
+          {item.time_ago}
+          {item.type !== 'job' && (
+            <Link to={`/item/${item.id}`} className="comment-number">
+              {' '}
+              &#8226; {commentLabel(item.comments_count)}
+            </Link>
+          )}
+        </div>
+      </div>
+      <div className="subtext-laptop">
+        {item.type !== 'job' && (
+          <span>
+            {item.points} points by{' '}
+            <Link to={`/user/${item.user}`}>{item.user}</Link>
+          </span>
+        )}
+        <span className={item.type !== 'job' ? 'item-details' : undefined}>
+          {item.time_ago}
+          {item.type !== 'job' && (
+            <span>
+              {' '}
+              | <Link to={`/item/${item.id}`}>{commentLabel(item.comments_count)}</Link>
+            </span>
+          )}
+        </span>
+      </div>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
Replaces the stub `src/components/Item/Item.tsx` with a faithful React port of the Angular `ItemComponent` (feed list item). No other files were touched; routing, services, models, context, and SCSS are unchanged.

Behavior mirrors the original template:
- `hasUrl = item.url.indexOf('http') === 0` decides external `<a href>` (with `target/rel` driven by `settings.openLinkInNewTab`) vs internal `<Link to="/item/:id">`.
- `style={{ marginBottom: ` `${settings.listSpacing}px` ` }}` and `style={{ fontSize: ` `${settings.titleFontSize}px` ` }}` replace the Angular `[ngStyle]` bindings.
- `subtext-palm` / `subtext-laptop` blocks gate user/points/comments on `item.type !== 'job'`, matching the original `*ngIf`.
- `commentLabel(item.comments_count)` replaces the `| comment` pipe.
- All `className` strings kept identical to the Angular template so the existing `Item.scss` applies.

`npm run build` and `npm run lint` both pass with zero errors and zero warnings from this file.

Link to Devin session: https://app.devin.ai/sessions/b988c2ee309b428999ebf69618e08504
Requested by: @eashansinha
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| 🟢 Reviewed | [`3d23094`](https://github.com/cog-gtm/angular2-hn/pull/404/commits/3d230948d8d9bcb68004a687c318e7fb09850a29) |

<a href="https://staging.itsdev.in/review/cog-gtm/angular2-hn/pull/404" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->