### PR TITLE
PR 2 — Types + Hacker News API service (with MSW tests)

### DIFF
--- a/src/services/hackerNewsApi.test.ts
+++ b/src/services/hackerNewsApi.test.ts
@@ -1,0 +1,133 @@
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+import { server } from '../test/mocks/server';
+import {
+  BASE_URL,
+  fetchFeed,
+  fetchItemContent,
+  fetchPollContent,
+  fetchUser,
+} from './hackerNewsApi';
+import type { Story } from '../types/story';
+
+describe('hackerNewsApi', () => {
+  describe('fetchFeed', () => {
+    it('requests /{feedType}?page={page} and returns the story list', async () => {
+      let requestedUrl = '';
+      server.use(
+        http.get(`${BASE_URL}/news`, ({ request }) => {
+          requestedUrl = request.url;
+          return HttpResponse.json([{ id: 1, title: 'Hello' }]);
+        })
+      );
+
+      const stories = await fetchFeed('news', 2);
+
+      const url = new URL(requestedUrl);
+      expect(url.pathname).toBe('/news');
+      expect(url.searchParams.get('page')).toBe('2');
+      expect(stories).toHaveLength(1);
+      expect(stories[0].title).toBe('Hello');
+    });
+
+    it('supports other feed types', async () => {
+      server.use(
+        http.get(`${BASE_URL}/ask`, () => HttpResponse.json([]))
+      );
+      await expect(fetchFeed('ask', 1)).resolves.toEqual([]);
+    });
+
+    it('propagates errors on non-ok responses', async () => {
+      server.use(
+        http.get(`${BASE_URL}/news`, () => new HttpResponse(null, { status: 500 }))
+      );
+      await expect(fetchFeed('news', 1)).rejects.toThrow(/status 500/);
+    });
+  });
+
+  describe('fetchItemContent', () => {
+    it('returns a non-poll story unchanged', async () => {
+      const story: Partial<Story> = { id: 42, type: 'story', title: 'A story' };
+      server.use(
+        http.get(`${BASE_URL}/item/42`, () => HttpResponse.json(story))
+      );
+
+      const result = await fetchItemContent(42);
+      expect(result.id).toBe(42);
+      expect(result.title).toBe('A story');
+    });
+
+    it('aggregates poll option votes into poll_votes_count', async () => {
+      const pollStory: Partial<Story> = {
+        id: 100,
+        type: 'poll',
+        title: 'Best language?',
+        poll: [
+          { points: 0, content: 'A' },
+          { points: 0, content: 'B' },
+          { points: 0, content: 'C' },
+        ],
+      };
+      const optionPoints: Record<number, number> = { 101: 5, 102: 10, 103: 2 };
+
+      server.use(
+        http.get(`${BASE_URL}/item/100`, () => HttpResponse.json(pollStory)),
+        http.get(`${BASE_URL}/item/:id`, ({ params }) => {
+          const id = Number(params.id);
+          return HttpResponse.json({ points: optionPoints[id], content: `opt-${id}` });
+        })
+      );
+
+      const result = await fetchItemContent(100);
+
+      expect(result.poll_votes_count).toBe(17);
+      expect(result.poll).toEqual([
+        { points: 5, content: 'opt-101' },
+        { points: 10, content: 'opt-102' },
+        { points: 2, content: 'opt-103' },
+      ]);
+    });
+
+    it('propagates errors from the item request', async () => {
+      server.use(
+        http.get(`${BASE_URL}/item/7`, () => new HttpResponse(null, { status: 404 }))
+      );
+      await expect(fetchItemContent(7)).rejects.toThrow(/status 404/);
+    });
+  });
+
+  describe('fetchPollContent', () => {
+    it('requests /item/{id} and returns a poll result', async () => {
+      server.use(
+        http.get(`${BASE_URL}/item/55`, () =>
+          HttpResponse.json({ points: 9, content: 'choice' })
+        )
+      );
+      await expect(fetchPollContent(55)).resolves.toEqual({ points: 9, content: 'choice' });
+    });
+  });
+
+  describe('fetchUser', () => {
+    it('requests /user/{id} and returns the user', async () => {
+      let requestedUrl = '';
+      server.use(
+        http.get(`${BASE_URL}/user/pg`, ({ request }) => {
+          requestedUrl = request.url;
+          return HttpResponse.json({ id: 'pg', karma: 12345, created: 'long ago' });
+        })
+      );
+
+      const user = await fetchUser('pg');
+      expect(new URL(requestedUrl).pathname).toBe('/user/pg');
+      expect(user.id).toBe('pg');
+      expect(user.karma).toBe(12345);
+    });
+
+    it('propagates errors on non-ok responses', async () => {
+      server.use(
+        http.get(`${BASE_URL}/user/ghost`, () => new HttpResponse(null, { status: 404 }))
+      );
+      await expect(fetchUser('ghost')).rejects.toThrow(/status 404/);
+    });
+  });
+});

