### PR TITLE
fix: Wave 3 — Sass deprecations, deep combinator, and template fixes

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,5 +1,5 @@
-@import "./shared/scss/media";
-@import "./shared/scss/theme_variables";
+@use "./shared/scss/media" as *;
+@use "./shared/scss/theme_variables" as *;
 
 .body-cover {
   width: 100%;

--- a/src/app/core/footer/footer.component.scss
+++ b/src/app/core/footer/footer.component.scss
@@ -1,5 +1,5 @@
-@import "../../shared/scss/media";
-@import "../../shared/scss/theme_variables";
+@use "../../shared/scss/media" as *;
+@use "../../shared/scss/theme_variables" as *;
 
 #footer {
   position: relative;

--- a/src/app/core/header/header.component.scss
+++ b/src/app/core/header/header.component.scss
@@ -1,5 +1,5 @@
-@import "../../shared/scss/media";
-@import "../../shared/scss/theme_variables";
+@use "../../shared/scss/media" as *;
+@use "../../shared/scss/theme_variables" as *;
 
 #header {
   color: #fff;

--- a/src/app/core/settings/settings.component.scss
+++ b/src/app/core/settings/settings.component.scss
@@ -1,5 +1,5 @@
-@import "../../shared/scss/media";
-@import "../../shared/scss/theme_variables";
+@use "../../shared/scss/media" as *;
+@use "../../shared/scss/theme_variables" as *;
 
 .overlay {
   position: fixed;

--- a/src/app/feeds/feed/feed.component.scss
+++ b/src/app/feeds/feed/feed.component.scss
@@ -1,5 +1,5 @@
-@import "../../shared/scss/media";
-@import "../../shared/scss/theme_variables";
+@use "../../shared/scss/media" as *;
+@use "../../shared/scss/theme_variables" as *;
 
 a {
   text-decoration: none;

--- a/src/app/feeds/item/item.component.scss
+++ b/src/app/feeds/item/item.component.scss
@@ -1,5 +1,5 @@
-@import "../../shared/scss/media";
-@import "../../shared/scss/theme_variables";
+@use "../../shared/scss/media" as *;
+@use "../../shared/scss/theme_variables" as *;
 
 p {
     margin: 2px 0;

--- a/src/app/item-details/comment/comment.component.scss
+++ b/src/app/item-details/comment/comment.component.scss
@@ -1,7 +1,7 @@
-@import "../../shared/scss/media";
-@import "../../shared/scss/theme_variables";
+@use "../../shared/scss/media" as *;
+@use "../../shared/scss/theme_variables" as *;
 
-:host >>> {
+::ng-deep {
   a {
     font-weight: bold;
     text-decoration: none;

--- a/src/app/item-details/comment/comment.component.scss
+++ b/src/app/item-details/comment/comment.component.scss
@@ -1,7 +1,7 @@
 @use "../../shared/scss/media" as *;
 @use "../../shared/scss/theme_variables" as *;
 
-::ng-deep {
+:host ::ng-deep {
   a {
     font-weight: bold;
     text-decoration: none;

--- a/src/app/item-details/item-details.component.scss
+++ b/src/app/item-details/item-details.component.scss
@@ -1,5 +1,5 @@
-@import "../shared/scss/media";
-@import "../shared/scss/theme_variables";
+@use "../shared/scss/media" as *;
+@use "../shared/scss/theme_variables" as *;
 
 .main-content {
   position: relative;

--- a/src/app/shared/components/error-message/error-message.component.scss
+++ b/src/app/shared/components/error-message/error-message.component.scss
@@ -1,5 +1,6 @@
-@import "../../scss/media";
-@import "../../scss/theme_variables";
+@use "sass:math";
+@use "../../scss/media" as *;
+@use "../../scss/theme_variables" as *;
 
 .error-section {
   height: 300px;
@@ -65,9 +66,9 @@
           content: "";
           position: absolute;
           top: 100%;
-          left: $skull-size / 15;
-          border-right: $skull-size / 20 solid transparent;
-          border-left: $skull-size / 40 solid transparent;
+          left: math.div($skull-size, 15);
+          border-right: math.div($skull-size, 20) solid transparent;
+          border-left: math.div($skull-size, 40) solid transparent;
         }
       }
     }
@@ -77,7 +78,7 @@
       position: absolute;
       top: 75%;
       left: 30%;
-      border-radius: 0 0 $skull-size / 10 $skull-size / 10;
+      border-radius: 0 0 math.div($skull-size, 10) math.div($skull-size, 10);
       &:before {
         content: "";
         position: absolute;

--- a/src/app/shared/components/loader/loader.component.scss
+++ b/src/app/shared/components/loader/loader.component.scss
@@ -1,5 +1,5 @@
-@import "../../scss/media";
-@import "../../scss/theme_variables";
+@use "../../scss/media" as *;
+@use "../../scss/theme_variables" as *;
 
 .loader {
   -webkit-animation: load1 1s infinite ease-in-out;

--- a/src/app/shared/scss/_themes.scss
+++ b/src/app/shared/scss/_themes.scss
@@ -1,5 +1,7 @@
-@import "./media";
-@import "./theme_variables";
+@use "sass:math";
+@use "sass:color";
+@use "./media" as *;
+@use "./theme_variables" as *;
 
 /* ----------------------------------
 
@@ -142,10 +144,10 @@
               }
 
               &:before {
-                border-top: $skull-size / 8 solid $wrapper-background-color;
+                border-top: math.div($skull-size, 8) solid $wrapper-background-color;
 
                 @media #{$mobile-only} {
-                  border-top: $skull-size / 8 solid $wrapper-mobile-background-color;
+                  border-top: math.div($skull-size, 8) solid $wrapper-mobile-background-color;
                 }
               }
             }
@@ -230,7 +232,7 @@
   $theme-amoledblack-body-background-color,
   $theme-amoledblack-text-color,
   $theme-amoledblack-text-color,
-  darken($theme-amoledblack-text-color, 33%),
+  color.adjust($theme-amoledblack-text-color, $lightness: -33%),
   $theme-amoledblack-body-background-color,
   $theme-amoledblack-subtext-color,
   $theme-amoledblack-secondary-color,

--- a/src/app/user/user.component.scss
+++ b/src/app/user/user.component.scss
@@ -1,7 +1,7 @@
-@import "../shared/scss/media";
-@import "../shared/scss/theme_variables";
+@use "../shared/scss/media" as *;
+@use "../shared/scss/theme_variables" as *;
 
-:host >>> pre {
+::ng-deep pre {
   white-space: pre-wrap;
 }
 

--- a/src/app/user/user.component.scss
+++ b/src/app/user/user.component.scss
@@ -1,7 +1,7 @@
 @use "../shared/scss/media" as *;
 @use "../shared/scss/theme_variables" as *;
 
-::ng-deep pre {
+:host ::ng-deep pre {
   white-space: pre-wrap;
 }
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,4 +1,4 @@
-@import "./app/shared/scss/themes";
+@use "./app/shared/scss/themes";
 
 html {
   height: 100%;


### PR DESCRIPTION
## Summary

Resolves Sass deprecations and CSS deep combinator issues that would become errors in Dart Sass 2.0, as part of the Angular 9→20 migration.

**Sass `@import` → `@use`/`@forward`** across all 13 SCSS files:
```scss
// before
@import "../../shared/scss/media";
@import "../../shared/scss/theme_variables";

// after
@use "../../shared/scss/media" as *;
@use "../../shared/scss/theme_variables" as *;
```

**`/` division → `math.div()`** in `error-message.component.scss` and `_themes.scss`:
```scss
// before
left: $skull-size / 15;
border-top: $skull-size / 8 solid $wrapper-background-color;

// after  
left: math.div($skull-size, 15);
border-top: math.div($skull-size, 8) solid $wrapper-background-color;
```

**`darken()` → `color.adjust()`** in `_themes.scss`:
```scss
// before
darken($theme-amoledblack-text-color, 33%)
// after
color.adjust($theme-amoledblack-text-color, $lightness: -33%)
```

**`:host >>>` → `:host ::ng-deep`** in `comment.component.scss` and `user.component.scss`:
```scss
// before
:host >>> { a { ... } }
:host >>> pre { ... }
// after
:host ::ng-deep { a { ... } }
:host ::ng-deep pre { ... }
```
`:host` prefix preserved to keep styles scoped to the component and prevent global leaks.

No template or component API breaking changes found — all components already use `standalone: false`, no `@ViewChild`/`@ContentChild` usage, and NgModule patterns are compatible with Angular 20. Build passes cleanly with `npx ng build`.

Link to Devin session: https://app.devin.ai/sessions/fb28a14a2b814b00944621984df964be
Requested by: @tobydrinkall
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/428?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/428" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/angular2-hn/pull/428" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->