### PR TITLE
React migration: ItemDetails and Comment components

### DIFF
--- a/src/components/Comment/Comment.scss
+++ b/src/components/Comment/Comment.scss
@@ -1,0 +1,83 @@
+@import "../../styles/media";
+@import "../../styles/theme_variables";
+
+a {
+  font-weight: bold;
+  text-decoration: none;
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.meta {
+  font-size: 13px;
+  color: #696969;
+  font-weight: bold;
+  letter-spacing: 0.5px;
+  margin-bottom: 8px;
+  a {
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+  .time {
+    padding-left: 5px;
+  }
+}
+
+@media #{$mobile-only} {
+  .meta {
+    font-size: 14px;
+    margin-bottom: 10px;
+    .time {
+      padding: 0;
+      float: right;
+    }
+  }
+}
+
+.meta-collapse {
+  margin-bottom: 20px;
+}
+
+.deleted-meta {
+  font-size: 12px;
+  font-weight: bold;
+  letter-spacing: 0.5px;
+  margin: 30px 0;
+  a {
+    text-decoration: none;
+  }
+}
+
+.collapse {
+  font-size: 13px;
+  letter-spacing: 2px;
+  cursor: pointer;
+}
+
+.comment-tree {
+  margin-left: 24px;
+}
+
+@media #{$tablet-only} {
+  .comment-tree {
+    margin-left: 8px;
+  }
+}
+
+.comment-text {
+  font-size: 15px;
+  margin-top: 0;
+  margin-bottom: 20px;
+  word-wrap: break-word;
+  line-height: 1.5em;
+}
+
+.subtree {
+  margin-left: 0;
+  padding: 0;
+  list-style-type: none;
+}

--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -1,11 +1,43 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
 import { Comment as CommentModel } from '../../models/comment';
 import './Comment.scss';
 
-interface CommentProps {
-    comment: CommentModel;
-}
+export default function Comment({ comment }: { comment: CommentModel }) {
+    const [collapse, setCollapse] = useState(false);
 
-// STUB — implemented by a child session.
-export default function Comment({ comment }: CommentProps) {
-    return <div>{comment.user}</div>;
+    if (comment.deleted) {
+        return (
+            <div className="deleted-meta">
+                <span className="collapse">[deleted]</span> | Comment Deleted
+            </div>
+        );
+    }
+
+    return (
+        <div>
+            <div className={`meta${collapse ? ' meta-collapse' : ''}`}>
+                <span className="collapse" onClick={() => setCollapse(!collapse)}>
+                    [{collapse ? '+' : '-'}]
+                </span>
+                <Link to={`/user/${comment.user}`}>{comment.user}</Link>
+                <span className="time">{comment.time_ago}</span>
+            </div>
+            <div className="comment-tree">
+                <div style={{ display: collapse ? 'none' : undefined }}>
+                    <p
+                        className="comment-text"
+                        dangerouslySetInnerHTML={{ __html: comment.content }}
+                    />
+                    <ul className="subtree">
+                        {comment.comments.map((subComment) => (
+                            <li key={subComment.id}>
+                                <Comment comment={subComment} />
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            </div>
+        </div>
+    );
 }

--- a/src/components/ItemDetails/ItemDetails.scss
+++ b/src/components/ItemDetails/ItemDetails.scss
@@ -1,0 +1,151 @@
+@import "../../styles/media";
+@import "../../styles/theme_variables";
+
+.main-content {
+  position: relative;
+  width: 100%;
+  min-height: 100vh;
+  -webkit-transition: opacity .2s ease;
+  transition: opacity .2s ease;
+  box-sizing: border-box;
+  padding: 8px 0;
+  z-index: 0;
+}
+
+.item {
+  box-sizing: border-box;
+  padding: 10px 40px 0 40px;
+  z-index: 0;
+}
+
+@media #{$tablet-only} {
+  .item {
+    padding: 10px 20px 0 40px;
+  }
+}
+
+@media #{$mobile-only} {
+  .item {
+    box-sizing: border-box;
+    padding: 110px 15px 0 15px;
+  }
+}
+
+.head-margin {
+  margin-bottom: 15px;
+}
+
+p {
+  margin: 2px 0;
+}
+
+.subject {
+  word-wrap: break-word;
+  margin-top: 20px;
+}
+
+a {
+  cursor: pointer;
+  text-decoration: none;
+}
+
+@media #{$mobile-only} {
+  .laptop {
+    display: none;
+  }
+}
+
+@media #{$laptop-only} {
+  .mobile {
+    display: none;
+  }
+}
+
+.title {
+  font-size: 16px;
+  font-family: Verdana, Geneva, sans-serif;
+}
+
+.title-block {
+  text-align: center;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  margin: 0 75px;
+}
+
+@media #{$mobile-only} {
+  .title {
+    font-size: 15px;
+  }
+  .back-button {
+    position: absolute;
+    top: 52%;
+    width: 0.6rem;
+    height: 0.6rem;
+    background: transparent;
+    box-shadow: 0 0 0 lightgray;
+    transition: all 200ms ease;
+    left: 4%;
+    transform: translate3d(0, -50%, 0) rotate(-135deg);
+  }
+}
+
+.subtext {
+  font-size: 12px;
+  font-weight: bold;
+  letter-spacing: 0.5px;
+}
+
+.domain {
+  letter-spacing: 0.5px;
+}
+
+.subtext a {
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.item-details {
+  padding: 10px;
+}
+
+.item-header {
+  padding-bottom: 10px;
+}
+
+@media #{$mobile-only} {
+  .item-header {
+    padding: 10px 0 10px 0;
+    position: fixed;
+    width: 100%;
+    left: 0;
+    top: 62px;
+  }
+}
+
+.pollResults {
+  margin-bottom: 1em;
+}
+
+.pollContent {
+  * {
+    padding-bottom: 0;
+    margin-bottom: -1em;
+    margin-top: 1em;
+  }
+  .pollBar {
+    height: 10px;
+    margin-bottom: 1em;
+  }
+}
+
+ul {
+  list-style-type: none;
+  padding: 10px 0;
+}
+
+li {
+  display: list-item;
+}

