### PR TITLE
feat(feed): port Feed page to React

### DIFF
--- a/src/pages/Feed/Feed.tsx
+++ b/src/pages/Feed/Feed.tsx
@@ -1,10 +1,80 @@
+import { useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+
+import type { Story } from '../../models/story';
+import { fetchFeed } from '../../services/hackernews-api';
+import Loader from '../../components/Loader/Loader';
+import ErrorMessage from '../../components/ErrorMessage/ErrorMessage';
+import Item from '../../components/Item/Item';
 import './Feed.scss';
 
 interface FeedProps {
   feedType: string;
 }
 
-// TODO(child-session): port FeedComponent (fetch feed, list items, pagination).
 export default function Feed({ feedType }: FeedProps) {
-  return <div className="main-content" data-feed-type={feedType} />;
+  const { page } = useParams();
+  const pageNum = page ? +page : 1;
+
+  const [items, setItems] = useState<Story[] | undefined>(undefined);
+  const [errorMessage, setErrorMessage] = useState('');
+  const [listStart, setListStart] = useState(0);
+
+  useEffect(() => {
+    setItems(undefined);
+    setErrorMessage('');
+
+    fetchFeed(feedType, pageNum)
+      .then((fetchedItems) => {
+        setItems(fetchedItems);
+        setListStart((pageNum - 1) * 30 + 1);
+        window.scrollTo(0, 0);
+      })
+      .catch(() => {
+        setErrorMessage('Could not load ' + feedType + ' stories.');
+      });
+  }, [feedType, pageNum]);
+
+  return (
+    <div className="main-content">
+      {!items && !errorMessage && <Loader />}
+      {!items && errorMessage !== '' && <ErrorMessage message={errorMessage} />}
+
+      {items && (
+        <div>
+          {feedType === 'jobs' && (
+            <p className="job-header">
+              These are jobs at startups that were funded by Y Combinator. You
+              can also get a job at a YC startup through{' '}
+              <a href="https://triplebyte.com/?ref=yc_jobs">Triplebyte</a>.
+            </p>
+          )}
+          {feedType !== 'new' && (
+            <ol
+              className={feedType !== 'jobs' ? 'list-margin' : undefined}
+              start={listStart}
+            >
+              {items.map((item) => (
+                <li key={item.id} className="post">
+                  <Item item={item} />
+                </li>
+              ))}
+            </ol>
+          )}
+          <div className="nav">
+            {listStart !== 1 && (
+              <Link to={`/${feedType}/${pageNum - 1}`} className="prev">
+                &#8249; Prev
+              </Link>
+            )}
+            {items.length === 30 && (
+              <Link to={`/${feedType}/${pageNum + 1}`} className="more">
+                More &#8250;
+              </Link>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
 }

--- a/src/pages/Feed/Feed.tsx
+++ b/src/pages/Feed/Feed.tsx
@@ -21,18 +21,25 @@ export default function Feed({ feedType }: FeedProps) {
   const [listStart, setListStart] = useState(0);
 
   useEffect(() => {
+    let ignore = false;
     setItems(undefined);
     setErrorMessage('');
 
     fetchFeed(feedType, pageNum)
       .then((fetchedItems) => {
+        if (ignore) return;
         setItems(fetchedItems);
         setListStart((pageNum - 1) * 30 + 1);
         window.scrollTo(0, 0);
       })
       .catch(() => {
+        if (ignore) return;
         setErrorMessage('Could not load ' + feedType + ' stories.');
       });
+
+    return () => {
+      ignore = true;
+    };
   }, [feedType, pageNum]);
 
   return (


### PR DESCRIPTION
## Summary
Replaces the `src/pages/Feed/Feed.tsx` stub with the real React port of the Angular `FeedComponent` (paginated story list). Part of the Angular 9 → React (Vite + TS) migration onto `devin/react-migration-base`.

- `feedType` is a prop; page comes from the route param: `const pageNum = page ? +page : 1`.
- State: `items: Story[] | undefined`, `errorMessage: string`, `listStart: number`.
- `useEffect([feedType, pageNum])`: resets `items`→undefined / `errorMessage`→'', calls `fetchFeed(feedType, pageNum)`; on success sets items, `listStart = (pageNum-1)*30 + 1`, `window.scrollTo(0,0)`; on error sets `'Could not load ' + feedType + ' stories.'`.
- Renders `<Loader/>` while loading, `<ErrorMessage/>` on error, otherwise the `<ol start={listStart}>` of `<Item/>`s plus Prev/More pagination `Link`s. Class names kept identical to the original template so existing SCSS applies.

Only `src/pages/Feed/Feed.tsx` changed. `npm run build` and `npm run lint` both pass with zero errors/warnings.

Link to Devin session: https://app.devin.ai/sessions/a4fe2719f4a14299ad41a0ce7ae5bfab
Requested by: @eashansinha
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| 🟢 Reviewed | [`ed40bf7`](https://github.com/cog-gtm/angular2-hn/pull/405/commits/ed40bf7fdb0c931dd054ae1ae7482c52f096c8f3) |

<a href="https://staging.itsdev.in/review/cog-gtm/angular2-hn/pull/405" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->