### PR TITLE
PR 4 — App shell + React Router v6 routing (with tests)

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -1,0 +1,24 @@
+@import "./styles/scss/media";
+@import "./styles/scss/theme_variables";
+
+.body-cover {
+  width: 100%;
+  z-index: 0;
+  position: fixed;
+  height: 100%;
+}
+
+.wrapper {
+  position: relative;
+  width: 85%;
+  min-height: 80px;
+  margin: 0 auto;
+  font-family: "HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
+  font-size: 15px;
+  height: 100%;
+  line-height: 1.3;
+
+   @media #{$mobile-only} {
+    width: 100%;
+  }
+}

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,10 +1,97 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import App from './App';
+import { SettingsProvider } from './context/SettingsProvider';
 
-describe('App', () => {
-  it('renders the app heading', () => {
-    render(<App />);
-    expect(screen.getByRole('heading', { name: /angular 2 hn/i })).toBeInTheDocument();
+function renderApp(initialEntries: string[]) {
+  return render(
+    <MemoryRouter initialEntries={initialEntries}>
+      <SettingsProvider>
+        <App />
+      </SettingsProvider>
+    </MemoryRouter>
+  );
+}
+
+describe('App shell + routing', () => {
+  afterEach(() => {
+    delete window.ga;
+  });
+
+  it('redirects / to /news/1', () => {
+    renderApp(['/']);
+    expect(screen.getByTestId('feed-page')).toHaveTextContent('news (page 1)');
+  });
+
+  it.each([
+    ['/news/1', 'news (page 1)'],
+    ['/newest/2', 'newest (page 2)'],
+    ['/show/3', 'show (page 3)'],
+    ['/ask/1', 'ask (page 1)'],
+    ['/jobs/1', 'jobs (page 1)'],
+  ])('renders the feed page for %s', (path, expected) => {
+    renderApp([path]);
+    expect(screen.getByTestId('feed-page')).toHaveTextContent(expected);
+  });
+
+  it('renders the item details route with its id', () => {
+    renderApp(['/item/8863']);
+    expect(screen.getByTestId('item-details-page')).toHaveTextContent('8863');
+  });
+
+  it('renders the user route with its id', () => {
+    renderApp(['/user/pg']);
+    expect(screen.getByTestId('user-page')).toHaveTextContent('pg');
+  });
+
+  it('renders header navigation links and footer', () => {
+    renderApp(['/news/1']);
+    expect(screen.getByRole('link', { name: 'new' })).toHaveAttribute('href', '/newest/1');
+    expect(screen.getByRole('link', { name: 'show' })).toHaveAttribute('href', '/show/1');
+    expect(screen.getByRole('link', { name: 'ask' })).toHaveAttribute('href', '/ask/1');
+    expect(screen.getByRole('link', { name: 'jobs' })).toHaveAttribute('href', '/jobs/1');
+    expect(screen.getByRole('link', { name: 'GitHub' })).toBeInTheDocument();
+  });
+
+  it('applies the current theme class on the root wrapper', () => {
+    localStorage.setItem('theme', 'amoledblack');
+    const { container } = renderApp(['/news/1']);
+    expect(container.querySelector('.amoledblack')).not.toBeNull();
+  });
+
+  it('navigates when a nav link is clicked', async () => {
+    renderApp(['/news/1']);
+    await userEvent.click(screen.getByRole('link', { name: 'jobs' }));
+    expect(screen.getByTestId('feed-page')).toHaveTextContent('jobs (page 1)');
+  });
+
+  describe('settings modal', () => {
+    it('opens and closes the settings modal from the header cog', async () => {
+      renderApp(['/news/1']);
+      expect(screen.queryByRole('heading', { name: 'Settings' })).not.toBeInTheDocument();
+
+      await userEvent.click(screen.getByAltText('Settings'));
+      expect(screen.getByRole('heading', { name: 'Settings' })).toBeInTheDocument();
+
+      await userEvent.click(screen.getByText('×'));
+      expect(screen.queryByRole('heading', { name: 'Settings' })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Google Analytics pageviews', () => {
+    it('fires a pageview on initial load and on navigation', async () => {
+      const ga = vi.fn();
+      window.ga = ga;
+      renderApp(['/news/1']);
+      expect(ga).toHaveBeenCalledWith('set', 'page', '/news/1');
+      expect(ga).toHaveBeenCalledWith('send', 'pageview');
+
+      ga.mockClear();
+      await userEvent.click(screen.getByRole('link', { name: 'ask' }));
+      expect(ga).toHaveBeenCalledWith('set', 'page', '/ask/1');
+      expect(ga).toHaveBeenCalledWith('send', 'pageview');
+    });
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,22 @@
+import { AppRoutes } from './AppRoutes';
+import { Header } from './components/core/Header';
+import { Footer } from './components/core/Footer';
+import { useSettings } from './context/useSettings';
+import { usePageViews } from './hooks/usePageViews';
+import './App.scss';
+
 export default function App() {
+  const { settings } = useSettings();
+  usePageViews();
+
   return (
-    <main>
-      <h1>Angular 2 HN</h1>
-      <p>React migration in progress.</p>
-    </main>
+    <div className={settings.theme}>
+      <div className="body-cover"></div>
+      <div className="wrapper">
+        <Header />
+        <AppRoutes />
+        <Footer />
+      </div>
+    </div>
   );
 }

--- a/src/AppRoutes.tsx
+++ b/src/AppRoutes.tsx
@@ -1,0 +1,19 @@
+import { Navigate, Route, Routes } from 'react-router-dom';
+import { FeedPage } from './pages/FeedPage';
+import { ItemDetailsPage } from './pages/ItemDetailsPage';
+import { UserPage } from './pages/UserPage';
+
+export function AppRoutes() {
+  return (
+    <Routes>
+      <Route path="/" element={<Navigate to="/news/1" replace />} />
+      <Route path="/news/:page" element={<FeedPage feedType="news" />} />
+      <Route path="/newest/:page" element={<FeedPage feedType="newest" />} />
+      <Route path="/show/:page" element={<FeedPage feedType="show" />} />
+      <Route path="/ask/:page" element={<FeedPage feedType="ask" />} />
+      <Route path="/jobs/:page" element={<FeedPage feedType="jobs" />} />
+      <Route path="/item/:id" element={<ItemDetailsPage />} />
+      <Route path="/user/:id" element={<UserPage />} />
+    </Routes>
+  );
+}

--- a/src/components/core/Footer.scss
+++ b/src/components/core/Footer.scss
@@ -1,0 +1,23 @@
+@import "../../styles/scss/media";
+@import "../../styles/scss/theme_variables";
+
+#footer {
+  position: relative;
+  padding: 10px;
+  height: 60px;
+  letter-spacing: 0.7px;
+  text-align: center;
+
+  a {
+  	font-weight: bold;
+  	text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  @media #{$mobile-only} {
+    display: none;
+  }
+}

--- a/src/components/core/Footer.tsx
+++ b/src/components/core/Footer.tsx
@@ -1,0 +1,14 @@
+import './Footer.scss';
+
+export function Footer() {
+  return (
+    <div id="footer">
+      <p>
+        Show this project some ❤ on{' '}
+        <a href="https://github.com/hdjirdeh/angular2-hn" target="_blank" rel="noopener noreferrer">
+          GitHub
+        </a>
+      </p>
+    </div>
+  );
+}

--- a/src/components/core/Header.scss
+++ b/src/components/core/Header.scss
@@ -1,0 +1,149 @@
+@import "../../styles/scss/media";
+@import "../../styles/scss/theme_variables";
+
+#header {
+  color: #fff;
+  padding: 6px 0;
+  line-height: 18px;
+  vertical-align: middle;
+  position: relative;
+  z-index: 1;
+  width: 100%;
+
+  @media #{$mobile-only} {
+    height: 50px;
+    position: fixed;
+    top: 0;
+  }
+
+  a {
+    display: inline;
+  }
+}
+
+.home-link {
+  width: 50px;
+  height: 66px;
+}
+
+.logo-inner {
+  width: 32px;
+  position: absolute;
+  left: 17px;
+  top: 18px;
+  z-index: -1;
+  height: 32px;
+  border-radius: 50%;
+
+  @media #{$mobile-only} {
+    left: 16px;
+    top: 12px;
+  }
+}
+
+.logo {
+  width: 50px;
+  padding: 3px 8px 0;
+
+  @media #{$mobile-only} {
+    width: 45px;
+    padding: 0 0 0 10px;
+  }
+}
+
+h1 {
+  font-weight: normal;
+  display: inline-block;
+  vertical-align:middle;
+  margin: 0;
+  font-size: 16px;
+
+  a {
+    color: #fff;
+    text-decoration: none;
+  }
+}
+
+.name {
+  margin-right: 30px;
+  margin-bottom: 2px;
+
+  @media #{$mobile-only} {
+    display: none;
+  }
+}
+
+.header-text {
+  position: absolute;
+  width: inherit;
+  height: 20px;
+  left: 10px;
+  top: 27px;
+  z-index: -1;
+
+  @media #{$mobile-only} {
+    top: 22px;
+  }
+}
+
+.left {
+  position: absolute;
+  left: 60px;
+  font-size: 16px;
+
+  @media #{$mobile-only} {
+    width: 100%;
+    left: 0;
+  }
+}
+
+.header-nav {
+  display: inline-block;
+  margin-left: 20px;
+
+  @media #{$mobile-only} {
+    margin-left: 60px;
+  }
+
+  a {
+    color: hsla(0,0%,100%,.9);
+    text-decoration: none;
+    margin: 0 5px;
+    letter-spacing: 1.8px;
+
+    &:hover {
+      color: #fff;
+    }
+  }
+
+  .active {
+    color: #fff;
+  }
+}
+
+.info {
+  position: absolute;
+  top: 0;
+  right: 20px;
+  height: 100%;
+
+  @media #{$mobile-only} {
+    right: 10px;
+  }
+
+  img {
+    opacity: 0.8;
+    width: 25px;
+    margin-top: 21.5px;
+    display: block;
+
+    &:hover {
+      opacity: 1;
+      cursor: pointer;
+    }
+
+    @media #{$mobile-only} {
+      margin-top: 15px;
+    }
+  }
+}

