### PR TITLE
React migration: Feed and Item components

### DIFF
--- a/src/feeds/Feed.scss
+++ b/src/feeds/Feed.scss
@@ -1,0 +1,29 @@
+@import "../shared/scss/media";
+@import "../shared/scss/theme_variables";
+
+a { text-decoration: none; font-weight: bold; &:hover { text-decoration: underline; }; }
+ol {
+  padding: 0 40px; margin: 0;
+  @media #{$mobile-only} { box-sizing: border-box; list-style: none; padding: 0 10px; }
+  li { position: relative; -webkit-transition: background-color .2s ease; transition: background-color .2s ease; }
+}
+.list-margin { @media #{$mobile-only} { margin-top: 55px; } }
+.main-content {
+  position: relative; width: 100%; min-height: 100vh; -webkit-transition: opacity .2s ease; transition: opacity .2s ease; box-sizing: border-box; padding: 8px 0; z-index: 0;
+}
+.post {
+  padding: 10px 0 10px 5px; transition: background-color 0.2s ease; border-bottom: 1px solid #CECECB;
+  .itemNum { color: #696969; position: absolute; width: 30px; text-align: right; left: 0; top: 4px; }
+}
+.item-block { display: block; }
+.nav {
+  padding: 10px 40px; margin-top: 10px; font-size: 17px;
+  a { @media #{$mobile-only} { text-decoration: none; } }
+  @media #{$mobile-only} { margin: 20px 0; text-align: center; padding: 10px 80px; height: 20px; }
+  .prev { padding-right: 20px; @media #{$mobile-only} { float: left; padding-right: 0; } }
+  .more { @media #{$mobile-only} { float: right; } }
+}
+.job-header {
+  font-size: 15px; padding: 0 40px 10px;
+  @media #{$mobile-only} { padding: 60px 15px 25px 15px; }
+}

--- a/src/feeds/Feed.tsx
+++ b/src/feeds/Feed.tsx
@@ -1,4 +1,69 @@
-// Stub — replaced by the Feed/Item migration child session.
+import { useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { Story } from '../shared/models/story';
+import { fetchFeed } from '../shared/api';
+import { Loader } from '../shared/components/Loader';
+import { ErrorMessage } from '../shared/components/ErrorMessage';
+import { Item } from './Item';
+import './Feed.scss';
+
 export function Feed({ feedType }: { feedType: string }) {
-    return <div className="main-content">{feedType}</div>;
+    const { page } = useParams();
+    const pageNum = page ? +page : 1;
+
+    const [items, setItems] = useState<Story[] | undefined>(undefined);
+    const [errorMessage, setErrorMessage] = useState('');
+    const [listStart, setListStart] = useState(1);
+
+    useEffect(() => {
+        setItems(undefined);
+        setErrorMessage('');
+        fetchFeed(feedType, pageNum)
+            .then((stories) => {
+                setItems(stories);
+                setListStart(((pageNum - 1) * 30) + 1);
+                window.scrollTo(0, 0);
+            })
+            .catch(() => {
+                setErrorMessage('Could not load ' + feedType + ' stories.');
+            });
+    }, [feedType, pageNum]);
+
+    return (
+        <div className="main-content">
+            {!items && !errorMessage && <Loader />}
+            {!items && errorMessage !== '' && <ErrorMessage message={errorMessage} />}
+            {items && (
+                <div>
+                    {feedType === 'jobs' && (
+                        <p className="job-header">
+                            These are jobs at startups that were funded by Y Combinator. You can also get a job at a
+                            YC startup through <a href="https://triplebyte.com/?ref=yc_jobs">Triplebyte</a>.
+                        </p>
+                    )}
+                    <ol className={feedType !== 'jobs' ? 'list-margin' : undefined} start={listStart}>
+                        {items.map((item) => (
+                            <li className="post" key={item.id}>
+                                <div className="item-block">
+                                    <Item item={item} />
+                                </div>
+                            </li>
+                        ))}
+                    </ol>
+                    <div className="nav">
+                        {listStart !== 1 && (
+                            <Link to={`/${feedType}/${pageNum - 1}`} className="prev">
+                                ‹ Prev
+                            </Link>
+                        )}
+                        {items.length === 30 && (
+                            <Link to={`/${feedType}/${pageNum + 1}`} className="more">
+                                More ›
+                            </Link>
+                        )}
+                    </div>
+                </div>
+            )}
+        </div>
+    );
 }

--- a/src/feeds/Item.scss
+++ b/src/feeds/Item.scss
@@ -1,0 +1,22 @@
+@import "../shared/scss/media";
+@import "../shared/scss/theme_variables";
+
+p {
+    margin: 2px 0;
+    @media #{$mobile-only} { margin-bottom: 5px; margin-top: 0; }
+}
+a { cursor: pointer; text-decoration: none; }
+.title { font-size: 16px; font-family: Verdana, Geneva, sans-serif; }
+.subtext-laptop {
+    font-size: 12px; font-weight: bold; letter-spacing: 0.5px;
+    a { &:hover { text-decoration: underline; }; }
+    @media #{$mobile-only} { display: none; }
+}
+.subtext-palm {
+    font-size: 13px; font-weight: bold; letter-spacing: 0.5px;
+    a { &:hover { text-decoration: underline; }; }
+    .details { margin-top: 5px; .right { float: right; } }
+    @media #{$laptop-only} { display: none; }
+}
+.domain { color: #696969; letter-spacing: 0.5px; }
+.item-details { padding: 10px; }

--- a/src/feeds/Item.tsx
+++ b/src/feeds/Item.tsx
@@ -1,6 +1,70 @@
-// Stub — replaced by the Feed/Item migration child session.
+import { Link } from 'react-router-dom';
 import { Story } from '../shared/models/story';
+import { useSettings } from '../context/SettingsContext';
+import { commentCount } from '../shared/comment-count';
+import './Item.scss';
 
 export function Item({ item }: { item: Story }) {
-    return <div>{item.title}</div>;
+    const { openLinkInNewTab, titleFontSize, listSpacing } = useSettings();
+    const hasUrl = item.url.indexOf('http') === 0;
+
+    return (
+        <div style={{ marginBottom: `${listSpacing}px` }}>
+            {hasUrl ? (
+                <p>
+                    <a
+                        className="title"
+                        style={{ fontSize: `${titleFontSize}px` }}
+                        href={item.url}
+                        target={openLinkInNewTab ? '_blank' : undefined}
+                        rel={openLinkInNewTab ? 'noopener' : undefined}
+                    >
+                        {item.title}
+                    </a>
+                    {item.domain && <span className="domain">({item.domain})</span>}
+                </p>
+            ) : (
+                <p>
+                    <Link className="title" style={{ fontSize: `${titleFontSize}px` }} to={`/item/${item.id}`}>
+                        {item.title}
+                    </Link>
+                </p>
+            )}
+            <div className="subtext-palm">
+                {item.type !== 'job' && (
+                    <div className="details">
+                        <span className="name">
+                            <Link to={`/user/${item.user}`}>{item.user}</Link>
+                        </span>
+                        <span className="right">{item.points} ★</span>
+                    </div>
+                )}
+                <div className="details">
+                    {item.time_ago}
+                    {item.type !== 'job' && (
+                        <Link to={`/item/${item.id}`} className="comment-number">
+                            {' '}
+                            • {commentCount(item.comments_count)}
+                        </Link>
+                    )}
+                </div>
+            </div>
+            <div className="subtext-laptop">
+                {item.type !== 'job' && (
+                    <span>
+                        {item.points} points by <Link to={`/user/${item.user}`}>{item.user}</Link>
+                    </span>
+                )}
+                <span className={item.type !== 'job' ? 'item-details' : undefined}>
+                    {item.time_ago}
+                    {item.type !== 'job' && (
+                        <span>
+                            {' '}
+                            | <Link to={`/item/${item.id}`}>{commentCount(item.comments_count)}</Link>
+                        </span>
+                    )}
+                </span>
+            </div>
+        </div>
+    );
 }


### PR DESCRIPTION
## Summary
Ports the Angular `FeedComponent` and `ItemComponent` to React, replacing the existing stubs in `src/feeds/`.

- `Feed({ feedType })`: reads `:page` via `useParams()`, fetches `fetchFeed(feedType, pageNum)` in a `useEffect` keyed on `[feedType, pageNum]`. On success sets `items`, `listStart = ((pageNum-1)*30)+1`, and scrolls to top; on failure sets `errorMessage = 'Could not load ' + feedType + ' stories.'`. Renders `Loader`/`ErrorMessage`, the jobs header, an `<ol start={listStart}>` (`list-margin` when not jobs) of `<Item>`s, and Prev/More pagination `<Link>`s (Prev when `listStart !== 1`, More when `items.length === 30`).
- `Item({ item })`: uses `useSettings()` for `openLinkInNewTab`/`titleFontSize`/`listSpacing`. `hasUrl = item.url.indexOf('http') === 0` chooses an external `<a>` (with `target`/`rel` when new-tab) + optional domain span, or an internal `<Link to={/item/:id}>`. Renders the `subtext-palm` and `subtext-laptop` blocks, hiding author/points/comment links for `type === 'job'`, using `commentCount()` for the comment pill.

Since React doesn't forward `className` to a component, each list item wraps `<Item>` in `<div className="item-block">`. SCSS moved to sibling `Feed.scss`/`Item.scss` (global, imported at top of each `.tsx`) with `@import` paths rewritten to `../shared/scss/...` and Angular-only selectors removed.

`npm run build` (`tsc --noEmit && vite build`) and `npm run lint` both pass with no errors/warnings.


Link to Devin session: https://app.devin.ai/sessions/b66187e631bb4b6faae9d96226fd9879
Requested by: @devanshi-gpta
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/438?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/438" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->