--- a/src/services/hackerNewsApi.ts
+++ b/src/services/hackerNewsApi.ts
@@ -1,0 +1,42 @@
+import type { FeedType } from '../types/feed-type.type';
+import type { PollResult } from '../types/poll-result';
+import type { Story } from '../types/story';
+import type { User } from '../types/user';
+
+export const BASE_URL = 'https://node-hnapi.herokuapp.com';
+
+async function getJson<T>(url: string): Promise<T> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Request to ${url} failed with status ${response.status}`);
+  }
+  return (await response.json()) as T;
+}
+
+export function fetchFeed(feedType: string, page: number): Promise<Story[]> {
+  return getJson<Story[]>(`${BASE_URL}/${feedType}?page=${page}`);
+}
+
+export function fetchPollContent(id: number): Promise<PollResult> {
+  return getJson<PollResult>(`${BASE_URL}/item/${id}`);
+}
+
+export async function fetchItemContent(id: number): Promise<Story> {
+  const story = await getJson<Story>(`${BASE_URL}/item/${id}`);
+
+  if (story.type === ('poll' as FeedType) && Array.isArray(story.poll)) {
+    const numberOfPollOptions = story.poll.length;
+    story.poll_votes_count = 0;
+    for (let i = 1; i <= numberOfPollOptions; i++) {
+      const pollResult = await fetchPollContent(story.id + i);
+      story.poll[i - 1] = pollResult;
+      story.poll_votes_count += pollResult.points;
+    }
+  }
+
+  return story;
+}
+
+export function fetchUser(id: string): Promise<User> {
+  return getJson<User>(`${BASE_URL}/user/${id}`);
+}

--- a/src/types/comment.ts
+++ b/src/types/comment.ts
@@ -1,0 +1,10 @@
+export interface Comment {
+  id: number;
+  level: number;
+  user: string;
+  time: number;
+  time_ago: string;
+  content: string;
+  deleted: boolean;
+  comments: Comment[];
+}

--- a/src/types/feed-type.type.ts
+++ b/src/types/feed-type.type.ts
@@ -1,0 +1,1 @@
+export type FeedType = 'poll' | 'story' | 'job';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,6 @@
+export type { Comment } from './comment';
+export type { FeedType } from './feed-type.type';
+export type { PollResult } from './poll-result';
+export type { Settings } from './settings';
+export type { Story } from './story';
+export type { User } from './user';

--- a/src/types/poll-result.ts
+++ b/src/types/poll-result.ts
@@ -1,0 +1,4 @@
+export interface PollResult {
+  points: number;
+  content: string;
+}

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -1,0 +1,7 @@
+export interface Settings {
+  showSettings: boolean;
+  openLinkInNewTab: boolean;
+  theme: string;
+  titleFontSize: string;
+  listSpacing: string;
+}

--- a/src/types/story.ts
+++ b/src/types/story.ts
@@ -1,0 +1,21 @@
+import type { Comment } from './comment';
+import type { FeedType } from './feed-type.type';
+import type { PollResult } from './poll-result';
+
+export interface Story {
+  id: number;
+  title: string;
+  points: number;
+  user: string;
+  time: number;
+  time_ago: number;
+  type: FeedType;
+  url: string;
+  domain: string;
+  comments: Comment[];
+  comments_count: number;
+  poll: PollResult[];
+  poll_votes_count: number;
+  deleted: boolean;
+  dead: boolean;
+}

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,0 +1,8 @@
+export interface User {
+  id: string;
+  crated_time: number;
+  created: string;
+  karma: number;
+  avg: number;
+  about: string;
+}


### PR DESCRIPTION
## Summary
Second migration PR. Ports the Angular data layer into framework-agnostic TypeScript so later component PRs can consume it. No UI changes.

- **Types** (`src/app/shared/models/*` → `src/types/*`): `Story`, `User`, `Comment` (recursive), `PollResult`, `Settings`, `FeedType`. Angular `class` models become `interface`s; field names preserved verbatim for API parity (including the original `User.crated_time`). `src/types/index.ts` re-exports all.
- **API service** (`hackernews-api.service.ts` → `src/services/hackerNewsApi.ts`): RxJS `Observable` + `unfetch` replaced with plain `fetch` returning `Promise`s, base URL `https://node-hnapi.herokuapp.com`.
  - `fetchFeed(feedType, page)` → `GET /{feedType}?page={page}`
  - `fetchItemContent(id)` → `GET /item/{id}`; for `type === 'poll'`, fetches `/item/{id+i}` for `i = 1..poll.length`, sets `poll[i-1]` and accumulates `poll_votes_count += points`
  - `fetchPollContent(id)` → `GET /item/{id}`
  - `fetchUser(id)` → `GET /user/{id}`
  - Added explicit `res.ok` check so failed requests reject (error propagation), which the Angular `lazyFetch` did only on network rejection.

```ts
async function getJson<T>(url) {
  const res = await fetch(url);
  if (!res.ok) throw new Error(`Request to ${url} failed with status ${res.status}`);
  return res.json() as Promise<T>;
}
```

- **Tests** (`src/services/hackerNewsApi.test.ts`, MSW): assert request URL/params, poll vote aggregation (3 options → summed `poll_votes_count`), non-poll passthrough, user fetch, and error propagation on non-ok responses.

Verification: `npm test` (10 passing), `npm run build`, `npm run lint` all pass.

Link to Devin session: https://app.devin.ai/sessions/f5b5e0024ed64555ab5690d935d7c476
Requested by: @devanshi-gpta
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/494?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/494" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->