### PR TITLE
Add saved stories, sepia theme, and design polish

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -34,6 +34,11 @@ const routes: Routes = [
     children: feedRoutes,
     data: {feedType: 'jobs'}
   },
+  {
+    path: 'saved',
+    children: feedRoutes,
+    data: {feedType: 'saved'}
+  },
   {path: 'item', loadChildren: () => import('./item-details/item-details.module').then(m => m.ItemDetailsModule)},
   {path: 'user', loadChildren: () => import('./user/user.module').then(m => m.UserModule)}
 ];

--- a/src/app/core/header/header.component.html
+++ b/src/app/core/header/header.component.html
@@ -14,6 +14,8 @@
             <a routerLink="/ask/1" routerLinkActive="active" (click)="scrollTop()">ask</a>
               |
             <a routerLink="/jobs/1" routerLinkActive="active" (click)="scrollTop()">jobs</a>
+              |
+            <a routerLink="/saved/1" routerLinkActive="active" (click)="scrollTop()">saved</a>
           </span>
         </div>
       </div>

--- a/src/app/core/header/header.component.scss
+++ b/src/app/core/header/header.component.scss
@@ -111,13 +111,23 @@ h1 {
     margin: 0 5px;
     letter-spacing: 1.8px;
 
+    @media #{$mobile-only} {
+      margin: 0 2px;
+      letter-spacing: 1px;
+    }
+    padding-bottom: 2px;
+    border-bottom: 2px solid transparent;
+    transition: border-color 0.2s ease;
+
     &:hover {
       color: #fff;
+      border-bottom-color: hsla(0,0%,100%,.5);
     }
   }
 
   .active {
     color: #fff;
+    border-bottom-color: #fff;
   }
 }
 

--- a/src/app/core/settings/settings.component.html
+++ b/src/app/core/settings/settings.component.html
@@ -39,6 +39,17 @@
                     </div>
                     <div>
                         <label>
+                        <input #sepia 
+                            name="theme" 
+                            type="radio" 
+                            value="sepia" 
+                            [checked]="settings.theme === sepia.value"
+                            (click)="selectTheme(sepia.value)" />
+                            Sepia
+                        </label>
+                    </div>
+                    <div>
+                        <label>
                         <input 
                             #amoledblack 
                             name="theme" 

