### PR TITLE
React migration: Header and Settings components

### DIFF
--- a/src/components/Header/Header.scss
+++ b/src/components/Header/Header.scss
@@ -1,0 +1,149 @@
+@import "../../styles/media";
+@import "../../styles/theme_variables";
+
+#header {
+  color: #fff;
+  padding: 6px 0;
+  line-height: 18px;
+  vertical-align: middle;
+  position: relative;
+  z-index: 1;
+  width: 100%;
+
+  @media #{$mobile-only} {
+    height: 50px;
+    position: fixed;
+    top: 0;
+  }
+
+  a {
+    display: inline;
+  }
+}
+
+.home-link {
+  width: 50px;
+  height: 66px;
+}
+
+.logo-inner {
+  width: 32px;
+  position: absolute;
+  left: 17px;
+  top: 18px;
+  z-index: -1;
+  height: 32px;
+  border-radius: 50%;
+
+  @media #{$mobile-only} {
+    left: 16px;
+    top: 12px;
+  }
+}
+
+.logo {
+  width: 50px;
+  padding: 3px 8px 0;
+
+  @media #{$mobile-only} {
+    width: 45px;
+    padding: 0 0 0 10px;
+  }
+}
+
+h1 {
+  font-weight: normal;
+  display: inline-block;
+  vertical-align:middle;
+  margin: 0;
+  font-size: 16px;
+
+  a {
+    color: #fff;
+    text-decoration: none;
+  }
+}
+
+.name {
+  margin-right: 30px;
+  margin-bottom: 2px;
+
+  @media #{$mobile-only} {
+    display: none;
+  }
+}
+
+.header-text {
+  position: absolute;
+  width: inherit;
+  height: 20px;
+  left: 10px;
+  top: 27px;
+  z-index: -1;
+
+  @media #{$mobile-only} {
+    top: 22px;
+  }
+}
+
+.left {
+  position: absolute;
+  left: 60px;
+  font-size: 16px;
+
+  @media #{$mobile-only} {
+    width: 100%;
+    left: 0;
+  }
+}
+
+.header-nav {
+  display: inline-block;
+  margin-left: 20px;
+
+  @media #{$mobile-only} {
+    margin-left: 60px;
+  }
+
+  a {
+    color: hsla(0,0%,100%,.9);
+    text-decoration: none;
+    margin: 0 5px;
+    letter-spacing: 1.8px;
+
+    &:hover {
+      color: #fff;
+    }
+  }
+
+  .active {
+    color: #fff;
+  }
+}
+
+.info {
+  position: absolute;
+  top: 0;
+  right: 20px;
+  height: 100%;
+
+  @media #{$mobile-only} {
+    right: 10px;
+  }
+
+  img {
+    opacity: 0.8;
+    width: 25px;
+    margin-top: 21.5px;
+    display: block;
+
+    &:hover {
+      opacity: 1;
+      cursor: pointer;
+    }
+
+    @media #{$mobile-only} {
+      margin-top: 15px;
+    }
+  }
+}

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,6 +1,45 @@
+import { Link } from 'react-router-dom';
+import { useSettings } from '../../context/SettingsContext';
+import Settings from '../Settings/Settings';
 import './Header.scss';
 
-// STUB — implemented by a child session.
 export default function Header() {
-    return <header />;
+    const { settings, toggleSettings } = useSettings();
+
+    const scrollTop = () => {
+        window.scrollTo(0, 0);
+    };
+
+    return (
+        <header>
+            <div id="header">
+                <Link className="home-link" to="/news/1" onClick={scrollTop}>
+                    <div className="logo-inner"></div>
+                    <img className="logo" src="/assets/images/logo.svg" alt="Logo" />
+                </Link>
+                <div className="header-text">
+                    <div className="left">
+                        <span className="header-nav">
+                            <Link to="/newest/1" onClick={scrollTop}>new</Link>
+                            |
+                            <Link to="/show/1" onClick={scrollTop}>show</Link>
+                            |
+                            <Link to="/ask/1" onClick={scrollTop}>ask</Link>
+                            |
+                            <Link to="/jobs/1" onClick={scrollTop}>jobs</Link>
+                        </span>
+                    </div>
+                </div>
+                <div className="info">
+                    <img
+                        className="settings"
+                        src="/assets/images/cog.svg"
+                        alt="Settings"
+                        onClick={() => toggleSettings()}
+                    />
+                </div>
+            </div>
+            {settings.showSettings && <Settings />}
+        </header>
+    );
 }

