### PR TITLE
Task 5b: Settings panel

### DIFF
--- a/react/src/components/SettingsPanel.scss
+++ b/react/src/components/SettingsPanel.scss
@@ -1,0 +1,74 @@
+@import "../styles/media";
+@import "../styles/theme_variables";
+
+.overlay {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: rgba(0, 0, 0, 0.7);
+  opacity: 1;
+  z-index: 1;
+}
+
+.popup {
+  margin: 70px auto;
+  padding: 30px;
+  border-radius: 5px;
+  width: 30%;
+  position: relative;
+  h1 {
+    margin-top: 0;
+    margin-bottom: 0px;
+    color: #fff;
+    text-align: center;
+    letter-spacing: 1px;
+  }
+  h2 {
+    padding-top: 10px;
+  }
+  hr {
+    width: 40%;
+    margin-bottom: 20px;
+  }
+  .close {
+    position: absolute;
+    top: 12px;
+    right: 20px;
+    font-size: 30px;
+    font-weight: bold;
+    text-decoration: none;
+    color: rgba(255,255,255,0.8);
+    &:hover {
+      color: #fff;
+      cursor: pointer;
+    }
+  }
+  .content {
+    max-height: 30%;
+    color: #fff;
+    letter-spacing: 1px;
+    overflow: auto;
+  }
+  input[type=number] {
+      display: block;
+      width: 80%;
+      height: 20px;
+      margin-bottom: 15px;
+      border-radius: 5px;
+      padding: 2px;
+  }
+}
+
+.control-section {
+    margin-bottom: 15px;
+    padding-bottom: 15px;
+    border-bottom: 1px solid white;
+}
+
+@media screen and (max-width: 700px) {
+  .box, .popup {
+    width: 70%;
+  }
+}

--- a/react/src/components/SettingsPanel.test.tsx
+++ b/react/src/components/SettingsPanel.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SettingsProvider } from '../context/SettingsContext';
+import SettingsPanel from './SettingsPanel';
+
+function mockMatchMedia() {
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+    }));
+}
+
+function renderPanel() {
+    return render(
+        <SettingsProvider>
+            <SettingsPanel />
+        </SettingsProvider>,
+    );
+}
+
+describe('SettingsPanel', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        mockMatchMedia();
+    });
+
+    afterEach(() => {
+        cleanup();
+    });
+
+    it('renders the settings popup with all controls', () => {
+        renderPanel();
+        expect(screen.getByRole('heading', { name: 'Settings' })).toBeTruthy();
+        expect(screen.getByRole('checkbox')).toBeTruthy();
+        expect(screen.getByRole('radio', { name: 'Default' })).toBeTruthy();
+        expect(screen.getByRole('radio', { name: 'Night' })).toBeTruthy();
+        expect(screen.getByRole('radio', { name: 'Black (AMOLED)' })).toBeTruthy();
+        expect(screen.getByLabelText(/Font size:/)).toBeTruthy();
+        expect(screen.getByLabelText(/List spacing:/)).toBeTruthy();
+    });
+
+    it('toggles open links in a new tab', () => {
+        renderPanel();
+        const checkbox = screen.getByRole('checkbox') as HTMLInputElement;
+        expect(checkbox.checked).toBe(false);
+        fireEvent.click(checkbox);
+        expect(checkbox.checked).toBe(true);
+        expect(localStorage.getItem('openLinkInNewTab')).toBe('true');
+    });
+
+    it('selects a theme via the radio group', () => {
+        renderPanel();
+        const night = screen.getByRole('radio', { name: 'Night' }) as HTMLInputElement;
+        fireEvent.click(night);
+        expect(night.checked).toBe(true);
+        expect(localStorage.getItem('theme')).toBe('night');
+    });
+
+    it('changes font size and list spacing', () => {
+        renderPanel();
+        const fontInput = screen.getByLabelText(/Font size:/) as HTMLInputElement;
+        fireEvent.change(fontInput, { target: { value: '20' } });
+        expect(fontInput.value).toBe('20');
+        expect(localStorage.getItem('titleFontSize')).toBe('20');
+
+        const spacingInput = screen.getByLabelText(/List spacing:/) as HTMLInputElement;
+        fireEvent.change(spacingInput, { target: { value: '4' } });
+        expect(spacingInput.value).toBe('4');
+        expect(localStorage.getItem('listSpacing')).toBe('4');
+    });
+
+    it('calls toggleSettings when the close button is clicked', () => {
+        const { container } = renderPanel();
+        const close = container.querySelector('.close') as HTMLElement;
+        expect(close).toBeTruthy();
+        fireEvent.click(close);
+    });
+});