--- a/src/app/core/settings/settings.component.scss
+++ b/src/app/core/settings/settings.component.scss
@@ -15,7 +15,8 @@
 .popup {
   margin: 70px auto;
   padding: 30px;
-  border-radius: 5px;
+  border-radius: 10px;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.4);
   width: 30%;
   position: relative;
   h1 {

--- a/src/app/feeds/feed/feed.component.html
+++ b/src/app/feeds/feed/feed.component.html
@@ -3,15 +3,15 @@
   <app-error-message [message]="errorMessage" *ngIf="!items && errorMessage !==''"></app-error-message>
 
   <div *ngIf="items">
-    <p class="job-header empty-saved" *ngIf="feedType === 'saved' && items.length === 0">
+    <p class="job-header empty-saved" *ngIf="isSavedEmpty">
       You haven't saved any stories yet. Click “save” on a story to keep it here.
     </p>
     <p class="job-header" *ngIf="feedType === 'jobs'">
       These are jobs at startups that were funded by Y Combinator.
       You can also get a job at a YC startup through <a href="https://triplebyte.com/?ref=yc_jobs">Triplebyte</a>.
     </p>
-    <ol *ngIf="feedType !== 'new'" [class.list-margin]="feedType !== 'jobs' && !(feedType === 'saved' && items.length === 0)" start="{{ listStart }}">
-      <li *ngFor="let item of items" class="post">
+    <ol *ngIf="feedType !== 'new'" [class.list-margin]="feedType !== 'jobs' && !isSavedEmpty" start="{{ listStart }}">
+      <li *ngFor="let item of displayItems" class="post">
         <item class="item-block" [item]="item"></item>
       </li>
     </ol>

--- a/src/app/feeds/feed/feed.component.html
+++ b/src/app/feeds/feed/feed.component.html
@@ -3,11 +3,14 @@
   <app-error-message [message]="errorMessage" *ngIf="!items && errorMessage !==''"></app-error-message>
 
   <div *ngIf="items">
+    <p class="job-header empty-saved" *ngIf="feedType === 'saved' && items.length === 0">
+      You haven't saved any stories yet. Click “save” on a story to keep it here.
+    </p>
     <p class="job-header" *ngIf="feedType === 'jobs'">
       These are jobs at startups that were funded by Y Combinator.
       You can also get a job at a YC startup through <a href="https://triplebyte.com/?ref=yc_jobs">Triplebyte</a>.
     </p>
-    <ol *ngIf="feedType !== 'new'" [class.list-margin]="feedType !== 'jobs'" start="{{ listStart }}">
+    <ol *ngIf="feedType !== 'new'" [class.list-margin]="feedType !== 'jobs' && !(feedType === 'saved' && items.length === 0)" start="{{ listStart }}">
       <li *ngFor="let item of items" class="post">
         <item class="item-block" [item]="item"></item>
       </li>
@@ -16,7 +19,7 @@
       <a *ngIf="listStart !== 1" [routerLink]="['/' + feedType, pageNum - 1]" routerLinkActive="active" class="prev">
         ‹ Prev
       </a>
-      <a *ngIf="items.length === 30" [routerLink]="['/' + feedType, pageNum + 1]" routerLinkActive="active" class="more">
+      <a *ngIf="hasMore" [routerLink]="['/' + feedType, pageNum + 1]" routerLinkActive="active" class="more">
         More ›
       </a>
     </div>

--- a/src/app/feeds/feed/feed.component.scss
+++ b/src/app/feeds/feed/feed.component.scss
@@ -45,9 +45,14 @@ ol {
 }
 
 .post {
-  padding: 10px 0 10px 5px;
+  padding: 10px 5px;
   transition: background-color 0.2s ease;
-  border-bottom: 1px solid #CECECB;
+  border-bottom: 1px solid rgba(128, 128, 128, 0.25);
+  border-radius: 4px;
+
+  &:hover {
+    background-color: rgba(128, 128, 128, 0.08);
+  }
 
   .itemNum {
     color: #696969;
@@ -67,9 +72,20 @@ ol {
 .nav {
   padding: 10px 40px;
   margin-top: 10px;
-  font-size: 17px;
+  font-size: 15px;
 
   a {
+    display: inline-block;
+    padding: 6px 16px;
+    border: 1px solid currentColor;
+    border-radius: 20px;
+    transition: background-color 0.2s ease;
+
+    &:hover {
+      text-decoration: none;
+      background-color: rgba(128, 128, 128, 0.12);
+    }
+
     @media #{$mobile-only} {
       text-decoration: none;
     }
@@ -83,11 +99,11 @@ ol {
   }
 
   .prev {
-    padding-right: 20px;
+    margin-right: 20px;
 
     @media #{$mobile-only} {
       float: left;
-      padding-right: 0;
+      margin-right: 0;
     }
   }
 

--- a/src/app/feeds/feed/feed.component.ts
+++ b/src/app/feeds/feed/feed.component.ts
@@ -4,6 +4,7 @@ import { Subscription } from 'rxjs';
 import { ActivatedRoute } from '@angular/router';
 
 import { HackerNewsAPIService } from '../../shared/services/hackernews-api.service';
+import { BookmarksService } from '../../shared/services/bookmarks.service';
 import { Story } from '../../shared/models/story';
 
 @Component({
@@ -19,10 +20,12 @@ export class FeedComponent implements OnInit {
   feedType: string;
   pageNum: number;
   listStart: number;
+  hasMore = false;
   errorMessage = '';
 
   constructor(
     private _hackerNewsAPIService: HackerNewsAPIService,
+    private _bookmarksService: BookmarksService,
     private route: ActivatedRoute
   ) { }
 
@@ -35,9 +38,19 @@ export class FeedComponent implements OnInit {
 
     this.pageSub = this.route.params.subscribe(params => {
       this.pageNum = params['page'] ? +params['page'] : 1;
+      if (this.feedType === 'saved') {
+        this.items = this._bookmarksService.getPage(this.pageNum);
+        this.hasMore = this._bookmarksService.savedStories.length > this.pageNum * 30;
+        this.listStart = ((this.pageNum - 1) * 30) + 1;
+        window.scrollTo(0, 0);
+        return;
+      }
       this._hackerNewsAPIService.fetchFeed(this.feedType, this.pageNum)
         .subscribe(
-          items => this.items = items,
+          items => {
+            this.items = items;
+            this.hasMore = items.length === 30;
+          },
           error => this.errorMessage = 'Could not load ' + this.feedType + ' stories.',
           () => {
             this.listStart = ((this.pageNum - 1) * 30) + 1;

--- a/src/app/feeds/feed/feed.component.ts
+++ b/src/app/feeds/feed/feed.component.ts
@@ -20,7 +20,6 @@ export class FeedComponent implements OnInit {
   feedType: string;
   pageNum: number;
   listStart: number;
-  hasMore = false;
   errorMessage = '';
 
   constructor(
@@ -40,17 +39,13 @@ export class FeedComponent implements OnInit {
       this.pageNum = params['page'] ? +params['page'] : 1;
       if (this.feedType === 'saved') {
         this.items = this._bookmarksService.getPage(this.pageNum);
-        this.hasMore = this._bookmarksService.savedStories.length > this.pageNum * 30;
         this.listStart = ((this.pageNum - 1) * 30) + 1;
         window.scrollTo(0, 0);
         return;
       }
       this._hackerNewsAPIService.fetchFeed(this.feedType, this.pageNum)
         .subscribe(
-          items => {
-            this.items = items;
-            this.hasMore = items.length === 30;
-          },
+          items => this.items = items,
           error => this.errorMessage = 'Could not load ' + this.feedType + ' stories.',
           () => {
             this.listStart = ((this.pageNum - 1) * 30) + 1;
@@ -58,5 +53,20 @@ export class FeedComponent implements OnInit {
           }
         );
     });
+  }
+
+  get displayItems(): Story[] {
+    return this.feedType === 'saved' ? this._bookmarksService.getPage(this.pageNum) : this.items;
+  }
+
+  get isSavedEmpty(): boolean {
+    return this.feedType === 'saved' && this._bookmarksService.savedStories.length === 0;
+  }
+
+  get hasMore(): boolean {
+    if (this.feedType === 'saved') {
+      return this._bookmarksService.savedStories.length > this.pageNum * 30;
+    }
+    return !!this.items && this.items.length === 30;
   }
 }

--- a/src/app/feeds/item/item.component.html
+++ b/src/app/feeds/item/item.component.html
@@ -20,6 +20,9 @@
     <a [routerLink]="['/item', item.id]" routerLinkActive="active" class="comment-number" *ngIf="item.type !== 'job'"> •
       {{item.comments_count | comment }}
     </a>
+    <a class="save-link" *ngIf="item.type !== 'job'" [class.saved]="isSaved" (click)="toggleSave()"> •
+      {{ isSaved ? 'unsave' : 'save' }}
+    </a>
     </div>
   </div>
   <div class="subtext-laptop">
@@ -32,6 +35,9 @@
       <span *ngIf="item.type !== 'job'"> |
         <a [routerLink]="['/item', item.id]" routerLinkActive="active">
           {{item.comments_count | comment }}
+        </a> |
+        <a class="save-link" [class.saved]="isSaved" (click)="toggleSave()">
+          {{ isSaved ? 'unsave' : 'save' }}
         </a>
       </span>
     </span>

--- a/src/app/feeds/item/item.component.scss
+++ b/src/app/feeds/item/item.component.scss
@@ -58,6 +58,14 @@ p {
     }
   }
 
+  .save-link {
+    cursor: pointer;
+
+    &.saved {
+      font-weight: bold;
+    }
+  }
+
   .domain {
     color: #696969;
     letter-spacing: 0.5px;

--- a/src/app/feeds/item/item.component.ts
+++ b/src/app/feeds/item/item.component.ts
@@ -3,6 +3,7 @@ import { Story } from '../../shared/models/story';
 
 import { SettingsService } from '../../shared/services/settings.service';
 import { Settings } from '../../shared/models/settings';
+import { BookmarksService } from '../../shared/services/bookmarks.service';
 
 @Component({
   selector: 'item',
@@ -13,7 +14,10 @@ export class ItemComponent implements OnInit {
   @Input() item: Story;
   settings: Settings;
 
-  constructor(private _settingsService: SettingsService) {
+  constructor(
+    private _settingsService: SettingsService,
+    private _bookmarksService: BookmarksService
+  ) {
     this.settings = this._settingsService.settings;
   }
 
@@ -21,6 +25,14 @@ export class ItemComponent implements OnInit {
 
   get hasUrl(): boolean {
     return this.item.url.indexOf('http') === 0;
+  }
+
+  get isSaved(): boolean {
+    return this._bookmarksService.isSaved(this.item.id);
+  }
+
+  toggleSave() {
+    this._bookmarksService.toggle(this.item);
   }
 
 }

--- a/src/app/shared/scss/_theme_variables.scss
+++ b/src/app/shared/scss/_theme_variables.scss
@@ -30,6 +30,19 @@ $theme-night-logo-inner: $theme-night-header-background-color;
 // Night theme extras
 $theme-night-border: 2px solid #00c0ff;
 
+// Sepia theme colors
+$theme-sepia-body-background-color: #e9dfc9;
+$theme-sepia-wrapper-background-color: #f4ecd8;
+$theme-sepia-wrapper-mobile-background-color: #f4ecd8;
+$theme-sepia-text-color: #433422;
+$theme-sepia-subtext-color: #8a7355;
+$theme-sepia-secondary-color: #a0522d;
+$theme-sepia-header-background-color: #8f4f2a;
+$theme-sepia-logo-inner: #f4ecd8;
+
+// Sepia theme extras
+$theme-sepia-border: 2px solid #8f4f2a;
+
 // Black theme colors
 $theme-amoledblack-body-background-color: #000;
 $theme-amoledblack-text-color: rgba(255, 255, 255, 0.75);

--- a/src/app/shared/scss/_themes.scss
+++ b/src/app/shared/scss/_themes.scss
@@ -224,6 +224,21 @@
 );
 
 @include theme(
+  sepia,
+  $theme-sepia-body-background-color,
+  $theme-sepia-wrapper-background-color,
+  $theme-sepia-wrapper-mobile-background-color,
+  $theme-sepia-text-color,
+  $theme-sepia-text-color,
+  $theme-sepia-subtext-color,
+  $theme-sepia-header-background-color,
+  $theme-sepia-subtext-color,
+  $theme-sepia-secondary-color,
+  $theme-sepia-logo-inner,
+  $theme-sepia-border
+);
+
+@include theme(
   amoledblack,
   $theme-amoledblack-body-background-color,
   $theme-amoledblack-body-background-color,

--- a/src/app/shared/services/bookmarks.service.spec.ts
+++ b/src/app/shared/services/bookmarks.service.spec.ts
@@ -68,4 +68,13 @@ describe('BookmarksService', () => {
     expect(service.getPage(2).length).toBe(5);
     expect(service.getPage(1, 10).length).toBe(10);
   });
+
+  it('should return a stable array reference for repeated getPage calls', () => {
+    service.toggle(makeStory(1, 'First'));
+    expect(service.getPage(1)).toBe(service.getPage(1));
+    const before = service.getPage(1);
+    service.toggle(makeStory(2, 'Second'));
+    expect(service.getPage(1)).not.toBe(before);
+    expect(service.getPage(1)[0].id).toBe(2);
+  });
 });

--- a/src/app/shared/services/bookmarks.service.spec.ts
+++ b/src/app/shared/services/bookmarks.service.spec.ts
@@ -53,6 +53,13 @@ describe('BookmarksService', () => {
     expect(restored.savedStories.length).toBe(0);
   });
 
+  it('should recover from valid JSON that is not an array', () => {
+    localStorage.setItem('savedStories', '{"id":1}');
+    const restored = new BookmarksService();
+    expect(restored.savedStories.length).toBe(0);
+    expect(restored.isSaved(1)).toBe(false);
+  });
+
   it('should paginate saved stories', () => {
     for (let i = 1; i <= 35; i++) {
       service.toggle(makeStory(i, `Story ${i}`));

--- a/src/app/shared/services/bookmarks.service.spec.ts
+++ b/src/app/shared/services/bookmarks.service.spec.ts
@@ -1,0 +1,64 @@
+import { BookmarksService } from './bookmarks.service';
+import { Story } from '../models/story';
+
+function makeStory(id: number, title: string): Story {
+  const story = new Story();
+  story.id = id;
+  story.title = title;
+  return story;
+}
+
+describe('BookmarksService', () => {
+  let service: BookmarksService;
+
+  beforeEach(() => {
+    localStorage.removeItem('savedStories');
+    service = new BookmarksService();
+  });
+
+  it('should start with no saved stories', () => {
+    expect(service.savedStories.length).toBe(0);
+    expect(service.isSaved(1)).toBe(false);
+  });
+
+  it('should save a story on toggle', () => {
+    service.toggle(makeStory(1, 'First'));
+    expect(service.isSaved(1)).toBe(true);
+    expect(service.savedStories.length).toBe(1);
+  });
+
+  it('should unsave a saved story on second toggle', () => {
+    const story = makeStory(1, 'First');
+    service.toggle(story);
+    service.toggle(story);
+    expect(service.isSaved(1)).toBe(false);
+    expect(service.savedStories.length).toBe(0);
+  });
+
+  it('should put the most recently saved story first', () => {
+    service.toggle(makeStory(1, 'First'));
+    service.toggle(makeStory(2, 'Second'));
+    expect(service.savedStories[0].id).toBe(2);
+  });
+
+  it('should persist saved stories to localStorage', () => {
+    service.toggle(makeStory(1, 'First'));
+    const restored = new BookmarksService();
+    expect(restored.isSaved(1)).toBe(true);
+  });
+
+  it('should recover from corrupt localStorage data', () => {
+    localStorage.setItem('savedStories', 'not-json');
+    const restored = new BookmarksService();
+    expect(restored.savedStories.length).toBe(0);
+  });
+
+  it('should paginate saved stories', () => {
+    for (let i = 1; i <= 35; i++) {
+      service.toggle(makeStory(i, `Story ${i}`));
+    }
+    expect(service.getPage(1).length).toBe(30);
+    expect(service.getPage(2).length).toBe(5);
+    expect(service.getPage(1, 10).length).toBe(10);
+  });
+});

--- a/src/app/shared/services/bookmarks.service.ts
+++ b/src/app/shared/services/bookmarks.service.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@angular/core';
+
+import { Story } from '../models/story';
+
+const STORAGE_KEY = 'savedStories';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class BookmarksService {
+  savedStories: Story[] = [];
+
+  constructor() {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      try {
+        this.savedStories = JSON.parse(stored);
+      } catch (e) {
+        this.savedStories = [];
+      }
+    }
+  }
+
+  isSaved(id: number): boolean {
+    return this.savedStories.some(story => story.id === id);
+  }
+
+  toggle(story: Story) {
+    if (this.isSaved(story.id)) {
+      this.savedStories = this.savedStories.filter(saved => saved.id !== story.id);
+    } else {
+      this.savedStories = [story, ...this.savedStories];
+    }
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(this.savedStories));
+  }
+
+  getPage(page: number, pageSize: number = 30): Story[] {
+    return this.savedStories.slice((page - 1) * pageSize, page * pageSize);
+  }
+}

--- a/src/app/shared/services/bookmarks.service.ts
+++ b/src/app/shared/services/bookmarks.service.ts
@@ -14,7 +14,8 @@ export class BookmarksService {
     const stored = localStorage.getItem(STORAGE_KEY);
     if (stored) {
       try {
-        this.savedStories = JSON.parse(stored);
+        const parsed = JSON.parse(stored);
+        this.savedStories = Array.isArray(parsed) ? parsed : [];
       } catch (e) {
         this.savedStories = [];
       }

--- a/src/app/shared/services/bookmarks.service.ts
+++ b/src/app/shared/services/bookmarks.service.ts
@@ -10,6 +10,11 @@ const STORAGE_KEY = 'savedStories';
 export class BookmarksService {
   savedStories: Story[] = [];
 
+  private cachedPage: Story[] = [];
+  private cachedSource: Story[] = null;
+  private cachedPageNum: number = null;
+  private cachedPageSize: number = null;
+
   constructor() {
     const stored = localStorage.getItem(STORAGE_KEY);
     if (stored) {
@@ -36,6 +41,12 @@ export class BookmarksService {
   }
 
   getPage(page: number, pageSize: number = 30): Story[] {
-    return this.savedStories.slice((page - 1) * pageSize, page * pageSize);
+    if (this.cachedSource !== this.savedStories || this.cachedPageNum !== page || this.cachedPageSize !== pageSize) {
+      this.cachedPage = this.savedStories.slice((page - 1) * pageSize, page * pageSize);
+      this.cachedSource = this.savedStories;
+      this.cachedPageNum = page;
+      this.cachedPageSize = pageSize;
+    }
+    return this.cachedPage;
   }
 }


### PR DESCRIPTION
## Summary
Two new features plus visual polish:

**Saved stories (bookmarks)** — new `BookmarksService` (localStorage-backed, key `savedStories`) with `isSaved(id)` / `toggle(story)` / `getPage(page)`. Each story row gets a `save`/`unsave` link (desktop + mobile subtexts). New `/saved/:page` route reuses `FeedComponent`: when `feedType === 'saved'` it paginates the local list client-side instead of hitting the HN API, with an empty-state message. `saved` added to the header nav. Feed "More" link now uses an explicit `hasMore` flag so saved pages paginate correctly.

**Sepia theme** — fourth theme option in Settings, added via the existing `theme()` SCSS mixin with new `$theme-sepia-*` variables.

**Design polish** — story-row hover highlight, softened row borders, pill-style Prev/More pagination buttons, underline indicator for the active header nav link, and popup shadow/rounder corners. Hover/border colors use `rgba(128,128,128,…)` so they work in all four themes.

Tests: added `bookmarks.service.spec.ts` (7 specs — toggle/persist/corrupt-storage/pagination); all pass via `ng test`. `ng build` passes; `ng lint` errors are pre-existing style rules (46 on master) — no new rule classes introduced.


Link to Devin session: https://app.devin.ai/sessions/31e214693a044935a9066ab7d526e656
Requested by: @eashansinha
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| 🟢 Reviewed | [`7371a2f`](https://github.com/cog-gtm/angular2-hn/pull/507/commits/7371a2f842c8297adb8e8a0737bc46739da24ab7) |

<a href="https://staging.itsdev.in/review/cog-gtm/angular2-hn/pull/507" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->