--- a/src/components/Settings/Settings.scss
+++ b/src/components/Settings/Settings.scss
@@ -1,0 +1,74 @@
+@import "../../styles/media";
+@import "../../styles/theme_variables";
+
+.overlay {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: rgba(0, 0, 0, 0.7);
+  opacity: 1;
+  z-index: 1;
+}
+
+.popup {
+  margin: 70px auto;
+  padding: 30px;
+  border-radius: 5px;
+  width: 30%;
+  position: relative;
+  h1 {
+    margin-top: 0;
+    margin-bottom: 0px;
+    color: #fff;
+    text-align: center;
+    letter-spacing: 1px;
+  }
+  h2 {
+    padding-top: 10px;
+  }
+  hr {
+    width: 40%;
+    margin-bottom: 20px;
+  }
+  .close {
+    position: absolute;
+    top: 12px;
+    right: 20px;
+    font-size: 30px;
+    font-weight: bold;
+    text-decoration: none;
+    color: rgba(255,255,255,0.8);
+    &:hover {
+      color: #fff;
+      cursor: pointer;
+    }
+  }
+  .content {
+    max-height: 30%;
+    color: #fff;
+    letter-spacing: 1px;
+    overflow: auto;
+  }
+  input[type=number] {
+      display: block;
+      width: 80%;
+      height: 20px;
+      margin-bottom: 15px;
+      border-radius: 5px;
+      padding: 2px;
+  }
+}
+
+.control-section {
+    margin-bottom: 15px;
+    padding-bottom: 15px;
+    border-bottom: 1px solid white;
+}
+
+@media screen and (max-width: 700px) {
+  .box, .popup {
+    width: 70%;
+  }
+}

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -1,6 +1,102 @@
+import { useSettings } from '../../context/SettingsContext';
 import './Settings.scss';
 
-// STUB — implemented by a child session.
 export default function Settings() {
-    return <div className="overlay" />;
+    const {
+        settings,
+        toggleSettings,
+        toggleOpenLinksInNewTab,
+        setTheme,
+        setFont,
+        setSpacing,
+    } = useSettings();
+
+    return (
+        <div id="popup1" className="overlay">
+            <div className="popup">
+                <h1>Settings</h1>
+                <hr />
+                <span className="close" onClick={() => toggleSettings()}>
+                    &times;
+                </span>
+                <div className="content">
+                    <div className="control-section">
+                        <h2>Links</h2>
+                        <input
+                            type="checkbox"
+                            checked={settings.openLinkInNewTab}
+                            onChange={() => toggleOpenLinksInNewTab()}
+                        />
+                        Open links in a new tab
+                    </div>
+                    <div className="theme-controls">
+                        <div className="control-section">
+                            <h2>Select a theme</h2>
+                            <div>
+                                <label>
+                                    <input
+                                        name="theme"
+                                        type="radio"
+                                        value="default"
+                                        checked={settings.theme === 'default'}
+                                        onChange={() => setTheme('default')}
+                                    />
+                                    Default
+                                </label>
+                            </div>
+                            <div>
+                                <label>
+                                    <input
+                                        name="theme"
+                                        type="radio"
+                                        value="night"
+                                        checked={settings.theme === 'night'}
+                                        onChange={() => setTheme('night')}
+                                    />
+                                    Night
+                                </label>
+                            </div>
+                            <div>
+                                <label>
+                                    <input
+                                        name="theme"
+                                        type="radio"
+                                        value="amoledblack"
+                                        checked={settings.theme === 'amoledblack'}
+                                        onChange={() => setTheme('amoledblack')}
+                                    />
+                                    Black (AMOLED)
+                                </label>
+                            </div>
+                        </div>
+                        <div className="control-section">
+                            <h2>Change Font</h2>
+                            <div>
+                                <label>
+                                    Font size:
+                                    <input
+                                        min={1}
+                                        value={settings.titleFontSize}
+                                        type="number"
+                                        onChange={(e) => setFont(e.target.value)}
+                                    />
+                                </label>
+                            </div>
+                            <div>
+                                <label>
+                                    List spacing:
+                                    <input
+                                        min={0}
+                                        value={settings.listSpacing}
+                                        type="number"
+                                        onChange={(e) => setSpacing(e.target.value)}
+                                    />
+                                </label>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
 }


### PR DESCRIPTION
## Summary
Ports two Angular components to React + TS as part of the Angular 9 → React 18 migration. Both consume the existing `useSettings()` context; no other files touched.

- **`Header`** (`src/components/Header/`): logo home link to `/news/1`, nav `<Link>`s (`new`/`show`/`ask`/`jobs`) separated by `|`, and a cog image. Logo + nav clicks call `scrollTop()` (`window.scrollTo(0, 0)`); cog `onClick` calls `toggleSettings()`. Renders `<Settings />` when `settings.showSettings`. Image srcs `/assets/images/logo.svg` and `/assets/images/cog.svg`.
- **`Settings`** (`src/components/Settings/`): `#popup1.overlay` popup with `×` close → `toggleSettings()`; controlled "open links in new tab" checkbox → `toggleOpenLinksInNewTab()`; three controlled theme radios → `setTheme('default'|'night'|'amoledblack')`; controlled font-size / list-spacing number inputs → `setFont`/`setSpacing`.

Conversion notes:
- `*ngIf` → `cond && (...)`; `routerLink` → `<Link to=...>`; `[checked]`+`(change)` → controlled `checked`+`onChange`.
- Angular template refs (`#default` etc.) replaced with literal string comparisons (`settings.theme === 'default'`).
- SCSS ported verbatim with partial imports repointed to `../../styles/media` and `../../styles/theme_variables`; class names/ids preserved so global theme styles keep applying.

`npm run lint` passes clean; `npm run build` succeeds (only the repo-wide Sass `@import` deprecation warnings shared by the other components).


Link to Devin session: https://app.devin.ai/sessions/a4ffefc2259c474ebf8fa58501d5897c
Requested by: @devanshi-gpta
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/411?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/411" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->