### PR TITLE
Phase 3a: HackerNews API service

### DIFF
--- a/react/src/api/hackernews.test.ts
+++ b/react/src/api/hackernews.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fetchFeed, fetchItemContent, fetchPollContent, fetchUser } from './hackernews';
+import type { PollResult, Story } from '../models';
+
+const BASE_URL = 'https://node-hnapi.herokuapp.com';
+
+function jsonResponse(data: unknown): Response {
+    return {
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(data),
+    } as Response;
+}
+
+function errorResponse(status: number): Response {
+    return {
+        ok: false,
+        status,
+        json: () => Promise.reject(new Error('should not parse')),
+    } as Response;
+}
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+    vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    fetchMock.mockReset();
+});
+
+describe('fetchFeed', () => {
+    it('fetches the feed for the given type and page', async () => {
+        const stories = [{ id: 1 }, { id: 2 }] as Story[];
+        fetchMock.mockResolvedValueOnce(jsonResponse(stories));
+
+        const result = await fetchFeed('news', 2);
+
+        expect(fetchMock).toHaveBeenCalledWith(`${BASE_URL}/news?page=2`);
+        expect(result).toEqual(stories);
+    });
+
+    it('throws on non-ok responses', async () => {
+        fetchMock.mockResolvedValueOnce(errorResponse(500));
+
+        await expect(fetchFeed('news', 1)).rejects.toThrow('500');
+    });
+});
+
+describe('fetchItemContent', () => {
+    it('fetches a story by id', async () => {
+        const story = { id: 42, type: 'link' } as unknown as Story;
+        fetchMock.mockResolvedValueOnce(jsonResponse(story));
+
+        const result = await fetchItemContent(42);
+
+        expect(fetchMock).toHaveBeenCalledWith(`${BASE_URL}/item/42`);
+        expect(result).toEqual(story);
+    });
+
+    it('resolves poll options and totals the votes for polls', async () => {
+        const story = {
+            id: 100,
+            type: 'poll',
+            poll: [{}, {}] as PollResult[],
+        } as unknown as Story;
+        const option1: PollResult = { points: 3, content: 'a' };
+        const option2: PollResult = { points: 5, content: 'b' };
+        fetchMock
+            .mockResolvedValueOnce(jsonResponse(story))
+            .mockResolvedValueOnce(jsonResponse(option1))
+            .mockResolvedValueOnce(jsonResponse(option2));
+
+        const result = await fetchItemContent(100);
+
+        expect(fetchMock).toHaveBeenNthCalledWith(2, `${BASE_URL}/item/101`);
+        expect(fetchMock).toHaveBeenNthCalledWith(3, `${BASE_URL}/item/102`);
+        expect(result.poll).toEqual([option1, option2]);
+        expect(result.poll_votes_count).toBe(8);
+    });
+});
+
+describe('fetchPollContent', () => {
+    it('fetches a poll option by id', async () => {
+        const option: PollResult = { points: 7, content: 'c' };
+        fetchMock.mockResolvedValueOnce(jsonResponse(option));
+
+        const result = await fetchPollContent(101);
+
+        expect(fetchMock).toHaveBeenCalledWith(`${BASE_URL}/item/101`);
+        expect(result).toEqual(option);
+    });
+});
+
+describe('fetchUser', () => {
+    it('fetches a user by id', async () => {
+        const user = { id: 'pg' };
+        fetchMock.mockResolvedValueOnce(jsonResponse(user));
+
+        const result = await fetchUser('pg');
+
+        expect(fetchMock).toHaveBeenCalledWith(`${BASE_URL}/user/pg`);
+        expect(result).toEqual(user);
+    });
+
+    it('throws on non-ok responses', async () => {
+        fetchMock.mockResolvedValueOnce(errorResponse(404));
+
+        await expect(fetchUser('nope')).rejects.toThrow('404');
+    });
+});

--- a/react/src/api/hackernews.ts
+++ b/react/src/api/hackernews.ts
@@ -1,0 +1,38 @@
+import type { PollResult, Story, User } from '../models';
+
+const BASE_URL = 'https://node-hnapi.herokuapp.com';
+
+async function get<T>(url: string): Promise<T> {
+    const res = await fetch(url);
+    if (!res.ok) {
+        throw new Error(`Request to ${url} failed with status ${res.status}`);
+    }
+    return res.json() as Promise<T>;
+}
+
+export async function fetchFeed(feedType: string, page: number): Promise<Story[]> {
+    return get<Story[]>(`${BASE_URL}/${feedType}?page=${page}`);
+}
+
+export async function fetchItemContent(id: number): Promise<Story> {
+    const story = await get<Story>(`${BASE_URL}/item/${id}`);
+    if (story.type === 'poll') {
+        const pollResults = await Promise.all(
+            story.poll.map((_, index) => fetchPollContent(story.id + index + 1))
+        );
+        story.poll_votes_count = 0;
+        pollResults.forEach((pollResult, index) => {
+            story.poll[index] = pollResult;
+            story.poll_votes_count += pollResult.points;
+        });
+    }
+    return story;
+}
+
+export async function fetchPollContent(id: number): Promise<PollResult> {
+    return get<PollResult>(`${BASE_URL}/item/${id}`);
+}
+
+export async function fetchUser(id: string): Promise<User> {
+    return get<User>(`${BASE_URL}/user/${id}`);
+}


### PR DESCRIPTION
## Summary
Ports `src/app/shared/services/hackernews-api.service.ts` to `react/src/api/hackernews.ts` as plain async functions over native `fetch`, dropping the RxJS Observable/`lazyFetch` wrapper:

- `fetchFeed(feedType, page)`, `fetchItemContent(id)`, `fetchPollContent(id)`, `fetchUser(id)` — all via a private `get<T>(url)` helper that throws `Error` on non-ok responses and parses JSON otherwise.
- Poll handling in `fetchItemContent`: for `story.type === 'poll'`, poll options are fetched with `Promise.all(fetchPollContent(story.id + i))` for i in 1..poll.length, assigned into `story.poll[i - 1]`, and `story.poll_votes_count` is set to the sum of option `points`. Unlike the Angular version's fire-and-forget subscriptions, these are awaited before returning.

Adds vitest coverage in `react/src/api/hackernews.test.ts` (mocked `fetch`; URLs, poll aggregation, non-ok error paths).

Lint, typecheck, tests, and build all pass in `react/`.

Link to Devin session: https://app.devin.ai/sessions/40d83b261ac34225954712a6f98c02ae
Requested by: @eashansinha
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| 🟢 Reviewed | [`7d3765c`](https://github.com/cog-gtm/angular2-hn/pull/505/commits/7d3765c6c5425275b2e7a227f5bcdf2635af7c55) |

<a href="https://staging.itsdev.in/review/cog-gtm/angular2-hn/pull/505" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->