--- a/src/components/core/Header.tsx
+++ b/src/components/core/Header.tsx
@@ -1,0 +1,51 @@
+import { NavLink } from 'react-router-dom';
+import { useSettings } from '../../context/useSettings';
+import { Settings } from './Settings';
+import './Header.scss';
+
+export function Header() {
+  const { settings, toggleSettings } = useSettings();
+
+  const scrollTop = () => window.scrollTo(0, 0);
+
+  return (
+    <header>
+      <div id="header">
+        <NavLink to="/news/1" className="home-link" onClick={scrollTop}>
+          <div className="logo-inner"></div>
+          <img className="logo" src="assets/images/logo.svg" alt="Logo" />
+        </NavLink>
+        <div className="header-text">
+          <div className="left">
+            <span className="header-nav">
+              <NavLink to="/newest/1" onClick={scrollTop}>
+                new
+              </NavLink>
+              {' | '}
+              <NavLink to="/show/1" onClick={scrollTop}>
+                show
+              </NavLink>
+              {' | '}
+              <NavLink to="/ask/1" onClick={scrollTop}>
+                ask
+              </NavLink>
+              {' | '}
+              <NavLink to="/jobs/1" onClick={scrollTop}>
+                jobs
+              </NavLink>
+            </span>
+          </div>
+        </div>
+        <div className="info">
+          <img
+            className="settings"
+            src="assets/images/cog.svg"
+            alt="Settings"
+            onClick={toggleSettings}
+          />
+        </div>
+      </div>
+      {settings.showSettings && <Settings />}
+    </header>
+  );
+}

