### PR TITLE
PR 3 — Settings context + theming (with tests)

### DIFF
--- a/src/context/SettingsProvider.test.tsx
+++ b/src/context/SettingsProvider.test.tsx
@@ -1,0 +1,143 @@
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SettingsProvider } from './SettingsProvider';
+import { useSettings } from './useSettings';
+
+function installMatchMedia(initialMatches: boolean) {
+  const listeners = new Set<(event: MediaQueryListEvent) => void>();
+  const mql = {
+    matches: initialMatches,
+    media: '(prefers-color-scheme: dark)',
+    onchange: null,
+    addEventListener: (_type: string, cb: (event: MediaQueryListEvent) => void) => listeners.add(cb),
+    removeEventListener: (_type: string, cb: (event: MediaQueryListEvent) => void) =>
+      listeners.delete(cb),
+    addListener: (cb: (event: MediaQueryListEvent) => void) => listeners.add(cb),
+    removeListener: (cb: (event: MediaQueryListEvent) => void) => listeners.delete(cb),
+    dispatchEvent: () => true,
+  };
+  window.matchMedia = vi.fn().mockReturnValue(mql) as unknown as typeof window.matchMedia;
+  return {
+    emit(matches: boolean) {
+      mql.matches = matches;
+      listeners.forEach((cb) => cb({ matches } as MediaQueryListEvent));
+    },
+  };
+}
+
+function Harness() {
+  const { settings, toggleSettings, toggleOpenLinksInNewTab, setTheme, setFont, setSpacing } =
+    useSettings();
+  return (
+    <div>
+      <span data-testid="theme">{settings.theme}</span>
+      <span data-testid="showSettings">{String(settings.showSettings)}</span>
+      <span data-testid="openLinkInNewTab">{String(settings.openLinkInNewTab)}</span>
+      <span data-testid="titleFontSize">{settings.titleFontSize}</span>
+      <span data-testid="listSpacing">{settings.listSpacing}</span>
+      <button onClick={toggleSettings}>toggleSettings</button>
+      <button onClick={toggleOpenLinksInNewTab}>toggleLinks</button>
+      <button onClick={() => setTheme('amoledblack')}>setTheme</button>
+      <button onClick={() => setFont('20')}>setFont</button>
+      <button onClick={() => setSpacing('10')}>setSpacing</button>
+    </div>
+  );
+}
+
+function renderWithProvider() {
+  return render(
+    <SettingsProvider>
+      <Harness />
+    </SettingsProvider>
+  );
+}
+
+describe('SettingsProvider', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('system dark-mode selection', () => {
+    it('selects night theme when the system prefers dark and no theme is saved', () => {
+      installMatchMedia(true);
+      renderWithProvider();
+      expect(screen.getByTestId('theme')).toHaveTextContent('night');
+      expect(localStorage.getItem('theme')).toBe('night');
+    });
+
+    it('selects default theme when the system prefers light and no theme is saved', () => {
+      installMatchMedia(false);
+      renderWithProvider();
+      expect(screen.getByTestId('theme')).toHaveTextContent('default');
+      expect(localStorage.getItem('theme')).toBe('default');
+    });
+
+    it('honors a previously saved theme over the system preference', () => {
+      localStorage.setItem('theme', 'amoledblack');
+      installMatchMedia(true);
+      renderWithProvider();
+      expect(screen.getByTestId('theme')).toHaveTextContent('amoledblack');
+    });
+
+    it('updates the theme when the system preference changes', () => {
+      const media = installMatchMedia(false);
+      renderWithProvider();
+      expect(screen.getByTestId('theme')).toHaveTextContent('default');
+      act(() => media.emit(true));
+      expect(screen.getByTestId('theme')).toHaveTextContent('night');
+      expect(localStorage.getItem('theme')).toBe('night');
+    });
+  });
+
+  describe('persistence and toggles', () => {
+    beforeEach(() => installMatchMedia(false));
+
+    it('persists the theme when set explicitly', async () => {
+      renderWithProvider();
+      await userEvent.click(screen.getByText('setTheme'));
+      expect(screen.getByTestId('theme')).toHaveTextContent('amoledblack');
+      expect(localStorage.getItem('theme')).toBe('amoledblack');
+    });
+
+    it('toggles showSettings without persisting it', async () => {
+      renderWithProvider();
+      expect(screen.getByTestId('showSettings')).toHaveTextContent('false');
+      await userEvent.click(screen.getByText('toggleSettings'));
+      expect(screen.getByTestId('showSettings')).toHaveTextContent('true');
+      expect(localStorage.getItem('showSettings')).toBeNull();
+    });
+
+    it('toggles and persists openLinkInNewTab', async () => {
+      renderWithProvider();
+      expect(screen.getByTestId('openLinkInNewTab')).toHaveTextContent('false');
+      await userEvent.click(screen.getByText('toggleLinks'));
+      expect(screen.getByTestId('openLinkInNewTab')).toHaveTextContent('true');
+      expect(localStorage.getItem('openLinkInNewTab')).toBe('true');
+    });
+
+    it('persists titleFontSize and listSpacing', async () => {
+      renderWithProvider();
+      await userEvent.click(screen.getByText('setFont'));
+      await userEvent.click(screen.getByText('setSpacing'));
+      expect(screen.getByTestId('titleFontSize')).toHaveTextContent('20');
+      expect(screen.getByTestId('listSpacing')).toHaveTextContent('10');
+      expect(localStorage.getItem('titleFontSize')).toBe('20');
+      expect(localStorage.getItem('listSpacing')).toBe('10');
+    });
+
+    it('reads initial persisted values on mount', () => {
+      localStorage.setItem('openLinkInNewTab', 'true');
+      localStorage.setItem('titleFontSize', '18');
+      localStorage.setItem('listSpacing', '5');
+      renderWithProvider();
+      expect(screen.getByTestId('openLinkInNewTab')).toHaveTextContent('true');
+      expect(screen.getByTestId('titleFontSize')).toHaveTextContent('18');
+      expect(screen.getByTestId('listSpacing')).toHaveTextContent('5');
+    });
+  });
+});

