### PR TITLE
React migration: User component

### DIFF
--- a/src/components/User/User.scss
+++ b/src/components/User/User.scss
@@ -1,0 +1,89 @@
+@import "../../styles/media";
+@import "../../styles/theme_variables";
+
+pre {
+  white-space: pre-wrap;
+}
+
+.profile {
+  padding: 30px;
+}
+
+@media #{$mobile-only} {
+  .profile {
+    padding: 110px 15px 0 15px;
+  }
+  .title-block {
+    font-size: 15px;
+    text-align: center;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    margin: 0 75px;
+  }
+  .back-button {
+    position: absolute;
+    top: 52%;
+    width: 0.6rem;
+    height: 0.6rem;
+    background: transparent;
+    box-shadow: 0 0 0 lightgray;
+    transition: all 200ms ease;
+    left: 4%;
+    transform: translate3d(0, -50%, 0) rotate(-135deg);
+  }
+  .item-header {
+    padding-bottom: 10px;
+    background-color: #fff;
+    padding: 10px 0 10px 0;
+    position: fixed;
+    width: 100%;
+    left: 0;
+    top: 62px;
+    height: 20px;
+  }
+}
+
+@media #{$laptop-only} {
+  .mobile {
+    display: none;
+  }
+}
+
+.main-details {
+  .name {
+    font-weight: bold;
+    font-size: 32px;
+    letter-spacing: 2px;
+  }
+  .age {
+    font-weight: bold;
+    color: #696969;
+    padding-bottom: 0;
+  }
+  .right {
+    float: right;
+    font-weight: bold;
+    font-size: 32px;
+    letter-spacing: 2px;
+  }
+}
+
+@media #{$mobile-only} {
+  .main-details {
+    margin-top: 20px;
+    .name {
+      font-size: 18px;
+    }
+  }
+}
+
+@media #{$mobile-only} {
+  .main-details .right {
+    font-size: 18px;
+  }
+}
+
+.other-details {
+  word-wrap: break-word;
+}

--- a/src/components/User/User.tsx
+++ b/src/components/User/User.tsx
@@ -1,6 +1,67 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+
+import { fetchUser } from '../../api/hackerNews';
+import { User as UserModel } from '../../models/user';
+import Loader from '../Loader/Loader';
+import ErrorMessage from '../ErrorMessage/ErrorMessage';
 import './User.scss';
 
-// STUB — implemented by a child session.
 export default function User() {
-    return <div className="profile" />;
+    const { id } = useParams();
+    const navigate = useNavigate();
+    const [user, setUser] = useState<UserModel | null>(null);
+    const [errorMessage, setErrorMessage] = useState('');
+
+    useEffect(() => {
+        if (!id) {
+            return;
+        }
+
+        const controller = new AbortController();
+
+        fetchUser(id, controller.signal)
+            .then((data) => setUser(data))
+            .catch((error) => {
+                if (error instanceof DOMException && error.name === 'AbortError') {
+                    return;
+                }
+                setErrorMessage('Could not load user ' + id + '.');
+            });
+
+        return () => controller.abort();
+    }, [id]);
+
+    if (!user && !errorMessage) {
+        return <Loader />;
+    }
+
+    if (!user && errorMessage) {
+        return <ErrorMessage message={errorMessage} />;
+    }
+
+    if (!user) {
+        return null;
+    }
+
+    return (
+        <div className="profile">
+            <div className="mobile item-header">
+                <p className="title-block">
+                    <span className="back-button" onClick={() => navigate(-1)} />
+                    Profile: {user.id}
+                </p>
+            </div>
+            <div className="main-details">
+                <span className="name">{user.id}</span>
+                <span className="right">{user.karma} ★</span>
+                <p className="age">Created {user.created}</p>
+            </div>
+            {user.about && (
+                <div className="other-details">
+                    <p dangerouslySetInnerHTML={{ __html: user.about }} />
+                </div>
+            )}
+        </div>
+    );
 }


### PR DESCRIPTION
## Summary
Ports the Angular `UserComponent` (`src/app/user/`) to React at `src/components/User/User.tsx` (+ `User.scss`), replacing the previous stub.

- Reads the route param via `useParams()` and fetches with `fetchUser(id, signal)` inside a `useEffect` keyed on `[id]`, using an `AbortController` aborted in cleanup. `AbortError` is ignored; other failures set `errorMessage = 'Could not load user ' + id + '.'`.
- Render states mirror the original: `<Loader />` while `!user && !errorMessage`, `<ErrorMessage message={errorMessage} />` while `!user && errorMessage`, otherwise the `.profile` markup.
- Mobile header `.title-block` uses `<span className="back-button" onClick={() => navigate(-1)} />` (`useNavigate()` replaces Angular's `Location.back()`); `user.about` is rendered via `dangerouslySetInnerHTML` (was `[innerHTML]`).
- SCSS ported verbatim with the shared-path imports (`../../styles/media`, `../../styles/theme_variables`); dropped the `:host >>> pre` wrapper, keeping `pre { white-space: pre-wrap; }`. All class names preserved so global theme styles continue to apply.

`npm run lint` and `npm run build` both pass with zero errors/warnings.


Link to Devin session: https://app.devin.ai/sessions/e62048a17c104b1b941af02c7f5cb589
Requested by: @devanshi-gpta
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/410?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/410" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->