### PR TITLE
feat(shell): port Header and Settings to React

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,6 +1,73 @@
+import { NavLink } from 'react-router-dom';
+import { useSettings } from '../../context/SettingsContext';
+import Settings from '../Settings/Settings';
 import './Header.scss';
 
-// TODO(child-session): port HeaderComponent (logo, nav links, settings toggle).
 export default function Header() {
-  return <header id="header" />;
+  const { settings, toggleSettings } = useSettings();
+
+  const scrollTop = () => window.scrollTo(0, 0);
+
+  return (
+    <header>
+      <div id="header">
+        <NavLink
+          className={({ isActive }) =>
+            isActive ? 'home-link active' : 'home-link'
+          }
+          to="/news/1"
+          onClick={() => scrollTop()}
+        >
+          <div className="logo-inner"></div>
+          <img className="logo" src="/assets/images/logo.svg" alt="Logo" />
+        </NavLink>
+        <div className="header-text">
+          <div className="left">
+            <span className="header-nav">
+              <NavLink
+                className={({ isActive }) => (isActive ? 'active' : undefined)}
+                to="/newest/1"
+                onClick={() => scrollTop()}
+              >
+                new
+              </NavLink>
+              |
+              <NavLink
+                className={({ isActive }) => (isActive ? 'active' : undefined)}
+                to="/show/1"
+                onClick={() => scrollTop()}
+              >
+                show
+              </NavLink>
+              |
+              <NavLink
+                className={({ isActive }) => (isActive ? 'active' : undefined)}
+                to="/ask/1"
+                onClick={() => scrollTop()}
+              >
+                ask
+              </NavLink>
+              |
+              <NavLink
+                className={({ isActive }) => (isActive ? 'active' : undefined)}
+                to="/jobs/1"
+                onClick={() => scrollTop()}
+              >
+                jobs
+              </NavLink>
+            </span>
+          </div>
+        </div>
+        <div className="info">
+          <img
+            className="settings"
+            src="/assets/images/cog.svg"
+            alt="Settings"
+            onClick={() => toggleSettings()}
+          />
+        </div>
+      </div>
+      {settings.showSettings && <Settings />}
+    </header>
+  );
 }

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -46,7 +46,6 @@ export default function Settings() {
                       type="radio"
                       value={value}
                       checked={settings.theme === value}
-                      onClick={() => setTheme(value)}
                       onChange={() => setTheme(value)}
                     />{' '}
                     {label}

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -1,6 +1,89 @@
+import { useSettings } from '../../context/SettingsContext';
 import './Settings.scss';
 
-// TODO(child-session): port SettingsComponent (theme/font/spacing/link controls).
+const themeOptions = [
+  { value: 'default', label: 'Default' },
+  { value: 'night', label: 'Night' },
+  { value: 'amoledblack', label: 'Black (AMOLED)' },
+] as const;
+
 export default function Settings() {
-  return null;
+  const {
+    settings,
+    toggleSettings,
+    toggleOpenLinksInNewTab,
+    setTheme,
+    setFont,
+    setSpacing,
+  } = useSettings();
+
+  return (
+    <div id="popup1" className="overlay">
+      <div className="popup">
+        <h1>Settings</h1>
+        <hr />
+        <span className="close" onClick={() => toggleSettings()}>
+          &times;
+        </span>
+        <div className="content">
+          <div className="control-section">
+            <h2>Links</h2>
+            <input
+              type="checkbox"
+              checked={settings.openLinkInNewTab}
+              onChange={() => toggleOpenLinksInNewTab()}
+            />{' '}
+            Open links in a new tab
+          </div>
+          <div className="theme-controls">
+            <div className="control-section">
+              <h2>Select a theme</h2>
+              {themeOptions.map(({ value, label }) => (
+                <div key={value}>
+                  <label>
+                    <input
+                      name="theme"
+                      type="radio"
+                      value={value}
+                      checked={settings.theme === value}
+                      onClick={() => setTheme(value)}
+                      onChange={() => setTheme(value)}
+                    />{' '}
+                    {label}
+                  </label>
+                </div>
+              ))}
+            </div>
+            <div className="control-section">
+              <h2>Change Font</h2>
+              <div>
+                <label>
+                  Font size:{' '}
+                  <input
+                    min="1"
+                    value={settings.titleFontSize}
+                    name="theme"
+                    type="number"
+                    onChange={(e) => setFont(e.target.value)}
+                  />
+                </label>
+              </div>
+              <div>
+                <label>
+                  List spacing:{' '}
+                  <input
+                    min="0"
+                    value={settings.listSpacing}
+                    name="theme"
+                    type="number"
+                    onChange={(e) => setSpacing(e.target.value)}
+                  />
+                </label>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
Ports the core shell components from the original Angular app to React, replacing the stubs on the migration base branch. Footer was already correct and is unchanged.

- **`Header.tsx`**: logo + nav (`new`/`show`/`ask`/`jobs`) using `NavLink` with `className={({isActive}) => isActive ? 'active' : undefined}` to mimic `routerLinkActive="active"`, and `onClick={() => scrollTop()}` (`window.scrollTo(0, 0)`). The cog image calls `toggleSettings()`; `{settings.showSettings && <Settings />}` renders the popup. Class names match the original template so existing SCSS applies.
- **`Settings.tsx`**: faithful port of the popup (`overlay`/`popup`/`content`/`control-section`/`theme-controls`/`close`, `id="popup1"`). Controlled inputs wired to `useSettings()`:
  - checkbox → `checked={settings.openLinkInNewTab}` / `toggleOpenLinksInNewTab()`
  - three theme radios → `checked={settings.theme === value}` / `setTheme(value)`
  - font size & list spacing number inputs → `setFont` / `setSpacing`

Both `npm run build` and `npm run lint` (`--max-warnings=0`) pass clean.

Link to Devin session: https://app.devin.ai/sessions/525f0087babb43fca965121357a698b8
Requested by: @eashansinha
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| 🟢 Reviewed | [`d539013`](https://github.com/cog-gtm/angular2-hn/pull/406/commits/d53901377aba5bf216191b4b37f08f618264d75c) |

<a href="https://staging.itsdev.in/review/cog-gtm/angular2-hn/pull/406" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->