### PR TITLE
Phase 2a: port shared models

### DIFF
--- a/react/src/models/comment.ts
+++ b/react/src/models/comment.ts
@@ -1,0 +1,10 @@
+export interface Comment {
+    id: number;
+    level: number;
+    user: string;
+    time: number;
+    time_ago: string;
+    content: string;
+    deleted: boolean;
+    comments: Comment[];
+}

--- a/react/src/models/feed-type.type.ts
+++ b/react/src/models/feed-type.type.ts
@@ -1,0 +1,3 @@
+export type FeedType = 'poll' | 'story' | 'job';
+
+export type FeedRoute = 'news' | 'newest' | 'show' | 'ask' | 'jobs';

--- a/react/src/models/index.ts
+++ b/react/src/models/index.ts
@@ -1,0 +1,6 @@
+export type { Comment } from './comment';
+export type { FeedType, FeedRoute } from './feed-type.type';
+export type { PollResult } from './poll-result';
+export type { Settings } from './settings';
+export type { Story } from './story';
+export type { User } from './user';

--- a/react/src/models/poll-result.ts
+++ b/react/src/models/poll-result.ts
@@ -1,0 +1,4 @@
+export interface PollResult {
+    points: number;
+    content: string;
+}

--- a/react/src/models/settings.ts
+++ b/react/src/models/settings.ts
@@ -1,0 +1,7 @@
+export interface Settings {
+    showSettings: boolean;
+    openLinkInNewTab: boolean;
+    theme: string;
+    titleFontSize: string;
+    listSpacing: string;
+}

--- a/react/src/models/story.ts
+++ b/react/src/models/story.ts
@@ -1,0 +1,21 @@
+import type { Comment } from './comment';
+import type { FeedType } from './feed-type.type';
+import type { PollResult } from './poll-result';
+
+export interface Story {
+    id: number;
+    title: string;
+    points: number;
+    user: string;
+    time: number;
+    time_ago: number;
+    type: FeedType;
+    url: string;
+    domain: string;
+    comments: Comment[];
+    comments_count: number;
+    poll: PollResult[];
+    poll_votes_count: number;
+    deleted: boolean;
+    dead: boolean;
+}

--- a/react/src/models/user.ts
+++ b/react/src/models/user.ts
@@ -1,0 +1,8 @@
+export interface User {
+    id: string;
+    crated_time: number;
+    created: string;
+    karma: number;
+    avg: number;
+    about: string;
+}


### PR DESCRIPTION
## Summary
Ports all Angular shared models from `src/app/shared/models/` into pure-type files under `react/src/models/`:

- `Comment`, `PollResult`, `Settings`, `Story`, `User` converted from `export class` to `export interface`, keeping field names/types verbatim (including quirks like `User.crated_time` and `Story.time_ago: number`).
- `feed-type.type.ts` keeps `export type FeedType = 'poll' | 'story' | 'job';` and adds `export type FeedRoute = 'news' | 'newest' | 'show' | 'ask' | 'jobs';` for route feed types.
- `react/src/models/index.ts` re-exports everything via `export type`.

No runtime code; type-only imports used in `story.ts`. `npm run lint`, `npm run typecheck`, and `npm run build` pass in `react/`.

Link to Devin session: https://app.devin.ai/sessions/9feb8ce4973e4ca3ba88807a29bf7bef
Requested by: @eashansinha
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| 🟢 Reviewed | [`1d69eb4`](https://github.com/cog-gtm/angular2-hn/pull/503/commits/1d69eb4bae9ed8699137d3a66b935017ae70f37f) |

<a href="https://staging.itsdev.in/review/cog-gtm/angular2-hn/pull/503" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->