--- a/src/components/ItemDetails/ItemDetails.tsx
+++ b/src/components/ItemDetails/ItemDetails.tsx
@@ -1,6 +1,146 @@
+import { useEffect, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import { fetchItemContent } from '../../api/hackerNews';
+import { Story } from '../../models/story';
+import { commentCount } from '../../helpers/comment';
+import { useSettings } from '../../context/SettingsContext';
+import Loader from '../Loader/Loader';
+import ErrorMessage from '../ErrorMessage/ErrorMessage';
+import Comment from '../Comment/Comment';
 import './ItemDetails.scss';
 
-// STUB — implemented by a child session.
 export default function ItemDetails() {
-    return <div className="main-content" />;
+    const { id } = useParams();
+    const navigate = useNavigate();
+    const { settings } = useSettings();
+    const [item, setItem] = useState<Story | null>(null);
+    const [errorMessage, setErrorMessage] = useState('');
+
+    useEffect(() => {
+        const controller = new AbortController();
+        setItem(null);
+        setErrorMessage('');
+        fetchItemContent(Number(id), controller.signal)
+            .then((story) => setItem(story))
+            .catch((error) => {
+                if (error instanceof Error && error.name === 'AbortError') {
+                    return;
+                }
+                setErrorMessage('Could not load item comments.');
+            });
+        window.scrollTo(0, 0);
+        return () => controller.abort();
+    }, [id]);
+
+    if (!item && !errorMessage) {
+        return (
+            <div className="main-content">
+                <Loader />
+            </div>
+        );
+    }
+
+    if (!item && errorMessage) {
+        return (
+            <div className="main-content">
+                <ErrorMessage message={errorMessage} />
+            </div>
+        );
+    }
+
+    if (!item) {
+        return <div className="main-content" />;
+    }
+
+    const hasUrl = item.url ? item.url.indexOf('http') === 0 : false;
+    const target = settings.openLinkInNewTab ? '_blank' : undefined;
+    const rel = settings.openLinkInNewTab ? 'noopener' : undefined;
+    const laptopClass = [
+        'laptop',
+        item.comments_count > 0 || item.type === 'job' ? 'item-header' : '',
+        item.text ? 'head-margin' : '',
+    ]
+        .filter(Boolean)
+        .join(' ');
+
+    return (
+        <div className="main-content">
+            <div className="item">
+                <div className="mobile item-header">
+                    <p className="title-block">
+                        <span className="back-button" onClick={() => navigate(-1)} />
+                        {hasUrl ? (
+                            <a className="title" href={item.url} target={target} rel={rel}>
+                                {item.title}
+                            </a>
+                        ) : (
+                            <Link className="title" to={`/item/${item.id}`}>
+                                {item.title}
+                            </Link>
+                        )}
+                    </p>
+                </div>
+                <div className={laptopClass}>
+                    {hasUrl ? (
+                        <p>
+                            <a className="title" href={item.url} target={target} rel={rel}>
+                                {item.title}
+                            </a>
+                            {item.domain && <span className="domain">({item.domain})</span>}
+                        </p>
+                    ) : (
+                        <p>
+                            <Link className="title" to={`/item/${item.id}`}>
+                                {item.title}
+                            </Link>
+                        </p>
+                    )}
+                    <div className="subtext">
+                        {item.type !== 'job' && (
+                            <span>
+                                {item.points} points by{' '}
+                                <Link to={`/user/${item.user}`}>{item.user}</Link>
+                            </span>
+                        )}
+                        <span className={item.type !== 'job' ? 'item-details' : undefined}>
+                            {item.time_ago}
+                            {item.type !== 'job' && (
+                                <span>
+                                    {' '}|{' '}
+                                    <Link to={`/item/${item.id}`}>
+                                        {commentCount(item.comments_count)}
+                                    </Link>
+                                </span>
+                            )}
+                        </span>
+                    </div>
+                </div>
+                {item.type === 'poll' && (
+                    <div className="pollResults">
+                        {item.poll.map((pollResult, index) => (
+                            <div className="pollContent" key={index}>
+                                <div dangerouslySetInnerHTML={{ __html: pollResult.content }} />
+                                <div className="subtext">{pollResult.points} points</div>
+                                <div
+                                    className="pollBar"
+                                    style={{
+                                        width:
+                                            (pollResult.points / item.poll_votes_count) * 100 + '%',
+                                    }}
+                                />
+                            </div>
+                        ))}
+                    </div>
+                )}
+                <p className="subject" dangerouslySetInnerHTML={{ __html: item.content ?? '' }} />
+                <ul className="comment-list">
+                    {item.comments.map((comment) => (
+                        <li key={comment.id}>
+                            <Comment comment={comment} />
+                        </li>
+                    ))}
+                </ul>
+            </div>
+        </div>
+    );
 }


### PR DESCRIPTION
## Summary
Ports the Angular `ItemDetailsComponent` and `CommentComponent` to React + TypeScript, implementing the two stubs at `src/components/ItemDetails/` and `src/components/Comment/`. Original Angular source under `src/app/` is left untouched (reference only).

**ItemDetails** (`src/components/ItemDetails/ItemDetails.tsx`)
- `export default function ItemDetails()`, lazy-loaded by the router.
- Reads `id` via `useParams()`, fetches with `fetchItemContent(+id, signal)` in a `useEffect` keyed on `[id]` using an `AbortController` (aborted in cleanup; `AbortError` ignored). `window.scrollTo(0, 0)` on mount/param change. On non-abort error sets `'Could not load item comments.'`.
- Renders `<Loader />` while loading, `<ErrorMessage message={...} />` on error.
- Reproduces both the mobile (`.mobile.item-header` with `.back-button` → `navigate(-1)`) and laptop header variants, including external `<a>` vs internal `<Link>` titles, domain, points, user link, time_ago and the comments link via `commentCount(item.comments_count)`. Honors `settings.openLinkInNewTab` for `target`/`rel`. Preserves conditional classes (`item-header`, `head-margin`, `item-details`).
- Poll rendering (`.pollResults` / `.pollContent` / `.pollBar` with `width` percentage) and the `.subject` body via `dangerouslySetInnerHTML`.
- Top-level comment list rendering `<Comment comment={...} />`.

**Comment** (`src/components/Comment/Comment.tsx`)
- `export default function Comment({ comment }: { comment: CommentModel })` (model imported as `CommentModel` to avoid the name clash).
- Per-instance collapse via `useState(false)`; toggles `[+]`/`[-]` and `meta-collapse`.
- Renders `.meta` (user `<Link>`, `.time`), `.comment-tree` whose inner content is hidden when collapsed (mirrors `[hidden]`), `.comment-text` via `dangerouslySetInnerHTML`, and a recursive `.subtree`. Deleted comments render `.deleted-meta`.

Both `.scss` files are ported from the originals with `@import` paths updated to `../../styles/media` and `../../styles/theme_variables`, and Angular `:host >>>` wrappers dropped (class names kept identical).

## Validation
- `npm run lint` — passes (`--max-warnings 0`).
- `npm run build` — passes.

Only the four target files were modified.


Link to Devin session: https://app.devin.ai/sessions/c8564465920c4c11baeee33d8182fb5e
Requested by: @devanshi-gpta
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/412?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/412" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->