### PR TITLE
feat(item-details): port ItemDetails page + recursive Comment to React

### DIFF
--- a/src/pages/Comment/Comment.tsx
+++ b/src/pages/Comment/Comment.tsx
@@ -1,3 +1,6 @@
+import { useState } from 'react';
+import { NavLink } from 'react-router-dom';
+
 import type { Comment as CommentModel } from '../../models/comment';
 import './Comment.scss';
 
@@ -5,7 +8,48 @@ interface CommentProps {
   comment: CommentModel;
 }
 
-// TODO(child-session): port CommentComponent (collapse, nested comments).
 export default function Comment({ comment }: CommentProps) {
-  return <div className="comment-tree">{comment.user}</div>;
+  const [collapse, setCollapse] = useState(false);
+
+  if (comment.deleted) {
+    return (
+      <div>
+        <div className="deleted-meta">
+          <span className="collapse">[deleted]</span> | Comment Deleted
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className={collapse ? 'meta meta-collapse' : 'meta'}>
+        <span className="collapse" onClick={() => setCollapse(!collapse)}>
+          [{collapse ? '+' : '-'}]
+        </span>
+        <NavLink
+          to={`/user/${comment.user}`}
+          className={({ isActive }) => (isActive ? 'active' : undefined)}
+        >
+          {comment.user}
+        </NavLink>
+        <span className="time">{comment.time_ago}</span>
+      </div>
+      <div className="comment-tree">
+        <div hidden={collapse}>
+          <p
+            className="comment-text"
+            dangerouslySetInnerHTML={{ __html: comment.content }}
+          ></p>
+          <ul className="subtree">
+            {comment.comments.map((subComment) => (
+              <li key={subComment.id}>
+                <Comment comment={subComment} />
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/src/pages/ItemDetails/ItemDetails.tsx
+++ b/src/pages/ItemDetails/ItemDetails.tsx
@@ -1,6 +1,161 @@
+import { useEffect, useState } from 'react';
+import { NavLink, useNavigate, useParams } from 'react-router-dom';
+
+import ErrorMessage from '../../components/ErrorMessage/ErrorMessage';
+import Loader from '../../components/Loader/Loader';
+import { useSettings } from '../../context/SettingsContext';
+import type { Story } from '../../models/story';
+import { fetchItemContent } from '../../services/hackernews-api';
+import { commentLabel } from '../../utils/comment';
+import Comment from '../Comment/Comment';
 import './ItemDetails.scss';
 
-// TODO(child-session): port ItemDetailsComponent (fetch item, poll, comments).
 export default function ItemDetails() {
-  return <div className="main-content" />;
+  const [item, setItem] = useState<Story>();
+  const [errorMessage, setErrorMessage] = useState('');
+  const { id } = useParams();
+  const itemID = +(id ?? 0);
+  const navigate = useNavigate();
+  const { settings } = useSettings();
+
+  useEffect(() => {
+    fetchItemContent(itemID)
+      .then(setItem)
+      .catch(() => setErrorMessage('Could not load item comments.'));
+    window.scrollTo(0, 0);
+  }, [itemID]);
+
+  const goBack = () => navigate(-1);
+  const hasUrl = item && item.url.indexOf('http') === 0;
+  const laptopClassName = [
+    'laptop',
+    item && (item.comments_count > 0 || item.type === 'job')
+      ? 'item-header'
+      : '',
+    item && item.text ? 'head-margin' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div className="main-content">
+      {!item && !errorMessage && <Loader />}
+      {!item && errorMessage !== '' && <ErrorMessage message={errorMessage} />}
+
+      {item && (
+        <div className="item">
+          <div className="mobile item-header">
+            <p className="title-block">
+              <span className="back-button" onClick={() => goBack()}></span>
+              {hasUrl ? (
+                <a
+                  className="title"
+                  href={item.url}
+                  target={settings.openLinkInNewTab ? '_blank' : undefined}
+                  rel={settings.openLinkInNewTab ? 'noopener' : undefined}
+                >
+                  {item.title}
+                </a>
+              ) : (
+                <NavLink
+                  to={`/item/${item.id}`}
+                  className={({ isActive }) =>
+                    isActive ? 'active' : undefined
+                  }
+                >
+                  {item.title}
+                </NavLink>
+              )}
+            </p>
+          </div>
+          <div className={laptopClassName}>
+            {hasUrl ? (
+              <p>
+                <a
+                  className="title"
+                  href={item.url}
+                  target={settings.openLinkInNewTab ? '_blank' : undefined}
+                  rel={settings.openLinkInNewTab ? 'noopener' : undefined}
+                >
+                  {item.title}
+                </a>
+                {item.domain && <span className="domain">({item.domain})</span>}
+              </p>
+            ) : (
+              <p>
+                <NavLink
+                  className={({ isActive }) =>
+                    isActive ? 'active' : undefined
+                  }
+                  to={`/item/${item.id}`}
+                >
+                  {item.title}
+                </NavLink>
+              </p>
+            )}
+            <div className="subtext">
+              {item.type !== 'job' && (
+                <span>
+                  {item.points} points by{' '}
+                  <NavLink
+                    to={`/user/${item.user}`}
+                    className={({ isActive }) =>
+                      isActive ? 'active' : undefined
+                    }
+                  >
+                    {item.user}
+                  </NavLink>
+                </span>
+              )}
+              <span className={item.type !== 'job' ? 'item-details' : undefined}>
+                {item.time_ago}{' '}
+                {item.type !== 'job' && (
+                  <span>
+                    {' '}
+                    |{' '}
+                    <NavLink
+                      to={`/item/${item.id}`}
+                      className={({ isActive }) =>
+                        isActive ? 'active' : undefined
+                      }
+                    >
+                      {commentLabel(item.comments_count)}
+                    </NavLink>
+                  </span>
+                )}
+              </span>
+            </div>
+          </div>
+          {item.type === 'poll' && (
+            <div className="pollResults">
+              {item.poll.map((pollResult, i) => (
+                <div className="pollContent" key={i}>
+                  <div dangerouslySetInnerHTML={{ __html: pollResult.content }}></div>
+                  <div className="subtext">{pollResult.points} points</div>
+                  <div
+                    className="pollBar"
+                    style={{
+                      width:
+                        (pollResult.points / item.poll_votes_count) * 100 + '%',
+                    }}
+                  ></div>
+                </div>
+              ))}
+            </div>
+          )}
+          <p
+            className="subject"
+            dangerouslySetInnerHTML={{ __html: item.content ?? '' }}
+          ></p>
+          <ul className="comment-list">
+            {item.comments.map((comment) => (
+              <li key={comment.id}>
+                <Comment comment={comment} />
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
 }

--- a/src/pages/ItemDetails/ItemDetails.tsx
+++ b/src/pages/ItemDetails/ItemDetails.tsx
@@ -19,10 +19,20 @@ export default function ItemDetails() {
   const { settings } = useSettings();
 
   useEffect(() => {
+    let stale = false;
+    setItem(undefined);
+    setErrorMessage('');
     fetchItemContent(itemID)
-      .then(setItem)
-      .catch(() => setErrorMessage('Could not load item comments.'));
+      .then((data) => {
+        if (!stale) setItem(data);
+      })
+      .catch(() => {
+        if (!stale) setErrorMessage('Could not load item comments.');
+      });
     window.scrollTo(0, 0);
+    return () => {
+      stale = true;
+    };
   }, [itemID]);
 
   const goBack = () => navigate(-1);


### PR DESCRIPTION
## Summary
Ports the Angular `ItemDetailsComponent` and recursive `CommentComponent` to React, replacing the stubs. Part of the Angular→React migration into `devin/react-migration-base`.

- `src/pages/ItemDetails/ItemDetails.tsx`: fetches the item via `fetchItemContent(itemID)` (id from `useParams`) in a `useEffect` keyed on `itemID`, sets `errorMessage` on failure, and `window.scrollTo(0,0)`. Renders `Loader`/`ErrorMessage` states, mobile + laptop headers (back button → `navigate(-1)`, title link target/rel driven by `settings.openLinkInNewTab`), poll bars (`width: points/poll_votes_count*100 + '%'`), `subject` via `dangerouslySetInnerHTML`, and the comment list mapping to `<Comment>`.
- `src/pages/Comment/Comment.tsx`: recursive component with local `collapse` state toggled by the `[+]/[-]` span; `hidden={collapse}` keeps the subtree rendered; nested `comment.comments` render `<Comment>` recursively; deleted branch renders the `[deleted]` meta. User link uses `NavLink` to mimic `routerLinkActive="active"`.

Class names kept identical to the Angular templates so existing SCSS applies. Only these two files changed. `npm run build` and `npm run lint` both pass clean.

Link to Devin session: https://app.devin.ai/sessions/4f4aa71403fb4b02bff6b6f002db9a80
Requested by: @eashansinha
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| 🟢 Reviewed | [`356f388`](https://github.com/cog-gtm/angular2-hn/pull/407/commits/356f388166c64c47891ef089e0244b2967b02057) |

<a href="https://staging.itsdev.in/review/cog-gtm/angular2-hn/pull/407" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->