--- a/src/components/core/Settings.scss
+++ b/src/components/core/Settings.scss
@@ -1,0 +1,74 @@
+@import "../../styles/scss/media";
+@import "../../styles/scss/theme_variables";
+
+.overlay {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: rgba(0, 0, 0, 0.7);
+  opacity: 1;
+  z-index: 1;
+}
+
+.popup {
+  margin: 70px auto;
+  padding: 30px;
+  border-radius: 5px;
+  width: 30%;
+  position: relative;
+  h1 {
+    margin-top: 0;
+    margin-bottom: 0px;
+    color: #fff;
+    text-align: center;
+    letter-spacing: 1px;
+  }
+  h2 {
+    padding-top: 10px;
+  }
+  hr {
+    width: 40%;
+    margin-bottom: 20px;
+  }
+  .close {
+    position: absolute;
+    top: 12px;
+    right: 20px;
+    font-size: 30px;
+    font-weight: bold;
+    text-decoration: none;
+    color: rgba(255,255,255,0.8);
+    &:hover {
+      color: #fff;
+      cursor: pointer;
+    }
+  }
+  .content {
+    max-height: 30%;
+    color: #fff;
+    letter-spacing: 1px;
+    overflow: auto;
+  }
+  input[type=number] {
+      display: block;
+      width: 80%;
+      height: 20px;
+      margin-bottom: 15px;
+      border-radius: 5px;
+      padding: 2px;
+  }
+}
+
+.control-section {
+    margin-bottom: 15px;
+    padding-bottom: 15px;
+    border-bottom: 1px solid white;
+}
+
+@media screen and (max-width: 700px) {
+  .box, .popup {
+    width: 70%;
+  }
+}

