### PR TITLE
React migration: User profile component

### DIFF
--- a/src/user/UserProfile.scss
+++ b/src/user/UserProfile.scss
@@ -1,0 +1,20 @@
+@import "../shared/scss/media";
+@import "../shared/scss/theme_variables";
+
+pre { white-space: pre-wrap; }
+.profile { padding: 30px; }
+@media #{$mobile-only} {
+  .profile { padding: 110px 15px 0 15px; }
+  .title-block { font-size: 15px; text-align: center; text-overflow: ellipsis; white-space: nowrap; overflow: hidden; margin: 0 75px; }
+  .back-button { position: absolute; top: 52%; width: 0.6rem; height: 0.6rem; background: transparent; box-shadow: 0 0 0 lightgray; transition: all 200ms ease; left: 4%; transform: translate3d(0, -50%, 0) rotate(-135deg); }
+  .item-header { padding-bottom: 10px; background-color: #fff; padding: 10px 0 10px 0; position: fixed; width: 100%; left: 0; top: 62px; height: 20px; }
+}
+@media #{$laptop-only} { .mobile { display: none; } }
+.main-details {
+  .name { font-weight: bold; font-size: 32px; letter-spacing: 2px; }
+  .age { font-weight: bold; color: #696969; padding-bottom: 0; }
+  .right { float: right; font-weight: bold; font-size: 32px; letter-spacing: 2px; }
+}
+@media #{$mobile-only} { .main-details { margin-top: 20px; .name { font-size: 18px; } } }
+@media #{$mobile-only} { .main-details .right { font-size: 18px; } }
+.other-details { word-wrap: break-word; }

--- a/src/user/UserProfile.tsx
+++ b/src/user/UserProfile.tsx
@@ -1,4 +1,52 @@
-// Stub — replaced by the User migration child session.
+import './UserProfile.scss';
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { User } from '../shared/models/user';
+import { fetchUser } from '../shared/api';
+import { Loader } from '../shared/components/Loader';
+import { ErrorMessage } from '../shared/components/ErrorMessage';
+
 export function UserProfile() {
-    return <div className="profile" />;
+    const { id } = useParams();
+    const navigate = useNavigate();
+    const [user, setUser] = useState<User | undefined>(undefined);
+    const [errorMessage, setErrorMessage] = useState('');
+
+    const goBack = () => navigate(-1);
+
+    useEffect(() => {
+        if (!id) {
+            return;
+        }
+        fetchUser(id)
+            .then(setUser)
+            .catch(() => setErrorMessage('Could not load user ' + id + '.'));
+    }, [id]);
+
+    return (
+        <>
+            {!user && !errorMessage && <Loader />}
+            {!user && errorMessage !== '' && <ErrorMessage message={errorMessage} />}
+            {user && (
+                <div className="profile">
+                    <div className="mobile item-header">
+                        <p className="title-block">
+                            <span className="back-button" onClick={goBack}></span>
+                            Profile: {user.id}
+                        </p>
+                    </div>
+                    <div className="main-details">
+                        <span className="name">{user.id}</span>
+                        <span className="right">{user.karma} ★</span>
+                        <p className="age">Created {user.created}</p>
+                    </div>
+                    {user.about && (
+                        <div className="other-details">
+                            <p dangerouslySetInnerHTML={{ __html: user.about }} />
+                        </div>
+                    )}
+                </div>
+            )}
+        </>
+    );
 }


### PR DESCRIPTION
## Summary
Ports the Angular `UserComponent` to React, replacing the `src/user/UserProfile.tsx` stub with a real functional component plus `src/user/UserProfile.scss`.

- Reads the route param via `useParams()`, fetches the profile with `fetchUser(id)` in a `useEffect` keyed on `id` (guarded when `id` is undefined).
- State: `user: User | undefined` and `errorMessage: string`. On fetch failure sets `errorMessage = 'Could not load user ' + id + '.'`.
- Render mirrors the original template: `<Loader />` while pending, `<ErrorMessage />` on error, else the `.profile` block (mobile header with back button → `navigate(-1)`, main details with karma/created, and `.other-details` via `dangerouslySetInnerHTML` when `user.about` is present).
- SCSS ported verbatim with `@import` paths repointed to `../shared/scss/...` and the Angular `:host >>>` wrapper dropped (keeping `pre { white-space: pre-wrap; }`).

Keeps the `UserProfile` named export required by the router's lazy import. `npm run build` and `npm run lint` both pass with no errors/warnings.

Link to Devin session: https://app.devin.ai/sessions/145a4418013b49278d6f77a351c31978
Requested by: @devanshi-gpta
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/437?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/437" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->