### PR TITLE
Task 5c: Feed page

### DIFF
--- a/react/src/pages/Feed.scss
+++ b/react/src/pages/Feed.scss
@@ -1,0 +1,108 @@
+@import "../styles/media";
+@import "../styles/theme_variables";
+
+a {
+  text-decoration: none;
+  font-weight: bold;
+
+  &:hover {
+    text-decoration: underline;
+  };
+}
+
+ol {
+  padding: 0 40px;
+  margin: 0;
+
+  @media #{$mobile-only} {
+    box-sizing: border-box;
+    list-style: none;
+    padding: 0 10px;
+  }
+
+  li {
+    position: relative;
+    -webkit-transition: background-color .2s ease;
+    transition: background-color .2s ease;
+  }
+}
+
+.list-margin {
+  @media #{$mobile-only} {
+    margin-top: 55px;
+  }
+}
+
+.main-content {
+  position: relative;
+  width: 100%;
+  min-height: 100vh;
+  -webkit-transition: opacity .2s ease;
+  transition: opacity .2s ease;
+  box-sizing: border-box;
+  padding: 8px 0;
+  z-index: 0;
+}
+
+.post {
+  padding: 10px 0 10px 5px;
+  transition: background-color 0.2s ease;
+  border-bottom: 1px solid #CECECB;
+
+  .itemNum {
+    color: #696969;
+    position: absolute;
+    width: 30px;
+    text-align: right;
+    left: 0;
+    top: 4px;
+  }
+}
+
+.item-block {
+  display: block;
+}
+
+
+.nav {
+  padding: 10px 40px;
+  margin-top: 10px;
+  font-size: 17px;
+
+  a {
+    @media #{$mobile-only} {
+      text-decoration: none;
+    }
+  }
+
+  @media #{$mobile-only} {
+    margin: 20px 0;
+    text-align: center;
+    padding: 10px 80px;
+    height: 20px;
+  }
+
+  .prev {
+    padding-right: 20px;
+
+    @media #{$mobile-only} {
+      float: left;
+      padding-right: 0;
+    }
+  }
+
+  .more {
+    @media #{$mobile-only} {
+      float: right;
+    }
+  }
+}
+
+.job-header {
+  font-size: 15px;
+  padding: 0 40px 10px;
+
+  @media #{$mobile-only} {
+    padding: 60px 15px 25px 15px;
+  }
+}

--- a/react/src/pages/Feed.test.tsx
+++ b/react/src/pages/Feed.test.tsx
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Story } from '../models';
+import Feed from './Feed';
+
+vi.mock('../api/hackernews', () => ({
+    fetchFeed: vi.fn(),
+}));
+
+import { fetchFeed } from '../api/hackernews';
+
+const mockedFetchFeed = vi.mocked(fetchFeed);
+
+function makeStory(id: number): Story {
+    return {
+        id,
+        title: `Story ${id}`,
+        points: 1,
+        user: 'user',
+        time: 0,
+        time_ago: '1 hour ago',
+        comments_count: 0,
+        type: 'link',
+        url: `https://example.com/${id}`,
+        domain: 'example.com',
+        comments: [],
+        content: '',
+        poll: [],
+        poll_votes_count: 0,
+        dead: false,
+        deleted: false,
+        level: 0,
+    } as unknown as Story;
+}
+
+function renderFeed(path: string) {
+    return render(
+        <MemoryRouter initialEntries={[path]}>
+            <Routes>
+                <Route path='/:feedType/:page' element={<Feed />} />
+            </Routes>
+        </MemoryRouter>
+    );
+}
+
+describe('Feed', () => {
+    beforeEach(() => {
+        window.scrollTo = vi.fn();
+    });
+
+    afterEach(() => {
+        cleanup();
+        vi.clearAllMocks();
+    });
+
+    it('shows a loader while stories are loading', () => {
+        mockedFetchFeed.mockReturnValue(new Promise(() => {}));
+        const { container } = renderFeed('/news/1');
+        expect(container.querySelector('.loader')).not.toBeNull();
+    });
+
+    it('renders stories in an ordered list with correct start', async () => {
+        mockedFetchFeed.mockResolvedValue([makeStory(1), makeStory(2)]);
+        renderFeed('/news/2');
+
+        await waitFor(() => {
+            expect(screen.getByText('Story 1')).not.toBeNull();
+        });
+        expect(mockedFetchFeed).toHaveBeenCalledWith('news', 2);
+        const list = document.querySelector('ol');
+        expect(list?.getAttribute('start')).toBe('31');
+        expect(list?.className).toContain('list-margin');
+    });
+
+    it('shows an error message when the feed fails to load', async () => {
+        mockedFetchFeed.mockRejectedValue(new Error('boom'));
+        renderFeed('/news/1');
+
+        await waitFor(() => {
+            expect(screen.getByText('Could not load news stories.')).not.toBeNull();
+        });
+    });
+
+    it('shows the jobs blurb for the jobs feed', async () => {
+        mockedFetchFeed.mockResolvedValue([makeStory(1)]);
+        renderFeed('/jobs/1');
+
+        await waitFor(() => {
+            expect(screen.getByText('Triplebyte')).not.toBeNull();
+        });
+        expect(document.querySelector('ol')?.className).not.toContain('list-margin');
+    });
+
+    it('renders Prev and More navigation links appropriately', async () => {
+        mockedFetchFeed.mockResolvedValue(
+            Array.from({ length: 30 }, (_, i) => makeStory(i + 1))
+        );
+        renderFeed('/news/2');
+
+        await waitFor(() => {
+            expect(screen.getByText('Story 1')).not.toBeNull();
+        });
+        const prev = document.querySelector('a.prev');
+        const more = document.querySelector('a.more');
+        expect(prev?.getAttribute('href')).toBe('/news/1');
+        expect(more?.getAttribute('href')).toBe('/news/3');
+    });
+
+    it('hides Prev on the first page and More when fewer than 30 items', async () => {
+        mockedFetchFeed.mockResolvedValue([makeStory(1)]);
+        renderFeed('/news/1');
+
+        await waitFor(() => {
+            expect(screen.getByText('Story 1')).not.toBeNull();
+        });
+        expect(document.querySelector('a.prev')).toBeNull();
+        expect(document.querySelector('a.more')).toBeNull();
+    });
+});

