### PR TITLE
Wave 2: Upgrade rxjs to ^7.8 and remove rxjs-compat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,7 @@
         "@angular/platform-browser": "^20.0.0",
         "@angular/router": "^20.0.0",
         "@angular/service-worker": "^20.0.0",
-        "rxjs": "~6.6.7",
-        "rxjs-compat": "^6.6.7",
+        "rxjs": "^7.8.2",
         "tslib": "^2.6.0",
         "unfetch": "^4.1.0",
         "zone.js": "~0.15.0"
@@ -276,16 +275,6 @@
         "yarn": ">= 1.13.0"
       }
     },
-    "node_modules/@angular-devkit/architect/node_modules/rxjs": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
-      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/@angular-devkit/build-angular": {
       "version": "20.3.31",
       "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-20.3.31.tgz",
@@ -419,16 +408,6 @@
         }
       }
     },
-    "node_modules/@angular-devkit/build-angular/node_modules/rxjs": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
-      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/@angular-devkit/build-webpack": {
       "version": "0.2003.31",
       "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.2003.31.tgz",
@@ -447,16 +426,6 @@
       "peerDependencies": {
         "webpack": "^5.30.0",
         "webpack-dev-server": "^5.0.2"
-      }
-    },
-    "node_modules/@angular-devkit/build-webpack/node_modules/rxjs": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
-      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
       }
     },
     "node_modules/@angular-devkit/core": {
@@ -487,16 +456,6 @@
         }
       }
     },
-    "node_modules/@angular-devkit/core/node_modules/rxjs": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
-      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/@angular-devkit/schematics": {
       "version": "20.3.31",
       "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-20.3.31.tgz",
@@ -514,16 +473,6 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
         "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
         "yarn": ">= 1.13.0"
-      }
-    },
-    "node_modules/@angular-devkit/schematics/node_modules/rxjs": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
-      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
       }
     },
     "node_modules/@angular/build": {
@@ -12756,28 +12705,13 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "6.6.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "tslib": "^1.9.0"
-      },
-      "engines": {
-        "npm": ">=2.0.0"
+        "tslib": "^2.1.0"
       }
