### PR TITLE
Wave 3: fix Sass deprecation warnings (component/style fixes)

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,5 +1,5 @@
-@import "./shared/scss/media";
-@import "./shared/scss/theme_variables";
+@use "./shared/scss/media" as *;
+@use "./shared/scss/theme_variables" as *;
 
 .body-cover {
   width: 100%;

--- a/src/app/core/footer/footer.component.scss
+++ b/src/app/core/footer/footer.component.scss
@@ -1,5 +1,5 @@
-@import "../../shared/scss/media";
-@import "../../shared/scss/theme_variables";
+@use "../../shared/scss/media" as *;
+@use "../../shared/scss/theme_variables" as *;
 
 #footer {
   position: relative;

--- a/src/app/core/header/header.component.scss
+++ b/src/app/core/header/header.component.scss
@@ -1,5 +1,5 @@
-@import "../../shared/scss/media";
-@import "../../shared/scss/theme_variables";
+@use "../../shared/scss/media" as *;
+@use "../../shared/scss/theme_variables" as *;
 
 #header {
   color: #fff;

--- a/src/app/core/settings/settings.component.scss
+++ b/src/app/core/settings/settings.component.scss
@@ -1,5 +1,5 @@
-@import "../../shared/scss/media";
-@import "../../shared/scss/theme_variables";
+@use "../../shared/scss/media" as *;
+@use "../../shared/scss/theme_variables" as *;
 
 .overlay {
   position: fixed;

--- a/src/app/feeds/feed/feed.component.scss
+++ b/src/app/feeds/feed/feed.component.scss
@@ -1,5 +1,5 @@
-@import "../../shared/scss/media";
-@import "../../shared/scss/theme_variables";
+@use "../../shared/scss/media" as *;
+@use "../../shared/scss/theme_variables" as *;
 
 a {
   text-decoration: none;

--- a/src/app/feeds/item/item.component.scss
+++ b/src/app/feeds/item/item.component.scss
@@ -1,5 +1,5 @@
-@import "../../shared/scss/media";
-@import "../../shared/scss/theme_variables";
+@use "../../shared/scss/media" as *;
+@use "../../shared/scss/theme_variables" as *;
 
 p {
     margin: 2px 0;

--- a/src/app/item-details/comment/comment.component.scss
+++ b/src/app/item-details/comment/comment.component.scss
@@ -1,7 +1,7 @@
-@import "../../shared/scss/media";
-@import "../../shared/scss/theme_variables";
+@use "../../shared/scss/media" as *;
+@use "../../shared/scss/theme_variables" as *;
 
-:host >>> {
+:host ::ng-deep {
   a {
     font-weight: bold;
     text-decoration: none;

--- a/src/app/item-details/item-details.component.scss
+++ b/src/app/item-details/item-details.component.scss
@@ -1,5 +1,5 @@
-@import "../shared/scss/media";
-@import "../shared/scss/theme_variables";
+@use "../shared/scss/media" as *;
+@use "../shared/scss/theme_variables" as *;
 
 .main-content {
   position: relative;

--- a/src/app/shared/components/error-message/error-message.component.scss
+++ b/src/app/shared/components/error-message/error-message.component.scss
@@ -1,5 +1,6 @@
-@import "../../scss/media";
-@import "../../scss/theme_variables";
+@use "sass:math";
+@use "../../scss/media" as *;
+@use "../../scss/theme_variables" as *;
 
 .error-section {
   height: 300px;
@@ -65,9 +66,9 @@
           content: "";
           position: absolute;
           top: 100%;
-          left: $skull-size / 15;
-          border-right: $skull-size / 20 solid transparent;
-          border-left: $skull-size / 40 solid transparent;
+          left: math.div($skull-size, 15);
+          border-right: math.div($skull-size, 20) solid transparent;
+          border-left: math.div($skull-size, 40) solid transparent;
         }
       }
     }
@@ -77,7 +78,7 @@
       position: absolute;
       top: 75%;
       left: 30%;
-      border-radius: 0 0 $skull-size / 10 $skull-size / 10;
+      border-radius: 0 0 math.div($skull-size, 10) math.div($skull-size, 10);
       &:before {
         content: "";
         position: absolute;

--- a/src/app/shared/components/loader/loader.component.scss
+++ b/src/app/shared/components/loader/loader.component.scss
@@ -1,5 +1,5 @@
-@import "../../scss/media";
-@import "../../scss/theme_variables";
+@use "../../scss/media" as *;
+@use "../../scss/theme_variables" as *;
 
 .loader {
   -webkit-animation: load1 1s infinite ease-in-out;

--- a/src/app/shared/scss/_themes.scss
+++ b/src/app/shared/scss/_themes.scss
@@ -1,5 +1,7 @@
-@import "./media";
-@import "./theme_variables";
+@use "sass:color";
+@use "sass:math";
+@use "./media" as *;
+@use "./theme_variables" as *;
 
 /* ----------------------------------
 
@@ -142,10 +144,10 @@
               }
 
               &:before {
-                border-top: $skull-size / 8 solid $wrapper-background-color;
+                border-top: math.div($skull-size, 8) solid $wrapper-background-color;
 
                 @media #{$mobile-only} {
-                  border-top: $skull-size / 8 solid $wrapper-mobile-background-color;
+                  border-top: math.div($skull-size, 8) solid $wrapper-mobile-background-color;
                 }
               }
             }
@@ -230,7 +232,7 @@
   $theme-amoledblack-body-background-color,
   $theme-amoledblack-text-color,
   $theme-amoledblack-text-color,
-  darken($theme-amoledblack-text-color, 33%),
+  color.adjust($theme-amoledblack-text-color, $lightness: -33%),
   $theme-amoledblack-body-background-color,
   $theme-amoledblack-subtext-color,
   $theme-amoledblack-secondary-color,

--- a/src/app/user/user.component.scss
+++ b/src/app/user/user.component.scss
@@ -1,7 +1,7 @@
-@import "../shared/scss/media";
-@import "../shared/scss/theme_variables";
+@use "../shared/scss/media" as *;
+@use "../shared/scss/theme_variables" as *;
 
-:host >>> pre {
+:host ::ng-deep pre {
   white-space: pre-wrap;
 }
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,4 +1,4 @@
-@import "./app/shared/scss/themes";
+@use "./app/shared/scss/themes";
 
 html {
   height: 100%;


### PR DESCRIPTION
## Summary
Wave 3 of the Angular 9→20 upgrade, based on `devin/1782947720-angular20-core-upgrade` (PR #417). Scoped to Sass/style fixes only — no rxjs, lint tooling, test, NgModule, or control-flow changes.

- `@import` → `@use ... as *` in `src/styles.scss` and all `src/app/**/*.scss` (partials `_media.scss` / `_theme_variables.scss` are variable-only, so `as *` keeps existing variable references unchanged)
- `$skull-size / N` → `math.div($skull-size, N)` in `error-message.component.scss` and `_themes.scss` (`@use "sass:math"` added)
- `darken($theme-amoledblack-text-color, 33%)` → `color.adjust($theme-amoledblack-text-color, $lightness: -33%)` in `_themes.scss` (`@use "sass:color"` added)
- Deprecated `:host >>>` shadow-piercing combinator → `:host ::ng-deep` in `comment.component.scss` and `user.component.scss` (was emitting Dart Sass "bogus combinator" deprecation warnings and being dropped from output)

Templates were reviewed for Angular-20-deprecated syntax — none found; `*ngIf`/`*ngFor` and NgModules intentionally left as-is per scope.

### Verification
- `npm run build`: **passes with zero Sass deprecation warnings**. Only remaining warning is the pre-existing CommonJS `rxjs/Observable` optimization-bailout notice (rxjs is out of scope, Wave 4+).
- `npm run lint`: fails with `Cannot find builder "@angular-devkit/build-angular:tslint"` — **pre-existing** (tslint builder removed in the core upgrade; fixed in Wave 4).
- `npm test`: `Executed 0 of 0 SUCCESS` — no spec files exist (pre-existing).
- App renders at `http://localhost:4200` via `npm start`:

![HN feed rendering](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctOGQxNThmMDdlZTBmNDY3OGE0NjcwNzhiMzIzODgwYTQiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctOGQxNThmMDdlZTBmNDY3OGE0NjcwNzhiMzIzODgwYTQvNmNjMTRlYmYtMTk0NC00OWFlLTgyMWQtNjQ2MzdmYTI2NzI5IiwiaWF0IjoxNzgyOTQ4MzE2LCJleHAiOjE3ODM1NTMxMTYsImZpbGVuYW1lIjoiaG4tZmVlZC5wbmcifQ.M579hnyRxp_QG7vbeGIu6KCw2erwDKKT4aDmPp0JrBE)

Link to Devin session: https://app.devin.ai/sessions/43fca74241024028ac15823cadf91331
Requested by: @tobydrinkall
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/angular2-hn/pull/419" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->