--- a/react/src/pages/Feed.tsx
+++ b/react/src/pages/Feed.tsx
@@ -1,8 +1,87 @@
-import { useParams } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+
+import { fetchFeed } from '../api/hackernews';
+import ErrorMessage from '../components/ErrorMessage';
+import Item from '../components/Item';
+import Loader from '../components/Loader';
+import type { Story } from '../models';
+import './Feed.scss';
 
 function Feed() {
-    const { feedType, page } = useParams();
-    return <div className="main-content">{feedType} {page}</div>;
+    const params = useParams();
+    const feedType = params.feedType ?? 'news';
+    const page = params.page ? Number(params.page) : 1;
+
+    const [items, setItems] = useState<Story[] | null>(null);
+    const [errorMessage, setErrorMessage] = useState('');
+    const [listStart, setListStart] = useState(1);
+
+    useEffect(() => {
+        let cancelled = false;
+        setItems(null);
+        setErrorMessage('');
+
+        fetchFeed(feedType, page)
+            .then((stories) => {
+                if (cancelled) {
+                    return;
+                }
+                setItems(stories);
+                setListStart(((page - 1) * 30) + 1);
+                window.scrollTo(0, 0);
+            })
+            .catch(() => {
+                if (!cancelled) {
+                    setErrorMessage(`Could not load ${feedType} stories.`);
+                }
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [feedType, page]);
+
+    return (
+        <div className='main-content'>
+            {!items && !errorMessage && <Loader />}
+            {!items && errorMessage !== '' && <ErrorMessage message={errorMessage} />}
+
+            {items && (
+                <div>
+                    {feedType === 'jobs' && (
+                        <p className='job-header'>
+                            These are jobs at startups that were funded by Y Combinator.
+                            You can also get a job at a YC startup through <a href='https://triplebyte.com/?ref=yc_jobs'>Triplebyte</a>.
+                        </p>
+                    )}
+                    {feedType !== 'new' && (
+                        <ol className={feedType !== 'jobs' ? 'list-margin' : undefined} start={listStart}>
+                            {items.map((item) => (
+                                <li key={item.id} className='post'>
+                                    <div className='item-block'>
+                                        <Item item={item} />
+                                    </div>
+                                </li>
+                            ))}
+                        </ol>
+                    )}
+                    <div className='nav'>
+                        {listStart !== 1 && (
+                            <Link to={`/${feedType}/${page - 1}`} className='prev'>
+                                ‹ Prev
+                            </Link>
+                        )}
+                        {items.length === 30 && (
+                            <Link to={`/${feedType}/${page + 1}`} className='more'>
+                                More ›
+                            </Link>
+                        )}
+                    </div>
+                </div>
+            )}
+        </div>
+    );
 }
 
 export default Feed;


### PR DESCRIPTION
## Summary
Replaces the `Feed.tsx` stub with a full port of the Angular `feed.component.{ts,html,scss}`:

- `useParams()` → `feedType` (default `'news'`) and `page` (default 1); `useEffect([feedType, page])` resets `items` to null (so `<Loader/>` shows), then `fetchFeed(feedType, page)` → on success sets items, `listStart = ((page - 1) * 30) + 1`, `window.scrollTo(0, 0)`; on failure sets `errorMessage = 'Could not load ${feedType} stories.'` (stale responses ignored via a `cancelled` flag).
- Renders jobs blurb (Triplebyte link) when `feedType === 'jobs'`; `<ol start={listStart}>` with `list-margin` class unless jobs, `<li className='post'>` → `.item-block` wrapper → `<Item item/>`; Prev link (`class='prev'`) when `listStart !== 1`, More link (`class='more'`) when `items.length === 30`.
- `Feed.scss` copied from `feed.component.scss` with shared `@import`s repointed to `../styles/...` (same pattern as `Loader.scss`).
- Adds `Feed.test.tsx` (vitest + testing-library, mocked `fetchFeed`) covering loader, list rendering/start, error message, jobs blurb, and Prev/More nav visibility.

lint, typecheck, build, and tests all pass in `react/`.

Link to Devin session: https://app.devin.ai/sessions/d5fc443c88194688bda1df6ea5b7f7f4
Requested by: @eashansinha
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| 🟢 Reviewed | [`8f196c1`](https://github.com/cog-gtm/angular2-hn/pull/510/commits/8f196c198c112c314cab8ba40eaf128ff7b01768) |

<a href="https://staging.itsdev.in/review/cog-gtm/angular2-hn/pull/510" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->