--- a/src/context/SettingsProvider.tsx
+++ b/src/context/SettingsProvider.tsx
@@ -1,0 +1,88 @@
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
+import type { Settings } from '../types/settings';
+import { SettingsContext, type SettingsContextValue } from './settingsContext';
+
+const DARK_SCHEME_QUERY = '(prefers-color-scheme: dark)';
+
+function readInitialSettings(): Settings {
+  const openLinkInNewTab = localStorage.getItem('openLinkInNewTab');
+  return {
+    showSettings: false,
+    openLinkInNewTab: openLinkInNewTab ? JSON.parse(openLinkInNewTab) : false,
+    theme: 'default',
+    titleFontSize: localStorage.getItem('titleFontSize') ?? '16',
+    listSpacing: localStorage.getItem('listSpacing') ?? '0',
+  };
+}
+
+export function SettingsProvider({ children }: { children: ReactNode }) {
+  const [settings, setSettings] = useState<Settings>(readInitialSettings);
+
+  const setTheme = useCallback((theme: string) => {
+    localStorage.setItem('theme', theme);
+    setSettings((prev) => ({ ...prev, theme }));
+  }, []);
+
+  // Apply theme without persisting (used when honoring a previously saved theme).
+  const applyTheme = useCallback((theme: string) => {
+    setSettings((prev) => ({ ...prev, theme }));
+  }, []);
+
+  useEffect(() => {
+    const media = window.matchMedia(DARK_SCHEME_QUERY);
+
+    const handleSystemPreferredColorSchemeChange = (event: MediaQueryListEvent) => {
+      setTheme(event.matches ? 'night' : 'default');
+    };
+
+    media.addEventListener('change', handleSystemPreferredColorSchemeChange);
+
+    // initTheme: honor a saved theme, otherwise auto-select from the system preference.
+    const savedTheme = localStorage.getItem('theme');
+    if (savedTheme) {
+      applyTheme(savedTheme);
+    } else {
+      setTheme(media.matches ? 'night' : 'default');
+    }
+
+    return () => {
+      media.removeEventListener('change', handleSystemPreferredColorSchemeChange);
+    };
+  }, [setTheme, applyTheme]);
+
+  const toggleSettings = useCallback(() => {
+    setSettings((prev) => ({ ...prev, showSettings: !prev.showSettings }));
+  }, []);
+
+  const toggleOpenLinksInNewTab = useCallback(() => {
+    setSettings((prev) => {
+      const openLinkInNewTab = !prev.openLinkInNewTab;
+      localStorage.setItem('openLinkInNewTab', JSON.stringify(openLinkInNewTab));
+      return { ...prev, openLinkInNewTab };
+    });
+  }, []);
+
+  const setFont = useCallback((fontSize: string) => {
+    localStorage.setItem('titleFontSize', fontSize);
+    setSettings((prev) => ({ ...prev, titleFontSize: fontSize }));
+  }, []);
+
+  const setSpacing = useCallback((listSpacing: string) => {
+    localStorage.setItem('listSpacing', listSpacing);
+    setSettings((prev) => ({ ...prev, listSpacing }));
+  }, []);
+
+  const value = useMemo<SettingsContextValue>(
+    () => ({
+      settings,
+      toggleSettings,
+      toggleOpenLinksInNewTab,
+      setTheme,
+      setFont,
+      setSpacing,
+    }),
+    [settings, toggleSettings, toggleOpenLinksInNewTab, setTheme, setFont, setSpacing]
+  );
+
+  return <SettingsContext.Provider value={value}>{children}</SettingsContext.Provider>;
+}

