### PR TITLE
Wave 2: Upgrade to RxJS 7 and remove rxjs-compat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,7 @@
         "@angular/router": "^21.0.0",
         "@angular/service-worker": "^21.0.0",
         "node-fetch": "^2.6.0",
-        "rxjs": "~6.5.4",
-        "rxjs-compat": "^6.5.2",
+        "rxjs": "^7.8.2",
         "tslib": "^2.6.0",
         "unfetch": "^4.1.0",
         "zone.js": "~0.16.0"
@@ -287,16 +286,6 @@
         "yarn": ">= 1.13.0"
       }
     },
-    "node_modules/@angular-devkit/architect/node_modules/rxjs": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
-      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/@angular-devkit/build-angular": {
       "version": "21.2.18",
       "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-21.2.18.tgz",
@@ -430,16 +419,6 @@
         }
       }
     },
-    "node_modules/@angular-devkit/build-angular/node_modules/rxjs": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
-      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/@angular-devkit/build-webpack": {
       "version": "0.2102.18",
       "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.2102.18.tgz",
@@ -458,16 +437,6 @@
       "peerDependencies": {
         "webpack": "^5.30.0",
         "webpack-dev-server": "^5.0.2"
-      }
-    },
-    "node_modules/@angular-devkit/build-webpack/node_modules/rxjs": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
-      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
       }
     },
     "node_modules/@angular-devkit/core": {
@@ -498,16 +467,6 @@
         }
       }
     },
-    "node_modules/@angular-devkit/core/node_modules/rxjs": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
-      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/@angular-devkit/schematics": {
       "version": "21.2.18",
       "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-21.2.18.tgz",
@@ -525,16 +484,6 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
         "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
         "yarn": ">= 1.13.0"
-      }
-    },
-    "node_modules/@angular-devkit/schematics/node_modules/rxjs": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
-      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
       }
     },
     "node_modules/@angular/animations": {
@@ -14255,28 +14204,13 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz",
-      "integrity": "sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==",
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "tslib": "^1.9.0"
-      },
-      "engines": {
-        "npm": ">=2.0.0"
+        "tslib": "^2.1.0"
       }
