### PR TITLE
Wave 3: Component/template and Sass modernization

### DIFF
--- a/browserslist
+++ b/browserslist
@@ -5,8 +5,11 @@
 # You can see what browsers were selected by your queries by running:
 #   npx browserslist
 
-> 0.5%
-last 2 versions
+# Aligned with the browsers supported by Angular.
+# https://angular.dev/reference/versions#browser-support
+last 2 Chrome versions
+last 1 Firefox version
+last 2 Edge major versions
+last 2 Safari major versions
+last 2 iOS major versions
 Firefox ESR
-not dead
-not IE 9-11 # For IE 9-11 support, remove 'not'.

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,5 +1,5 @@
-@import "./shared/scss/media";
-@import "./shared/scss/theme_variables";
+@use "./shared/scss/media" as *;
+@use "./shared/scss/theme_variables" as *;
 
 .body-cover {
   width: 100%;

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,5 +1,5 @@
 import { BrowserModule } from '@angular/platform-browser';
-import { NgModule } from '@angular/core';
+import { NgModule, provideZoneChangeDetection } from '@angular/core';
 
 import { routing } from './app.routes';
 
@@ -26,7 +26,7 @@ import { SettingsService } from './shared/services/settings.service';
             enabled: environment.production,
         }),
     ],
-    providers: [HackerNewsAPIService, SettingsService],
+    providers: [provideZoneChangeDetection(), HackerNewsAPIService, SettingsService],
     bootstrap: [AppComponent],
 })
 export class AppModule {}

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -26,7 +26,7 @@ import { SettingsService } from './shared/services/settings.service';
             enabled: environment.production,
         }),
     ],
-    providers: [provideZoneChangeDetection(), HackerNewsAPIService, SettingsService],
+    providers: [provideZoneChangeDetection({ eventCoalescing: true }), HackerNewsAPIService, SettingsService],
     bootstrap: [AppComponent],
 })
 export class AppModule {}

--- a/src/app/core/footer/footer.component.scss
+++ b/src/app/core/footer/footer.component.scss
@@ -1,5 +1,5 @@
-@import "../../shared/scss/media";
-@import "../../shared/scss/theme_variables";
+@use "../../shared/scss/media" as *;
+@use "../../shared/scss/theme_variables" as *;
 
 #footer {
   position: relative;

--- a/src/app/core/header/header.component.scss
+++ b/src/app/core/header/header.component.scss
@@ -1,5 +1,5 @@
-@import "../../shared/scss/media";
-@import "../../shared/scss/theme_variables";
+@use "../../shared/scss/media" as *;
+@use "../../shared/scss/theme_variables" as *;
 
 #header {
   color: #fff;