--- a/src/context/settingsContext.ts
+++ b/src/context/settingsContext.ts
@@ -1,0 +1,13 @@
+import { createContext } from 'react';
+import type { Settings } from '../types/settings';
+
+export interface SettingsContextValue {
+  settings: Settings;
+  toggleSettings: () => void;
+  toggleOpenLinksInNewTab: () => void;
+  setTheme: (theme: string) => void;
+  setFont: (fontSize: string) => void;
+  setSpacing: (listSpacing: string) => void;
+}
+
+export const SettingsContext = createContext<SettingsContextValue | undefined>(undefined);

--- a/src/context/useSettings.ts
+++ b/src/context/useSettings.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import { SettingsContext, type SettingsContextValue } from './settingsContext';
+
+export function useSettings(): SettingsContextValue {
+  const context = useContext(SettingsContext);
+  if (!context) {
+    throw new Error('useSettings must be used within a SettingsProvider');
+  }
+  return context;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
+import './styles/index.scss';
 
 const container = document.getElementById('root');
 if (!container) {

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -1,0 +1,43 @@
+@import "./scss/themes";
+
+html {
+  height: 100%;
+  width: 100%;
+}
+
+body {
+  margin: 0;
+  height: 100%;
+  width: 100%;
+}
+
+pre {
+    white-space: pre-wrap;
+}
+
+.app-loader {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0;
+    position: fixed;
+    height: 100%;
+    width: 100%;
+    top: 0;
+    left: 0;
+    z-index: -1;
+}
+
+@media screen and (max-width: 768px) {
+  .app-loader {
+    background-color: #fff;
+  }
+}
+
+#root:empty + .app-loader {
+    opacity: 1;
+    z-index: 100;
+}
+#root:empty + .app-loader .logo {
+    width: 20vh;
+}

--- a/src/styles/scss/_media.scss
+++ b/src/styles/scss/_media.scss
@@ -1,0 +1,3 @@
+$mobile-only: "only screen and (max-width : 768px)";
+$laptop-only: "only screen and (min-width : 769px)";
+$tablet-only: "only screen and (max-width : 1024px)";

--- a/src/styles/scss/_theme_variables.scss
+++ b/src/styles/scss/_theme_variables.scss
@@ -1,0 +1,37 @@
+$skull-size: 200px;
+
+// -------------------------------------------------------------------------------------------
+// Theme Engine
+// -------------------------------------------------------------------------------------------
+
+// Day theme colors
+$theme-day-body-background-color: #fff;
+$theme-day-wrapper-background-color: #f5f5f5;
+$theme-day-wrapper-mobile-background-color: #fff;
+$theme-day-text-color: #000;
+$theme-day-subtext-color: #696969;
+$theme-day-secondary-color: #b92b27;
+$theme-day-header-background-color: $theme-day-secondary-color;
+$theme-day-logo-inner: #fff;
+
+// Day theme extras
+$theme-day-border: 2px solid #b92b27;
+
+// Night theme colors
+$theme-night-body-background-color: #37474F;
+$theme-night-wrapper-background-color: #263238;
+$theme-night-wrapper-mobile-background-color: $theme-night-wrapper-background-color;
+$theme-night-text-color: rgba(255, 255, 255, 0.7);
+$theme-night-subtext-color: #999;
+$theme-night-secondary-color: #00c0ff;
+$theme-night-header-background-color: #263238;
+$theme-night-logo-inner: $theme-night-header-background-color;
+
+// Night theme extras
+$theme-night-border: 2px solid #00c0ff;
+
+// Black theme colors
+$theme-amoledblack-body-background-color: #000;
+$theme-amoledblack-text-color: rgba(255, 255, 255, 0.75);
+$theme-amoledblack-subtext-color: rgba(255, 255, 255, 0.5);
+$theme-amoledblack-secondary-color: rgba(255, 255, 255, 0.6);