--- a/react/src/components/SettingsPanel.tsx
+++ b/react/src/components/SettingsPanel.tsx
@@ -1,5 +1,90 @@
+import { useSettings } from '../context/useSettings';
+
+import './SettingsPanel.scss';
+
 function SettingsPanel() {
-    return <div className="overlay"></div>;
+    const { settings, toggleSettings, toggleOpenLinksInNewTab, setTheme, setFont, setSpacing } = useSettings();
+
+    return (
+        <div id="popup1" className="overlay">
+            <div className="popup">
+                <h1>Settings</h1>
+                <hr />
+                <span className="close" onClick={() => toggleSettings()}>&times;</span>
+                <div className="content">
+                    <div className="control-section">
+                        <h2>Links</h2>
+                        <input
+                            type="checkbox"
+                            checked={settings.openLinkInNewTab}
+                            onChange={() => toggleOpenLinksInNewTab()} />
+                        Open links in a new tab
+                    </div>
+                    <div className="theme-controls">
+                        <div className="control-section">
+                            <h2>Select a theme</h2>
+                            <div>
+                                <label>
+                                    <input
+                                        name="theme"
+                                        type="radio"
+                                        value="default"
+                                        checked={settings.theme === 'default'}
+                                        onChange={() => setTheme('default')} />
+                                    Default
+                                </label>
+                            </div>
+                            <div>
+                                <label>
+                                    <input
+                                        name="theme"
+                                        type="radio"
+                                        value="night"
+                                        checked={settings.theme === 'night'}
+                                        onChange={() => setTheme('night')} />
+                                    Night
+                                </label>
+                            </div>
+                            <div>
+                                <label>
+                                    <input
+                                        name="theme"
+                                        type="radio"
+                                        value="amoledblack"
+                                        checked={settings.theme === 'amoledblack'}
+                                        onChange={() => setTheme('amoledblack')} />
+                                    Black (AMOLED)
+                                </label>
+                            </div>
+                        </div>
+                        <div className="control-section">
+                            <h2>Change Font</h2>
+                            <div>
+                                <label>
+                                    Font size:
+                                    <input
+                                        min="1"
+                                        value={settings.titleFontSize}
+                                        type="number"
+                                        onChange={(event) => setFont(event.target.value)} />
+                                </label>
+                            </div>
+                            <div>
+                                <label>
+                                    List spacing:
+                                    <input
+                                        min="0"
+                                        value={settings.listSpacing}
+                                        type="number"
+                                        onChange={(event) => setSpacing(event.target.value)} />
+                                </label>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
 }
 
 export default SettingsPanel;


### PR DESCRIPTION
## Summary
Replaces the `SettingsPanel` stub with a full React port of the Angular `settings.component.{ts,html,scss}` using `useSettings()`:
- Overlay/popup with h1 "Settings", close × → `toggleSettings()`, "Open links in a new tab" checkbox → `toggleOpenLinksInNewTab()`, theme radio group (default/night/amoledblack) → `setTheme(value)`, and controlled number inputs for Font size (min 1 → `setFont`) and List spacing (min 0 → `setSpacing`) using `onChange` in place of the Angular keyup handlers.
- `SettingsPanel.scss` ported from `settings.component.scss` with shared partial imports pointed at `../styles/...` (same pattern as Loader.scss).
- Adds `SettingsPanel.test.tsx` (vitest + testing-library) covering rendering, checkbox toggle, theme selection, and font/spacing changes with localStorage persistence.

lint, typecheck, build, and tests (26) all pass in `react/`.

Link to Devin session: https://app.devin.ai/sessions/8bde1f2fe98241148bc9c86cc1930320
Requested by: @eashansinha
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| 🟢 Reviewed | [`cd25165`](https://github.com/cog-gtm/angular2-hn/pull/509/commits/cd2516515635e50489cb852b0b9c8e13ddcb38d4) |

<a href="https://staging.itsdev.in/review/cog-gtm/angular2-hn/pull/509" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->