--- a/src/components/core/Settings.tsx
+++ b/src/components/core/Settings.tsx
@@ -1,0 +1,98 @@
+import { useSettings } from '../../context/useSettings';
+import './Settings.scss';
+
+export function Settings() {
+  const { settings, toggleSettings, toggleOpenLinksInNewTab, setTheme, setFont, setSpacing } =
+    useSettings();
+
+  return (
+    <div id="popup1" className="overlay">
+      <div className="popup">
+        <h1>Settings</h1>
+        <hr />
+        <span className="close" onClick={toggleSettings}>
+          &times;
+        </span>
+        <div className="content">
+          <div className="control-section">
+            <h2>Links</h2>
+            <input
+              type="checkbox"
+              checked={settings.openLinkInNewTab}
+              onChange={toggleOpenLinksInNewTab}
+            />
+            Open links in a new tab
+          </div>
+          <div className="theme-controls">
+            <div className="control-section">
+              <h2>Select a theme</h2>
+              <div>
+                <label>
+                  <input
+                    name="theme"
+                    type="radio"
+                    value="default"
+                    checked={settings.theme === 'default'}
+                    onChange={() => setTheme('default')}
+                  />
+                  Default
+                </label>
+              </div>
+              <div>
+                <label>
+                  <input
+                    name="theme"
+                    type="radio"
+                    value="night"
+                    checked={settings.theme === 'night'}
+                    onChange={() => setTheme('night')}
+                  />
+                  Night
+                </label>
+              </div>
+              <div>
+                <label>
+                  <input
+                    name="theme"
+                    type="radio"
+                    value="amoledblack"
+                    checked={settings.theme === 'amoledblack'}
+                    onChange={() => setTheme('amoledblack')}
+                  />
+                  Black (AMOLED)
+                </label>
+              </div>
+            </div>
+            <div className="control-section">
+              <h2>Change Font</h2>
+              <div>
+                <label>
+                  Font size:
+                  <input
+                    min="1"
+                    defaultValue={settings.titleFontSize}
+                    name="theme"
+                    type="number"
+                    onChange={(e) => setFont(e.currentTarget.value)}
+                  />
+                </label>
+              </div>
+              <div>
+                <label>
+                  List spacing:
+                  <input
+                    min="0"
+                    defaultValue={settings.listSpacing}
+                    name="theme"
+                    type="number"
+                    onChange={(e) => setSpacing(e.currentTarget.value)}
+                  />
+                </label>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/usePageViews.ts
+++ b/src/hooks/usePageViews.ts
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+declare global {
+  interface Window {
+    ga?: (...args: unknown[]) => void;
+  }
+}
+
+/**
+ * Fires a Google Analytics pageview on every route change, mirroring the
+ * Angular `AppComponent` subscription to `NavigationEnd`.
+ */
+export function usePageViews(): void {
+  const location = useLocation();
+
+  useEffect(() => {
+    const url = `${location.pathname}${location.search}`;
+    if (typeof window.ga === 'function') {
+      window.ga('set', 'page', url);
+      window.ga('send', 'pageview');
+    }
+  }, [location]);
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,8 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
 import App from './App';
+import { SettingsProvider } from './context/SettingsProvider';
 import './styles/index.scss';
 
 const container = document.getElementById('root');
@@ -10,6 +12,10 @@ if (!container) {
 
 createRoot(container).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <SettingsProvider>
+        <App />
+      </SettingsProvider>
+    </BrowserRouter>
   </StrictMode>
 );

--- a/src/pages/FeedPage.tsx
+++ b/src/pages/FeedPage.tsx
@@ -1,0 +1,11 @@
+import { useParams } from 'react-router-dom';
+
+// Placeholder until the feed feature is ported (PR 5).
+export function FeedPage({ feedType }: { feedType: string }) {
+  const { page } = useParams();
+  return (
+    <div data-testid="feed-page">
+      Feed placeholder: {feedType} (page {page})
+    </div>
+  );
+}

--- a/src/pages/ItemDetailsPage.tsx
+++ b/src/pages/ItemDetailsPage.tsx
@@ -1,0 +1,7 @@
+import { useParams } from 'react-router-dom';
+
+// Placeholder until the item-details feature is ported (PR 6).
+export function ItemDetailsPage() {
+  const { id } = useParams();
+  return <div data-testid="item-details-page">Item placeholder: {id}</div>;
+}

--- a/src/pages/UserPage.tsx
+++ b/src/pages/UserPage.tsx
@@ -1,0 +1,7 @@
+import { useParams } from 'react-router-dom';
+
+// Placeholder until the user profile feature is ported (PR 7).
+export function UserPage() {
+  const { id } = useParams();
+  return <div data-testid="user-page">User placeholder: {id}</div>;
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -19,6 +19,9 @@ if (!window.matchMedia) {
   }));
 }
 
+// jsdom does not implement scrollTo; stub it so scroll-to-top handlers are safe.
+window.scrollTo = vi.fn() as unknown as typeof window.scrollTo;
+
 beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
 
 afterEach(() => {


### PR DESCRIPTION
## Summary
Wires the app together: root shell, header/footer/settings modal, and routing. Feature pages are placeholders (ported in PRs 5–7).

- **Shell** (`app.component.html` → `App.tsx`): root `<div className={settings.theme}>` wrapper + `.body-cover`/`.wrapper`, with `<Header/> <AppRoutes/> <Footer/>`. `main.tsx` now mounts `<BrowserRouter><SettingsProvider><App/></SettingsProvider></BrowserRouter>`.
- **Core components** (`components/core/`, matching the repo migration note): `Header` (logo → `/news/1`, nav `NavLink`s → `/{type}/1` with auto `active` class, cog toggles the settings modal, scroll-to-top on nav), `Footer`, and `Settings` modal (controlled inputs bound to `useSettings`: open-in-new-tab checkbox, theme radios, font-size/list-spacing numbers, close button).
- **Routing** (`app.routes.ts` → `AppRoutes.tsx`):

```tsx
<Route path="/" element={<Navigate to="/news/1" replace />} />
<Route path="/news/:page"   element={<FeedPage feedType="news" />} />   // + newest/show/ask/jobs
<Route path="/item/:id"     element={<ItemDetailsPage />} />
<Route path="/user/:id"     element={<UserPage />} />
```

- **Analytics** (`app.component.ts` → `usePageViews`): fires `ga('set','page',url)` + `ga('send','pageview')` on every location change (guards on `window.ga`).
- **Test setup**: added jsdom `scrollTo` stub. Integration tests cover the `/`→`/news/1` redirect, all feed/item/user routes, nav-link hrefs + click navigation, theme class on root, settings modal open/close, and GA pageview firing on load + navigation.

Verification: `npm test` (31 passing), `npm run build`, `npm run lint` all pass. (Non-fatal Sass `@import` deprecation warnings and React Router v7 future-flag warnings remain.)

Link to Devin session: https://app.devin.ai/sessions/f5b5e0024ed64555ab5690d935d7c476
Requested by: @devanshi-gpta
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/496?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/496" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->