--- a/src/styles/scss/_themes.scss
+++ b/src/styles/scss/_themes.scss
@@ -1,0 +1,246 @@
+@use "sass:math";
+@import "./media";
+@import "./theme_variables";
+
+/* ----------------------------------
+
+  Want a new theme? Add your new theme variables here!
+
+---------------------------------- */
+
+@mixin theme(
+  $name,
+  $body-background-color,
+  $wrapper-background-color,
+  $wrapper-mobile-background-color,
+  $wrapper-color,
+  $item-a-color,
+  $item-a-visited-color,
+  $header-background-color,
+  $subtext-color,
+  $secondary-link-color,
+  $logo-inner-color,
+  $border
+) {
+  .#{$name} {
+    .body-cover {
+      background: $body-background-color;
+
+      @media #{$mobile-only} {
+       background: $wrapper-mobile-background-color;
+      }
+    }
+
+    .wrapper {
+      background: $wrapper-background-color;
+      color: $wrapper-color;
+
+      @media #{$mobile-only} {
+       background: $wrapper-mobile-background-color;
+      }
+
+      a {
+        color: $item-a-color;
+
+        &:visited {
+            color: $item-a-visited-color;
+        }
+      }
+
+      #header {
+        background: $header-background-color;
+        border-bottom: $border;
+      }
+
+      .logo-inner {
+        background: $logo-inner-color;
+      }
+
+      .nav {
+        a {
+          color: $secondary-link-color;
+
+          @media #{$mobile-only} {
+            color: $secondary-link-color;
+          }
+        }
+      }
+
+      #footer {
+        border-top: $border;
+
+        a {
+          color: $secondary-link-color;
+        }
+      }
+
+      .subtext, .subtext-palm, .subtext-laptop, .domain, .meta, .deleted-meta{
+        color: $subtext-color;
+
+        a {
+          color: $secondary-link-color;
+        }
+      }
+
+      .popup {
+        background: $header-background-color;
+      }
+
+      .item-header {
+        border-bottom: $border;
+
+        @media #{$mobile-only} {
+          background: $wrapper-mobile-background-color;
+        }
+      }
+
+      .pollContent {
+        .pollBar {
+          background: $secondary-link-color;
+        }
+      }
+
+      .loader {
+        color: $secondary-link-color;
+        background: $secondary-link-color;
+
+        &:before, &:after {
+          background: $secondary-link-color;
+        }
+      }
+
+      .job-header {
+        @media #{$mobile-only} {
+          border-bottom: $border;
+        }
+      }
+
+      .back-button {
+        @media #{$mobile-only} {
+          border-top: .3rem solid $secondary-link-color;
+          border-right: .3rem solid $secondary-link-color;
+        }
+      }
+
+      .error-section {
+        .skull {
+          .head {
+            background-color: $secondary-link-color;
+
+            &:before, &:after {
+              background-color: $wrapper-background-color;
+
+              @media #{$mobile-only} {
+                background-color: $wrapper-mobile-background-color;
+              }
+            }
+
+            .crack {
+              background-color: $wrapper-background-color;
+
+              @media #{$mobile-only} {
+                background-color: $wrapper-mobile-background-color;
+              }
+
+              &:before {
+                border-top: math.div($skull-size, 8) solid $wrapper-background-color;
+
+                @media #{$mobile-only} {
+                  border-top: math.div($skull-size, 8) solid $wrapper-mobile-background-color;
+                }
+              }
+            }
+          }
+
+          .mouth {
+            background-color: $secondary-link-color;
+
+            &:before {
+              background-color: $wrapper-background-color;
+
+              @media #{$mobile-only} {
+                background-color: $wrapper-mobile-background-color;
+              }
+            }
+          }
+
+          .teeth {
+            background-color: $wrapper-background-color;
+
+            @media #{$mobile-only} {
+              background-color: $wrapper-mobile-background-color;
+            }
+
+            &:before, &:after {
+              background-color: $wrapper-background-color;
+
+              @media #{$mobile-only} {
+                background-color: $wrapper-mobile-background-color;
+              }
+            }
+          }
+        }
+      }
+
+      .main-details {
+        .name {
+          color: $secondary-link-color;
+        }
+        .right {
+          color: $secondary-link-color;
+        }
+      }
+    }
+  }
+}
+
+@include theme(
+  default,
+  $theme-day-body-background-color,
+  $theme-day-wrapper-background-color,
+  $theme-day-wrapper-mobile-background-color,
+  $theme-day-text-color,
+  $theme-day-text-color,
+  $theme-day-subtext-color,
+  $theme-day-header-background-color,
+  $theme-day-subtext-color,
+  $theme-day-secondary-color,
+  $theme-day-logo-inner,
+  $theme-day-border
+);
+
+@include theme(
+  night,
+  $theme-night-body-background-color,
+  $theme-night-wrapper-background-color,
+  $theme-night-wrapper-mobile-background-color,
+  $theme-night-text-color,
+  $theme-night-text-color,
+  $theme-night-subtext-color,
+  $theme-night-header-background-color,
+  $theme-night-subtext-color,
+  $theme-night-secondary-color,
+  $theme-night-logo-inner,
+  $theme-night-border
+);
+
+@include theme(
+  amoledblack,
+  $theme-amoledblack-body-background-color,
+  $theme-amoledblack-body-background-color,
+  $theme-amoledblack-body-background-color,
+  $theme-amoledblack-text-color,
+  $theme-amoledblack-text-color,
+  darken($theme-amoledblack-text-color, 33%),
+  $theme-amoledblack-body-background-color,
+  $theme-amoledblack-subtext-color,
+  $theme-amoledblack-secondary-color,
+  $theme-amoledblack-body-background-color,
+  $theme-amoledblack-secondary-color
+);
+
+/* ----------------------------------
+
+  Include your new theme here as well as the settings component
+
+---------------------------------- */

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,13 +1,30 @@
 import '@testing-library/jest-dom/vitest';