-    },
-    "node_modules/rxjs-compat": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/rxjs-compat/-/rxjs-compat-6.5.2.tgz",
-      "integrity": "sha512-TRMkTp4FgSxE2HtGvxmgRukh3JqdFM7ejAj1Ti/VdodbPGfWvZR5+KdLKRV9jVDFyu2SknM8RD+PR54KGnoLjg==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/rxjs/node_modules/tslib": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
-      "license": "Apache-2.0"
     },
     "node_modules/safe-buffer": {
       "version": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
     "@angular/router": "^21.0.0",
     "@angular/service-worker": "^21.0.0",
     "node-fetch": "^2.6.0",
-    "rxjs": "~6.5.4",
-    "rxjs-compat": "^6.5.2",
+    "rxjs": "^7.8.2",
     "tslib": "^2.6.0",
     "unfetch": "^4.1.0",
     "zone.js": "~0.16.0"

--- a/src/app/feeds/feed/feed.component.ts
+++ b/src/app/feeds/feed/feed.component.ts
@@ -37,14 +37,14 @@ export class FeedComponent implements OnInit {
     this.pageSub = this.route.params.subscribe(params => {
       this.pageNum = params['page'] ? +params['page'] : 1;
       this._hackerNewsAPIService.fetchFeed(this.feedType, this.pageNum)
-        .subscribe(
-          items => this.items = items,
-          error => this.errorMessage = 'Could not load ' + this.feedType + ' stories.',
-          () => {
+        .subscribe({
+          next: items => this.items = items,
+          error: () => this.errorMessage = 'Could not load ' + this.feedType + ' stories.',
+          complete: () => {
             this.listStart = ((this.pageNum - 1) * 30) + 1;
             window.scrollTo(0, 0);
           }
-        );
+        });
     });
   }
 }

--- a/src/app/item-details/item-details.component.ts
+++ b/src/app/item-details/item-details.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { Location } from '@angular/common';
-import { Subscription } from 'rxjs/Subscription';
+import { Subscription } from 'rxjs';
 
 import { HackerNewsAPIService } from '../shared/services/hackernews-api.service';
 import { SettingsService } from '../shared/services/settings.service';

--- a/src/app/item-details/item-details.component.ts
+++ b/src/app/item-details/item-details.component.ts
@@ -33,9 +33,10 @@ export class ItemDetailsComponent implements OnInit {
   ngOnInit() {
     this.sub = this.route.params.subscribe(params => {
       let itemID = +params['id'];
-      this._hackerNewsAPIService.fetchItemContent(itemID).subscribe(item => {
-        this.item = item;
-      }, error => this.errorMessage = 'Could not load item comments.');
+      this._hackerNewsAPIService.fetchItemContent(itemID).subscribe({
+        next: item => this.item = item,
+        error: () => this.errorMessage = 'Could not load item comments.'
+      });
     });
     window.scrollTo(0, 0);
   }

--- a/src/app/shared/services/hackernews-api.service.ts
+++ b/src/app/shared/services/hackernews-api.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs/Observable';
+import { Observable } from 'rxjs';
 import fetch from 'unfetch';
 import {map } from 'rxjs/operators';
 

--- a/src/app/shared/services/hackernews-api.service.ts
+++ b/src/app/shared/services/hackernews-api.service.ts
@@ -26,9 +26,12 @@ export class HackerNewsAPIService {
         let numberOfPollOptions = story.poll.length;
         story.poll_votes_count = 0;
         for (let i = 1; i <= numberOfPollOptions; i++) {
-          this.fetchPollContent(story.id + i).subscribe(pollResults => {
-            story.poll[i - 1] = pollResults;
-            story.poll_votes_count += pollResults.points;
+          this.fetchPollContent(story.id + i).subscribe({
+            next: pollResults => {
+              story.poll[i - 1] = pollResults;
+              story.poll_votes_count += pollResults.points;
+            },
+            error: err => console.error('Could not load poll option', story.id + i, err)
           });
         }
       }

--- a/src/app/user/user.component.ts
+++ b/src/app/user/user.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { Location } from '@angular/common';
-import { Subscription } from 'rxjs/Subscription';
+import { Subscription } from 'rxjs';
 
 import { HackerNewsAPIService } from '../shared/services/hackernews-api.service';
 import { User } from '../shared/models/user';

--- a/src/app/user/user.component.ts
+++ b/src/app/user/user.component.ts
@@ -26,9 +26,10 @@ export class UserComponent implements OnInit {
   ngOnInit() {
     this.sub = this.route.params.subscribe(params => {
       let userID = params['id'];
-      this._hackerNewsAPIService.fetchUser(userID).subscribe(data => {
-        this.user = data;
-      }, error => this.errorMessage = 'Could not load user ' + userID + '.');
+      this._hackerNewsAPIService.fetchUser(userID).subscribe({
+        next: data => this.user = data,
+        error: () => this.errorMessage = 'Could not load user ' + userID + '.'
+      });
     });
   }
 


### PR DESCRIPTION
## Summary
Wave 2 of the Angular 9→21 migration: RxJS modernization on top of the Wave 1 core-upgrade branch.

- `rxjs` `~6.5.4` → `^7.8.2`; dropped `rxjs-compat` entirely (package.json + regenerated package-lock.json)
- Replaced deprecated deep imports with top-level ones:
  - `import { Observable } from 'rxjs/Observable'` → `from 'rxjs'` (hackernews-api.service.ts)
  - `import { Subscription } from 'rxjs/Subscription'` → `from 'rxjs'` (item-details.component.ts, user.component.ts)
- Migrated deprecated positional `subscribe(next, error, complete)` calls to the observer-object form `subscribe({ next, error, complete })` (item-details, user, feed components)
- Added an `error` handler to the `fetchPollContent` subscription in `fetchItemContent` — in RxJS 7 unhandled subscription errors are reported asynchronously instead of rethrown, so poll fetch failures would otherwise be silently swallowed

`npm run build` completes with zero errors and `rg "rxjs-compat|rxjs/Observable|rxjs/Subscription"` returns nothing.

Link to Devin session: https://app.devin.ai/sessions/d94fd6cfc50b45acbe137ebc4cd2d0a6
Requested by: @tobydrinkall
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/422?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/422" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/angular2-hn/pull/422" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->