### PR TITLE
PR 7 — User profile + shared components (with tests)

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -67,9 +67,14 @@ describe('App shell + routing', () => {
     expect((await screen.findAllByText('Deep item')).length).toBeGreaterThan(0);
   });
 
-  it('renders the user route with its id', () => {
+  it('renders the user route for the requested id', async () => {
+    server.use(
+      http.get(`${BASE_URL}/user/pg`, () =>
+        HttpResponse.json({ id: 'pg', karma: 155000, created: 'long ago', about: '' })
+      )
+    );
     renderApp(['/user/pg']);
-    expect(screen.getByTestId('user-page')).toHaveTextContent('pg');
+    expect((await screen.findAllByText('pg')).length).toBeGreaterThan(0);
   });
 
   it('renders header navigation links and footer', () => {

--- a/src/AppRoutes.tsx
+++ b/src/AppRoutes.tsx
@@ -1,7 +1,7 @@
 import { Navigate, Route, Routes } from 'react-router-dom';
 import { Feed } from './components/feeds/Feed';
 import { ItemDetails } from './components/item-details/ItemDetails';
-import { UserPage } from './pages/UserPage';
+import { UserProfile } from './components/user/UserProfile';
 
 export function AppRoutes() {
   return (
@@ -13,7 +13,7 @@ export function AppRoutes() {
       <Route path="/ask/:page" element={<Feed feedType="ask" />} />
       <Route path="/jobs/:page" element={<Feed feedType="jobs" />} />
       <Route path="/item/:id" element={<ItemDetails />} />
-      <Route path="/user/:id" element={<UserPage />} />
+      <Route path="/user/:id" element={<UserProfile />} />
     </Routes>
   );
 }

--- a/src/components/feeds/Feed.tsx
+++ b/src/components/feeds/Feed.tsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { fetchFeed } from '../../services/hackerNewsApi';
 import type { Story } from '../../types/story';
+import { ErrorMessage } from '../shared/ErrorMessage';
+import { Loader } from '../shared/Loader';
 import { Item } from './Item';
 import './Feed.scss';
 
@@ -40,12 +42,8 @@ export function Feed({ feedType }: { feedType: string }) {
 
   return (
     <div className="main-content">
-      {!items && !errorMessage && <div className="loader" data-testid="loader" />}
-      {!items && errorMessage !== '' && (
-        <div className="error-message" role="alert">
-          {errorMessage}
-        </div>
-      )}
+      {!items && !errorMessage && <Loader />}
+      {!items && errorMessage !== '' && <ErrorMessage message={errorMessage} />}
 
       {items && (
         <div>

--- a/src/components/item-details/ItemDetails.tsx
+++ b/src/components/item-details/ItemDetails.tsx
@@ -4,6 +4,8 @@ import { useSettings } from '../../context/useSettings';
 import { fetchItemContent } from '../../services/hackerNewsApi';
 import type { Story } from '../../types/story';
 import { formatCommentCount } from '../../utils/formatCommentCount';
+import { ErrorMessage } from '../shared/ErrorMessage';
+import { Loader } from '../shared/Loader';
 import { Comment } from './Comment';
 import './ItemDetails.scss';
 
@@ -44,12 +46,7 @@ export function ItemDetails() {
   if (!item) {
     return (
       <div className="main-content">
-        {!errorMessage && <div className="loader" data-testid="loader" />}
-        {errorMessage !== '' && (
-          <div className="error-message" role="alert">
-            {errorMessage}
-          </div>
-        )}
+        {errorMessage !== '' ? <ErrorMessage message={errorMessage} /> : <Loader />}
       </div>
     );
   }

--- a/src/components/shared/ErrorMessage.scss
+++ b/src/components/shared/ErrorMessage.scss
@@ -1,0 +1,116 @@
+@use "sass:math";
+@import "../../styles/scss/media";
+@import "../../styles/scss/theme_variables";
+
+.error-section {
+  height: 300px;
+  margin: 200px;
+
+  @media #{$mobile-only} {
+    height: 0;
+    display: block;
+    position: relative;
+    margin: 30vh 0;
+  }
+
+  p {
+    text-align: center;
+    padding: 0 25px;
+
+    &.strong {
+      margin-top: 25px;
+      font-weight: bold;
+    }
+  }
+
+  .skull {
+    width: $skull-size;
+    height: $skull-size;
+    position: relative;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    margin: auto;
+
+    .head {
+      width: 100%;
+      height: 75%;
+      border-radius: 15% / 20%;
+      position: absolute;
+      top: 0;
+      left: 0;
+      &:before, &:after {
+        content: "";
+        position: absolute;
+        border-radius: 50%;
+        width: 20%;
+        height: 30%;
+        bottom: 10%;
+      }
+      &:before {
+        left: 10%;
+      }
+      &:after {
+        right: 10%;
+      }
+      .crack {
+        width: 10%;
+        height: 10%;
+        position: absolute;
+        top: 0;
+        right: 25%;
+        transform: skew(-15deg);
+
+        &:before {
+          content: "";
+          position: absolute;
+          top: 100%;
+          left: math.div($skull-size, 15);
+          border-right: math.div($skull-size, 20) solid transparent;
+          border-left: math.div($skull-size, 40) solid transparent;
+        }
+      }
+    }
+    .mouth {
+      width: 40%;
+      height: 25%;
+      position: absolute;
+      top: 75%;
+      left: 30%;
+      border-radius: 0 0 math.div($skull-size, 10) math.div($skull-size, 10);
+      &:before {
+        content: "";
+        position: absolute;
+        width: 15%;
+        height: 50%;
+        border-radius: 50% / 30%;
+        left: 42.5%;
+        top: -25%;
+      }
+      .teeth {
+        position: absolute;
+        bottom: 0;
+        left: 45%;
+        width: 10%;
+        height: 50%;
+        margin-bottom: -5%;
+        border-radius: 50% / 20%;
+
+        &:before, &:after {
+          content: "";
+          position: absolute;
+          width: 100%;
+          height: 100%;
+          border-radius: 50% / 20%;
+        }
+        &:before {
+          left: -250%;
+        }
+        &:after {
+          right: -250%;
+        }
+      }
+    }
+  }
+}

--- a/src/components/shared/ErrorMessage.test.tsx
+++ b/src/components/shared/ErrorMessage.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ErrorMessage } from './ErrorMessage';
+
+describe('ErrorMessage', () => {
+  it('renders the provided message', () => {
+    render(<ErrorMessage message="Could not load news stories." />);
+    expect(screen.getByText('Could not load news stories.')).toBeInTheDocument();
+  });
+
+  it('exposes an alert role and offline hint', () => {
+    render(<ErrorMessage message="Boom" />);
+    expect(screen.getByRole('alert')).toHaveTextContent('Boom');
+    expect(screen.getByText(/offline viewing/)).toBeInTheDocument();
+  });
+});

--- a/src/components/shared/ErrorMessage.tsx
+++ b/src/components/shared/ErrorMessage.tsx
@@ -1,0 +1,21 @@
+import './ErrorMessage.scss';
+
+export function ErrorMessage({ message }: { message: string }) {
+  return (
+    <div className="error-section" role="alert">
+      <div className="skull">
+        <div className="head">
+          <div className="crack"></div>
+        </div>
+        <div className="mouth">
+          <div className="teeth"></div>
+        </div>
+      </div>
+      <p className="strong">{message}</p>
+      <p>
+        If you are offline viewing, you'll need to visit this page with a network connection first
+        before it can work offline.
+      </p>
+    </div>
+  );
+}

--- a/src/components/shared/Loader.scss
+++ b/src/components/shared/Loader.scss
@@ -1,0 +1,109 @@
+@import "../../styles/scss/media";
+@import "../../styles/scss/theme_variables";
+
+.loader {
+  -webkit-animation: load1 1s infinite ease-in-out;
+  animation: load1 1s infinite ease-in-out;
+  width: 1em;
+  height: 4em;
+  &:before, &:after {
+    -webkit-animation: load1 1s infinite ease-in-out;
+    animation: load1 1s infinite ease-in-out;
+    width: 1em;
+    height: 4em;
+  }
+  &:before, &:after {
+    position: absolute;
+    top: 0;
+    content: '';
+  }
+  &:before {
+    left: -1.5em;
+    -webkit-animation-delay: -0.32s;
+    animation-delay: -0.32s;
+  }
+}
+
+.loading-section {
+    height: 70px;
+    margin: 40px 0 40px 40px;
+
+  @media #{$mobile-only} {
+    display: block;
+    position: relative;
+    margin: 45vh 0;
+  }
+}
+
+.loader {
+  text-indent: -9999em;
+  margin: 20px 20px;
+  position: relative;
+  font-size: 11px;
+  -webkit-transform: translateZ(0);
+  -ms-transform: translateZ(0);
+  transform: translateZ(0);
+  -webkit-animation-delay: -0.16s;
+  animation-delay: -0.16s;
+  &:after {
+    left: 1.5em;
+  }
+
+  @media #{$mobile-only} {
+    margin: 20px auto;
+  }
+}
+
+@-webkit-keyframes load1 {
+  0%,
+    80%,
+    100% {
+    box-shadow: 0 0;
+    height: 2em;
+  }
+  40% {
+    box-shadow: 0 -2em;
+    height: 3em;
+  }
+}
+
+@keyframes load1 {
+  0%,
+    80%,
+    100% {
+    box-shadow: 0 0;
+    height: 2em;
+  }
+  40% {
+    box-shadow: 0 -2em;
+    height: 3em;
+  }
+}
+
+@media #{$mobile-only} {
+  @-webkit-keyframes load1 {
+    0%,
+      80%,
+      100% {
+      box-shadow: 0 0;
+      height: 4em;
+    }
+    40% {
+      box-shadow: 0 -2em;
+      height: 5em;
+    }
+  }
+
+  @keyframes load1 {
+    0%,
+      80%,
+      100% {
+      box-shadow: 0 0;
+      height: 3em;
+    }
+    40% {
+      box-shadow: 0 -2em;
+      height: 4em;
+    }
+  }
+}

--- a/src/components/shared/Loader.test.tsx
+++ b/src/components/shared/Loader.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Loader } from './Loader';
+
+describe('Loader', () => {
+  it('renders a loading indicator', () => {
+    render(<Loader />);
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
+});

--- a/src/components/shared/Loader.tsx
+++ b/src/components/shared/Loader.tsx
@@ -1,0 +1,9 @@
+import './Loader.scss';
+
+export function Loader() {
+  return (
+    <div className="loading-section">
+      <div className="loader">Loading...</div>
+    </div>
+  );
+}

--- a/src/components/user/UserProfile.scss
+++ b/src/components/user/UserProfile.scss
@@ -1,0 +1,89 @@
+@import "../../styles/scss/media";
+@import "../../styles/scss/theme_variables";
+
+.other-details pre {
+  white-space: pre-wrap;
+}
+
+.profile {
+  padding: 30px;
+}
+
+@media #{$mobile-only} {
+  .profile {
+    padding: 110px 15px 0 15px;
+  }
+  .title-block {
+    font-size: 15px;
+    text-align: center;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    margin: 0 75px;
+  }
+  .back-button {
+    position: absolute;
+    top: 52%;
+    width: 0.6rem;
+    height: 0.6rem;
+    background: transparent;
+    box-shadow: 0 0 0 lightgray;
+    transition: all 200ms ease;
+    left: 4%;
+    transform: translate3d(0, -50%, 0) rotate(-135deg);
+  }
+  .item-header {
+    padding-bottom: 10px;
+    background-color: #fff;
+    padding: 10px 0 10px 0;
+    position: fixed;
+    width: 100%;
+    left: 0;
+    top: 62px;
+    height: 20px;
+  }
+}
+
+@media #{$laptop-only} {
+  .mobile {
+    display: none;
+  }
+}
+
+.main-details {
+  .name {
+    font-weight: bold;
+    font-size: 32px;
+    letter-spacing: 2px;
+  }
+  .age {
+    font-weight: bold;
+    color: #696969;
+    padding-bottom: 0;
+  }
+  .right {
+    float: right;
+    font-weight: bold;
+    font-size: 32px;
+    letter-spacing: 2px;
+  }
+}
+
+@media #{$mobile-only} {
+  .main-details {
+    margin-top: 20px;
+    .name {
+      font-size: 18px;
+    }
+  }
+}
+
+@media #{$mobile-only} {
+  .main-details .right {
+    font-size: 18px;
+  }
+}
+
+.other-details {
+  word-wrap: break-word;
+}

--- a/src/components/user/UserProfile.test.tsx
+++ b/src/components/user/UserProfile.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+import { BASE_URL } from '../../services/hackerNewsApi';
+import { server } from '../../test/mocks/server';
+import { UserProfile } from './UserProfile';
+
+function renderUser(id: string, extraEntries: string[] = []) {
+  return render(
+    <MemoryRouter initialEntries={[...extraEntries, `/user/${id}`]} initialIndex={extraEntries.length}>
+      <Routes>
+        <Route path="/user/:id" element={<UserProfile />} />
+        <Route path="/news/:page" element={<div>news feed</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('UserProfile', () => {
+  it('renders id, karma, created and about HTML', async () => {
+    server.use(
+      http.get(`${BASE_URL}/user/pg`, () =>
+        HttpResponse.json({
+          id: 'pg',
+          karma: 155000,
+          created: 'April 12, 2007',
+          about: '<i>hacker</i>',
+        })
+      )
+    );
+
+    renderUser('pg');
+
+    expect((await screen.findAllByText('pg')).length).toBeGreaterThan(0);
+    expect(screen.getByText('155000 ★')).toBeInTheDocument();
+    expect(screen.getByText(/Created April 12, 2007/)).toBeInTheDocument();
+    expect(screen.getByText('hacker').tagName).toBe('I');
+  });
+
+  it('shows a loader before data resolves', () => {
+    server.use(
+      http.get(`${BASE_URL}/user/pg`, () => HttpResponse.json({ id: 'pg', karma: 1, created: 'x' }))
+    );
+    renderUser('pg');
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
+
+  it('shows an error message when the request fails', async () => {
+    server.use(http.get(`${BASE_URL}/user/ghost`, () => new HttpResponse(null, { status: 404 })));
+    renderUser('ghost');
+    expect(await screen.findByRole('alert')).toHaveTextContent('Could not load user ghost.');
+  });
+
+  it('navigates back when the back button is clicked', async () => {
+    server.use(
+      http.get(`${BASE_URL}/user/pg`, () => HttpResponse.json({ id: 'pg', karma: 1, created: 'x' }))
+    );
+
+    const { container } = renderUser('pg', ['/news/1']);
+    await screen.findAllByText('pg');
+
+    const backButton = container.querySelector('.back-button');
+    expect(backButton).not.toBeNull();
+    await userEvent.click(backButton as Element);
+
+    expect(await screen.findByText('news feed')).toBeInTheDocument();
+  });
+});

--- a/src/components/user/UserProfile.tsx
+++ b/src/components/user/UserProfile.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { fetchUser } from '../../services/hackerNewsApi';
+import type { User } from '../../types/user';
+import { ErrorMessage } from '../shared/ErrorMessage';
+import { Loader } from '../shared/Loader';
+import './UserProfile.scss';
+
+export function UserProfile() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+
+  const [user, setUser] = useState<User | undefined>(undefined);
+  const [errorMessage, setErrorMessage] = useState('');
+
+  useEffect(() => {
+    let ignore = false;
+    setUser(undefined);
+    setErrorMessage('');
+
+    fetchUser(id ?? '')
+      .then((result) => {
+        if (!ignore) {
+          setUser(result);
+        }
+      })
+      .catch(() => {
+        if (!ignore) {
+          setErrorMessage(`Could not load user ${id}.`);
+        }
+      });
+
+    return () => {
+      ignore = true;
+    };
+  }, [id]);
+
+  const goBack = () => navigate(-1);
+
+  if (!user) {
+    if (errorMessage !== '') {
+      return <ErrorMessage message={errorMessage} />;
+    }
+    return <Loader />;
+  }
+
+  return (
+    <div className="profile">
+      <div className="mobile item-header">
+        <p className="title-block">
+          <span className="back-button" onClick={goBack}></span>
+          Profile: {user.id}
+        </p>
+      </div>
+      <div className="main-details">
+        <span className="name">{user.id}</span>
+        <span className="right">{user.karma} ★</span>
+        <p className="age">Created {user.created}</p>
+      </div>
+      {user.about && (
+        <div className="other-details">
+          <p dangerouslySetInnerHTML={{ __html: user.about }} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/UserPage.tsx
+++ b/src/pages/UserPage.tsx
@@ -1,7 +1,0 @@
-import { useParams } from 'react-router-dom';
-
-// Placeholder until the user profile feature is ported (PR 7).
-export function UserPage() {
-  const { id } = useParams();
-  return <div data-testid="user-page">User placeholder: {id}</div>;
-}


### PR DESCRIPTION
## Summary
Ports the user profile page and the shared `Loader`/`ErrorMessage` components, and swaps the feed/item-details inline loading/error markup over to them.

- **`UserProfile`** (`components/user/UserProfile.tsx`, ports `user/*`): fetches `fetchUser(id)` on `id` change (stale-response guard). Renders id, `karma ★`, `Created {created}`, and `about` HTML via `dangerouslySetInnerHTML` (only when present). Back button uses `useNavigate()(-1)`. Shows `<Loader/>` while loading and `<ErrorMessage message="Could not load user {id}." />` on failure.
- **`Loader`** (`components/shared/`, ports `shared/components/loader`): the animated "Loading..." indicator.
- **`ErrorMessage`** (`components/shared/`, ports `shared/components/error-message`): takes a `message` prop, renders the skull markup + offline hint. Root carries `role="alert"` for accessibility/testability. SCSS uses `math.div` for the skull dimensions.
- **Refactor**: `Feed` and `ItemDetails` now render the shared `Loader`/`ErrorMessage` instead of the temporary inline placeholders from PRs 5–6.

Tests: user rendering (id/karma/created/about HTML), loader-before-data, error state, back navigation; `Loader` and `ErrorMessage` unit tests. App user-route test updated to render the real profile via MSW.

Verification: `npm test` (64 passing), `npm run build`, `npm run lint` all pass.

Link to Devin session: https://app.devin.ai/sessions/f5b5e0024ed64555ab5690d935d7c476
Requested by: @devanshi-gpta
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/499?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/499" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->