### PR TITLE
Task 5d: Item (feed row) component

### DIFF
--- a/react/src/components/Item.scss
+++ b/react/src/components/Item.scss
@@ -1,0 +1,68 @@
+@import "../styles/media";
+@import "../styles/theme_variables";
+
+p {
+    margin: 2px 0;
+
+    @media #{$mobile-only} {
+      margin-bottom: 5px;
+      margin-top: 0;
+   }
+  }
+
+  a {
+    cursor: pointer;
+    text-decoration: none;
+  }
+
+  .title {
+    font-size: 16px;
+    font-family: Verdana, Geneva, sans-serif;
+  }
+
+  .subtext-laptop {
+    font-size: 12px;
+    font-weight: bold;
+    letter-spacing: 0.5px;
+
+    a {
+      &:hover {
+        text-decoration: underline;
+      };
+    }
+    @media #{$mobile-only} {
+      display: none;
+    }
+  }
+
+  .subtext-palm {
+    font-size: 13px;
+    font-weight: bold;
+    letter-spacing: 0.5px;
+
+    a {
+      &:hover {
+        text-decoration: underline;
+      };
+    }
+
+    .details {
+      margin-top: 5px;
+
+      .right {
+        float: right;
+      }
+    }
+    @media #{$laptop-only} {
+      display: none;
+    }
+  }
+
+  .domain {
+    color: #696969;
+    letter-spacing: 0.5px;
+  }
+
+  .item-details {
+    padding: 10px;
+  }

--- a/react/src/components/Item.scss
+++ b/react/src/components/Item.scss
@@ -1,13 +1,14 @@
 @import "../styles/media";
 @import "../styles/theme_variables";
 
-p {
+.item {
+  p {
     margin: 2px 0;
 
     @media #{$mobile-only} {
       margin-bottom: 5px;
       margin-top: 0;
-   }
+    }
   }
 
   a {
@@ -66,3 +67,4 @@ p {
   .item-details {
     padding: 10px;
   }
+}

--- a/react/src/components/Item.test.tsx
+++ b/react/src/components/Item.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import Item from './Item';
+import { SettingsProvider } from '../context/SettingsContext';
+import type { Story } from '../models';
+
+function mockMatchMedia() {
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+    }));
+}
+
+function makeStory(overrides: Partial<Story> = {}): Story {
+    return {
+        id: 1,
+        title: 'A story',
+        points: 42,
+        user: 'alice',
+        time: 0,
+        time_ago: '2 hours ago' as unknown as number,
+        type: 'story',
+        url: 'https://example.com/article',
+        domain: 'example.com',
+        comments: [],
+        comments_count: 3,
+        poll: [],
+        poll_votes_count: 0,
+        deleted: false,
+        dead: false,
+        ...overrides,
+    };
+}
+
+function renderItem(item: Story) {
+    return render(
+        <SettingsProvider>
+            <MemoryRouter>
+                <Item item={item} />
+            </MemoryRouter>
+        </SettingsProvider>
+    );
+}
+
+describe('Item', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        mockMatchMedia();
+    });
+
+    afterEach(() => {
+        cleanup();
+    });
+
+    it('renders external link with domain when item has a url', () => {
+        renderItem(makeStory());
+        const title = screen.getByText('A story');
+        expect(title.tagName).toBe('A');
+        expect(title).toHaveProperty('href', 'https://example.com/article');
+        expect(screen.getByText('(example.com)')).toBeTruthy();
+    });
+
+    it('renders internal item link when item has no url', () => {
+        renderItem(makeStory({ url: 'item?id=1', domain: '' }));
+        const title = screen.getByText('A story');
+        expect(title.getAttribute('href')).toBe('/item/1');
+    });
+
+    it('shows points, user and comment label for non-job items', () => {
+        renderItem(makeStory());
+        expect(screen.getAllByText('alice').length).toBeGreaterThan(0);
+        expect(screen.getAllByText(/3 comments/).length).toBeGreaterThan(0);
+    });
+
+    it('hides points, user and comments for job items', () => {
+        renderItem(makeStory({ type: 'job', user: '', comments_count: 0 }));
+        expect(screen.queryByText(/points by/)).toBeNull();
+        expect(screen.queryByText(/discuss/)).toBeNull();
+    });
+});

--- a/react/src/components/Item.tsx
+++ b/react/src/components/Item.tsx
@@ -1,11 +1,78 @@
+import { Link } from 'react-router-dom';
+
 import type { Story } from '../models';