-    },
-    "node_modules/rxjs-compat": {
-      "version": "6.6.7",
-      "resolved": "https://registry.npmjs.org/rxjs-compat/-/rxjs-compat-6.6.7.tgz",
-      "integrity": "sha512-szN4fK+TqBPOFBcBcsR0g2cmTTUF/vaFEOZNuSdfU8/pGFnNmmn2u8SystYXG1QMrjOPBc6XTKHMVfENDf6hHw==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/rxjs/node_modules/tslib": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
-      "license": "Apache-2.0"
     },
     "node_modules/safe-buffer": {
       "version": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "@angular/platform-browser": "^20.0.0",
     "@angular/router": "^20.0.0",
     "@angular/service-worker": "^20.0.0",
-    "rxjs": "~6.6.7",
-    "rxjs-compat": "^6.6.7",
+    "rxjs": "^7.8.2",
     "tslib": "^2.6.0",
     "unfetch": "^4.1.0",
     "zone.js": "~0.15.0"

--- a/src/app/feeds/feed/feed.component.ts
+++ b/src/app/feeds/feed/feed.component.ts
@@ -37,14 +37,14 @@ export class FeedComponent implements OnInit {
     this.pageSub = this.route.params.subscribe(params => {
       this.pageNum = params['page'] ? +params['page'] : 1;
       this._hackerNewsAPIService.fetchFeed(this.feedType, this.pageNum)
-        .subscribe(
-          items => this.items = items,
-          error => this.errorMessage = 'Could not load ' + this.feedType + ' stories.',
-          () => {
+        .subscribe({
+          next: items => this.items = items,
+          error: () => this.errorMessage = 'Could not load ' + this.feedType + ' stories.',
+          complete: () => {
             this.listStart = ((this.pageNum - 1) * 30) + 1;
             window.scrollTo(0, 0);
           }
-        );
+        });
     });
   }
 }

--- a/src/app/item-details/item-details.component.ts
+++ b/src/app/item-details/item-details.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { Location } from '@angular/common';
-import { Subscription } from 'rxjs/Subscription';
+import { Subscription } from 'rxjs';
 
 import { HackerNewsAPIService } from '../shared/services/hackernews-api.service';
 import { SettingsService } from '../shared/services/settings.service';
@@ -33,9 +33,12 @@ export class ItemDetailsComponent implements OnInit {
   ngOnInit() {
     this.sub = this.route.params.subscribe(params => {
       let itemID = +params['id'];
-      this._hackerNewsAPIService.fetchItemContent(itemID).subscribe(item => {
-        this.item = item;
-      }, error => this.errorMessage = 'Could not load item comments.');
+      this._hackerNewsAPIService.fetchItemContent(itemID).subscribe({
+        next: item => {
+          this.item = item;
+        },
+        error: () => this.errorMessage = 'Could not load item comments.'
+      });
     });
     window.scrollTo(0, 0);
   }

--- a/src/app/shared/services/hackernews-api.service.ts
+++ b/src/app/shared/services/hackernews-api.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs/Observable';
+import { Observable, map } from 'rxjs';
 import fetch from 'unfetch';
-import {map } from 'rxjs/operators';
 
 import { Story } from '../models/story';
 import { User } from '../models/user';
@@ -45,7 +44,7 @@ export class HackerNewsAPIService {
   }
 }
 
-function lazyFetch<T>(url, options?) {
+function lazyFetch<T>(url: string, options?: RequestInit) {
   return new Observable<T>(fetchObserver => {
     let cancelToken = false;
     fetch(url, options)

--- a/src/app/user/user.component.ts
+++ b/src/app/user/user.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { Location } from '@angular/common';
-import { Subscription } from 'rxjs/Subscription';
+import { Subscription } from 'rxjs';
 
 import { HackerNewsAPIService } from '../shared/services/hackernews-api.service';
 import { User } from '../shared/models/user';
@@ -26,9 +26,12 @@ export class UserComponent implements OnInit {
   ngOnInit() {
     this.sub = this.route.params.subscribe(params => {
       let userID = params['id'];
-      this._hackerNewsAPIService.fetchUser(userID).subscribe(data => {
-        this.user = data;
-      }, error => this.errorMessage = 'Could not load user ' + userID + '.');
+      this._hackerNewsAPIService.fetchUser(userID).subscribe({
+        next: data => {
+          this.user = data;
+        },
+        error: () => this.errorMessage = 'Could not load user ' + userID + '.'
+      });
     });
   }
 


### PR DESCRIPTION
## Summary
Wave 2 of the Angular 9→20 upgrade (based on #417's branch): migrates the app off rxjs 6 + rxjs-compat to rxjs ^7.8.

- `package.json`: `rxjs` `~6.6.7` → `^7.8.2`, `rxjs-compat` removed.
- Deep imports replaced with root imports:
  - `rxjs/Observable` and `rxjs/operators` → `import { Observable, map } from 'rxjs'` (`hackernews-api.service.ts`)
  - `rxjs/Subscription` → `'rxjs'` (`user.component.ts`, `item-details.component.ts`)
- Deprecated positional `subscribe(next, error, complete)` calls converted to observer-object form `subscribe({ next, error, complete })` in `feed.component.ts`, `item-details.component.ts`, `user.component.ts`.
- Typed `lazyFetch(url: string, options?: RequestInit)` to fix implicit-any fallout.

## Verification
- `npm run build`: passes (warnings only — Sass `@import` deprecations, budget/browserslist warnings).
- `npm run lint`: fails with pre-existing `Cannot find builder "@angular-devkit/build-angular:tslint"` — lint tooling removal is being addressed in Wave 4, not touched here.
- `npm test`: runs and exits green but executes `0 of 0` specs (no spec files exist; Wave 4 adds tests).

Link to Devin session: https://app.devin.ai/sessions/28a497b9bf8548b19fd1af1471b5e203
Requested by: @tobydrinkall
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/420?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/420" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/angular2-hn/pull/420" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->