-import { afterAll, afterEach, beforeAll } from 'vitest';
+import { afterAll, afterEach, beforeAll, vi } from 'vitest';
 import { cleanup } from '@testing-library/react';
 import { server } from './mocks/server';
+
+// jsdom does not implement matchMedia; provide a minimal default so components
+// that read the color-scheme preference can render. Individual tests may install
+// a controllable implementation.
+if (!window.matchMedia) {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+}
 
 beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
 
 afterEach(() => {
   cleanup();
   server.resetHandlers();
+  localStorage.clear();
 });
 
 afterAll(() => server.close());


### PR DESCRIPTION
## Summary
Ports Angular's `SettingsService` and SCSS theme system into React.

- **State** (`settings.service.ts` → `src/context/`): `SettingsProvider` holds a `Settings` object; `useSettings()` hook exposes it plus `toggleSettings`, `toggleOpenLinksInNewTab`, `setTheme`, `setFont`, `setSpacing`. Context split across `settingsContext.ts` / `SettingsProvider.tsx` / `useSettings.ts` for clean fast-refresh boundaries.
- **Persistence**: `theme`, `titleFontSize`, `listSpacing`, `openLinkInNewTab` persist to `localStorage` (same keys/JSON encoding as Angular). `showSettings` stays in memory only. Initial values are read from `localStorage` on mount.
- **System theme**: subscribes to `window.matchMedia('(prefers-color-scheme: dark)')`. On mount, a saved theme wins; otherwise it auto-selects `night`/`default` from the current preference (and persists it, matching the Angular `initTheme` → `dispatchEvent` → `setTheme` path). A live `change` listener keeps tracking system changes.

```ts
useEffect(() => {
  const media = matchMedia('(prefers-color-scheme: dark)');
  media.addEventListener('change', e => setTheme(e.matches ? 'night' : 'default'));
  const saved = localStorage.getItem('theme');
  saved ? applyTheme(saved) : setTheme(media.matches ? 'night' : 'default');
}, []);
```

- **Styles** (`shared/scss/*` + `styles.scss` → `src/styles/`): theme mixin + `default`/`night`/`amoledblack` includes copied verbatim (class names preserved). Only change: `$skull-size / 8` → `math.div(...)` for Dart Sass. Imported once via `main.tsx`.
- **Test harness**: added a jsdom `matchMedia` default and `localStorage.clear()` in `src/test/setup.ts`.
- **Tests**: system dark/light selection, saved-theme precedence, live system change, explicit `setTheme` persistence, `showSettings` non-persistence, `openLinkInNewTab`/`titleFontSize`/`listSpacing` persistence, initial read.

Note: build emits Dart Sass deprecation *warnings* (legacy `@import`, `darken()`) inherited from the original stylesheets — non-fatal; left as-is to preserve the theme system verbatim.

Verification: `npm test` (19 passing), `npm run build`, `npm run lint` all pass.

Link to Devin session: https://app.devin.ai/sessions/f5b5e0024ed64555ab5690d935d7c476
Requested by: @devanshi-gpta
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/495?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/495" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->