+import { useSettings } from '../context/useSettings';
+import { commentLabel } from '../utils/commentLabel';
+
+import './Item.scss';
 
 interface ItemProps {
     item: Story;
 }
 
 function Item({ item }: ItemProps) {
-    return <div>{item.title}</div>;
+    const { settings } = useSettings();
+    const hasUrl = item.url.indexOf('http') === 0;
+    const titleStyle = { fontSize: settings.titleFontSize + 'px' };
+
+    return (
+        <div style={{ marginBottom: settings.listSpacing + 'px' }}>
+            {hasUrl ? (
+                <p>
+                    <a
+                        className='title'
+                        style={titleStyle}
+                        href={item.url}
+                        target={settings.openLinkInNewTab ? '_blank' : undefined}
+                        rel={settings.openLinkInNewTab ? 'noopener' : undefined}
+                    >
+                        {item.title}
+                    </a>
+                    {item.domain && <span className='domain'>({item.domain})</span>}
+                </p>
+            ) : (
+                <p>
+                    <Link className='title' style={titleStyle} to={`/item/${item.id}`}>
+                        {item.title}
+                    </Link>
+                </p>
+            )}
+            <div className='subtext-palm'>
+                {item.type !== 'job' && (
+                    <div className='details'>
+                        <span className='name'>
+                            <Link to={`/user/${item.user}`}>{item.user}</Link>
+                        </span>
+                        <span className='right'>{item.points} ★</span>
+                    </div>
+                )}
+                <div className='details'>
+                    {item.time_ago}
+                    {item.type !== 'job' && (
+                        <Link to={`/item/${item.id}`} className='comment-number'>
+                            {' '}• {commentLabel(item.comments_count)}
+                        </Link>
+                    )}
+                </div>
+            </div>
+            <div className='subtext-laptop'>
+                {item.type !== 'job' && (
+                    <span>
+                        {item.points} points by{' '}
+                        <Link to={`/user/${item.user}`}>{item.user}</Link>
+                    </span>
+                )}
+                <span className={item.type !== 'job' ? 'item-details' : undefined}>
+                    {item.time_ago}
+                    {item.type !== 'job' && (
+                        <span>
+                            {' '}| <Link to={`/item/${item.id}`}>{commentLabel(item.comments_count)}</Link>
+                        </span>
+                    )}
+                </span>
+            </div>
+        </div>
+    );
 }
 
 export default Item;

--- a/react/src/components/Item.tsx
+++ b/react/src/components/Item.tsx
@@ -16,7 +16,7 @@ function Item({ item }: ItemProps) {
     const titleStyle = { fontSize: settings.titleFontSize + 'px' };
 
     return (
-        <div style={{ marginBottom: settings.listSpacing + 'px' }}>
+        <div className='item' style={{ marginBottom: settings.listSpacing + 'px' }}>
             {hasUrl ? (
                 <p>
                     <a


### PR DESCRIPTION
## Summary
Replaces the `Item.tsx` stub with a full React port of the Angular `item.component.{ts,html,scss}`:

- `Item({ item }: { item: Story })` uses `useSettings()`; `hasUrl = item.url.indexOf('http') === 0`; root div gets `style={{ marginBottom: settings.listSpacing + 'px' }}`.
- Title: external `<a class="title">` (with `(domain)` span, `target='_blank'`/`rel='noopener'` only when `settings.openLinkInNewTab`) vs internal `<Link to={'/item/' + id}>`; both styled `fontSize: settings.titleFontSize + 'px'`.
- Ports both `subtext-palm` and `subtext-laptop` blocks, hiding points/user/comment parts when `item.type === 'job'`, using `commentLabel(item.comments_count)` for the `| comment` pipe and conditional `item-details` className.
- `Item.scss` copied from `item.component.scss` with shared partial imports fixed to `../styles/...`.
- Adds `Item.test.tsx` (vitest + testing-library) covering external/internal title links, non-job subtext, and job hiding.

`npm run lint`, `typecheck`, `test`, and `build` all pass in `react/`.

Link to Devin session: https://app.devin.ai/sessions/8a5cb886a5cd4ca69593f354b384518e
Requested by: @eashansinha
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| 🟢 Reviewed | [`b3920d7`](https://github.com/cog-gtm/angular2-hn/pull/511/commits/b3920d74bc316445a1251e4e8eee740f71146cc2) |

<a href="https://staging.itsdev.in/review/cog-gtm/angular2-hn/pull/511" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->