--- a/src/app/core/settings/settings.component.scss
+++ b/src/app/core/settings/settings.component.scss
@@ -1,5 +1,5 @@
-@import "../../shared/scss/media";
-@import "../../shared/scss/theme_variables";
+@use "../../shared/scss/media" as *;
+@use "../../shared/scss/theme_variables" as *;
 
 .overlay {
   position: fixed;

--- a/src/app/feeds/feed/feed.component.scss
+++ b/src/app/feeds/feed/feed.component.scss
@@ -1,5 +1,5 @@
-@import "../../shared/scss/media";
-@import "../../shared/scss/theme_variables";
+@use "../../shared/scss/media" as *;
+@use "../../shared/scss/theme_variables" as *;
 
 a {
   text-decoration: none;

--- a/src/app/feeds/item/item.component.scss
+++ b/src/app/feeds/item/item.component.scss
@@ -1,5 +1,5 @@
-@import "../../shared/scss/media";
-@import "../../shared/scss/theme_variables";
+@use "../../shared/scss/media" as *;
+@use "../../shared/scss/theme_variables" as *;
 
 p {
     margin: 2px 0;

--- a/src/app/item-details/comment/comment.component.scss
+++ b/src/app/item-details/comment/comment.component.scss
@@ -1,7 +1,7 @@
-@import "../../shared/scss/media";
-@import "../../shared/scss/theme_variables";
+@use "../../shared/scss/media" as *;
+@use "../../shared/scss/theme_variables" as *;
 
-:host >>> {
+:host ::ng-deep {
   a {
     font-weight: bold;
     text-decoration: none;

--- a/src/app/item-details/item-details.component.scss
+++ b/src/app/item-details/item-details.component.scss
@@ -1,5 +1,5 @@
-@import "../shared/scss/media";
-@import "../shared/scss/theme_variables";
+@use "../shared/scss/media" as *;
+@use "../shared/scss/theme_variables" as *;
 
 .main-content {
   position: relative;

--- a/src/app/shared/components/error-message/error-message.component.scss
+++ b/src/app/shared/components/error-message/error-message.component.scss
@@ -1,5 +1,6 @@
-@import "../../scss/media";
-@import "../../scss/theme_variables";
+@use "sass:math";
+@use "../../scss/media" as *;
+@use "../../scss/theme_variables" as *;
 
 .error-section {
   height: 300px;
@@ -65,9 +66,9 @@
           content: "";
           position: absolute;
           top: 100%;
-          left: $skull-size / 15;
-          border-right: $skull-size / 20 solid transparent;
-          border-left: $skull-size / 40 solid transparent;
+          left: math.div($skull-size, 15);
+          border-right: math.div($skull-size, 20) solid transparent;
+          border-left: math.div($skull-size, 40) solid transparent;
         }
       }
     }
@@ -77,7 +78,7 @@
       position: absolute;
       top: 75%;
       left: 30%;
-      border-radius: 0 0 $skull-size / 10 $skull-size / 10;
+      border-radius: 0 0 math.div($skull-size, 10) math.div($skull-size, 10);
       &:before {
         content: "";
         position: absolute;

--- a/src/app/shared/components/loader/loader.component.scss
+++ b/src/app/shared/components/loader/loader.component.scss
@@ -1,5 +1,5 @@
-@import "../../scss/media";
-@import "../../scss/theme_variables";
+@use "../../scss/media" as *;
+@use "../../scss/theme_variables" as *;
 
 .loader {
   -webkit-animation: load1 1s infinite ease-in-out;

--- a/src/app/shared/scss/_themes.scss
+++ b/src/app/shared/scss/_themes.scss
@@ -1,5 +1,7 @@
-@import "./media";
-@import "./theme_variables";
+@use "sass:color";
+@use "sass:math";
+@use "./media" as *;
+@use "./theme_variables" as *;
 
 /* ----------------------------------
 
@@ -142,10 +144,10 @@
               }
 
               &:before {
-                border-top: $skull-size / 8 solid $wrapper-background-color;
+                border-top: math.div($skull-size, 8) solid $wrapper-background-color;
 
                 @media #{$mobile-only} {
-                  border-top: $skull-size / 8 solid $wrapper-mobile-background-color;
+                  border-top: math.div($skull-size, 8) solid $wrapper-mobile-background-color;
                 }
               }
             }
@@ -230,7 +232,7 @@
   $theme-amoledblack-body-background-color,
   $theme-amoledblack-text-color,
   $theme-amoledblack-text-color,
-  darken($theme-amoledblack-text-color, 33%),
+  color.adjust($theme-amoledblack-text-color, $lightness: -33%),
   $theme-amoledblack-body-background-color,
   $theme-amoledblack-subtext-color,
   $theme-amoledblack-secondary-color,

--- a/src/app/user/user.component.scss
+++ b/src/app/user/user.component.scss
@@ -1,7 +1,7 @@
-@import "../shared/scss/media";
-@import "../shared/scss/theme_variables";
+@use "../shared/scss/media" as *;
+@use "../shared/scss/theme_variables" as *;
 
-:host >>> pre {
+:host ::ng-deep pre {
   white-space: pre-wrap;
 }
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,4 +1,4 @@
-@import "./app/shared/scss/themes";
+@use "./app/shared/scss/themes";
 
 html {
   height: 100%;


### PR DESCRIPTION
## Summary
Wave 3 of the Angular 9→21 migration (base: Wave 1 branch). `npm run build` now completes with zero errors and zero Sass deprecation warnings (only the pre-existing `rxjs/Observable` non-ESM warning remains — Wave 2 scope).

- **Sass modernization** (all component `.scss`, `src/styles.scss`, `_themes.scss`):
  - `@import "shared/scss/media|theme_variables"` → `@use "..." as *`
  - `$skull-size / N` → `math.div($skull-size, N)` via `@use "sass:math"` (error-message + `_themes.scss`)
  - `darken($c, 33%)` → `color.adjust($c, $lightness: -33%)`
  - Bogus combinators: `:host >>> ...` → `:host ::ng-deep ...` (user + comment components)
- **browserslist**: replaced the `> 0.5% / last 2 versions / not dead` query with the Angular-supported browser set (last 2 Chrome/Edge/Safari/iOS, Firefox + ESR), eliminating the "unsupported browsers" build warnings.
- **Runtime fix**: Angular 21 defaults to zoneless change detection, so the app fetched data but never re-rendered (stuck on the loader — reproducible on the base branch). Added `provideZoneChangeDetection()` to `AppModule` providers; the app now renders.

## Verification
Ran `ng serve` and clicked through news/newest/ask/show/jobs feeds and item comments:

![news feed](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctOGQxNThmMDdlZTBmNDY3OGE0NjcwNzhiMzIzODgwYTQiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctOGQxNThmMDdlZTBmNDY3OGE0NjcwNzhiMzIzODgwYTQvYmE3ZDc3OTktZWRhYS00NzlkLTk0YzMtZGRmYWY5NDg4MWMwIiwiaWF0IjoxNzgyOTg1NjM5LCJleHAiOjE3ODM1OTA0MzksImZpbGVuYW1lIjoid2F2ZTMtbmV3cy5wbmcifQ.xtjss3c5qq4-P0XBr_Rnd1rXqBxgP938KAq_MjgCRgk)
![comments](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctOGQxNThmMDdlZTBmNDY3OGE0NjcwNzhiMzIzODgwYTQiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctOGQxNThmMDdlZTBmNDY3OGE0NjcwNzhiMzIzODgwYTQvNDE1Y2JiMWQtZDg5Zi00ZDc5LTg0YjgtMzI4MzJlZmVhYTczIiwiaWF0IjoxNzgyOTg1NjM5LCJleHAiOjE3ODM1OTA0MzksImZpbGVuYW1lIjoid2F2ZTMtY29tbWVudHMucG5nIn0.yxVc8efJw-UdeCNnl_mt0zvYh38YhGA4YHnmBUc-AYU)

Note: user profile pages show the app's error state because the upstream `node-hnapi.herokuapp.com/user/:id` endpoint currently returns 404 for all users (verified via curl) — not related to these changes. The styled error page itself renders correctly (exercising the migrated skull SCSS).

Link to Devin session: https://app.devin.ai/sessions/694fd2293fc3459b87671b46a53eda31
Requested by: @tobydrinkall
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/424?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/424" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/angular2-hn/pull/424" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->