### PR TITLE
Phase 5a: Header + Footer components

### DIFF
--- a/react/src/components/Footer.scss
+++ b/react/src/components/Footer.scss
@@ -1,0 +1,23 @@
+@import "../styles/media";
+@import "../styles/theme_variables";
+
+#footer {
+  position: relative;
+  padding: 10px;
+  height: 60px;
+  letter-spacing: 0.7px;
+  text-align: center;
+
+  a {
+    font-weight: bold;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  @media #{$mobile-only} {
+    display: none;
+  }
+}

--- a/react/src/components/Footer.test.tsx
+++ b/react/src/components/Footer.test.tsx
@@ -1,0 +1,15 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import Footer from './Footer';
+
+describe('Footer', () => {
+    it('renders the GitHub link opening in a new tab', () => {
+        render(<Footer />);
+        const link = screen.getByText('GitHub');
+        expect(link.getAttribute('href')).toBe('https://github.com/hdjirdeh/angular2-hn');
+        expect(link.getAttribute('target')).toBe('_blank');
+        expect(link.getAttribute('rel')).toContain('noopener');
+    });
+});

--- a/react/src/components/Footer.tsx
+++ b/react/src/components/Footer.tsx
@@ -1,5 +1,14 @@
+import './Footer.scss';
+
 function Footer() {
-    return <div id="footer"></div>;
+    return (
+        <div id="footer">
+            <p>
+                Show this project some ❤ on{' '}
+                <a href="https://github.com/hdjirdeh/angular2-hn" target="_blank" rel="noopener noreferrer">GitHub</a>
+            </p>
+        </div>
+    );
 }
 
 export default Footer;

--- a/react/src/components/Header.scss
+++ b/react/src/components/Header.scss
@@ -1,0 +1,149 @@
+@import "../styles/media";
+@import "../styles/theme_variables";
+
+#header {
+  color: #fff;
+  padding: 6px 0;
+  line-height: 18px;
+  vertical-align: middle;
+  position: relative;
+  z-index: 1;
+  width: 100%;
+
+  @media #{$mobile-only} {
+    height: 50px;
+    position: fixed;
+    top: 0;
+  }
+
+  a {
+    display: inline;
+  }
+}
+
+.home-link {
+  width: 50px;
+  height: 66px;
+}
+
+.logo-inner {
+  width: 32px;
+  position: absolute;
+  left: 17px;
+  top: 18px;
+  z-index: -1;
+  height: 32px;
+  border-radius: 50%;
+
+  @media #{$mobile-only} {
+    left: 16px;
+    top: 12px;
+  }
+}
+
+.logo {
+  width: 50px;
+  padding: 3px 8px 0;
+
+  @media #{$mobile-only} {
+    width: 45px;
+    padding: 0 0 0 10px;
+  }
+}
+
+h1 {
+  font-weight: normal;
+  display: inline-block;
+  vertical-align: middle;
+  margin: 0;
+  font-size: 16px;
+
+  a {
+    color: #fff;
+    text-decoration: none;
+  }
+}
+
+.name {
+  margin-right: 30px;
+  margin-bottom: 2px;
+
+  @media #{$mobile-only} {
+    display: none;
+  }
+}
+
+.header-text {
+  position: absolute;
+  width: inherit;
+  height: 20px;
+  left: 10px;
+  top: 27px;
+  z-index: -1;
+
+  @media #{$mobile-only} {
+    top: 22px;
+  }
+}
+
+.left {
+  position: absolute;
+  left: 60px;
+  font-size: 16px;
+
+  @media #{$mobile-only} {
+    width: 100%;
+    left: 0;
+  }
+}
+
+.header-nav {
+  display: inline-block;
+  margin-left: 20px;
+
+  @media #{$mobile-only} {
+    margin-left: 60px;
+  }
+
+  a {
+    color: hsla(0, 0%, 100%, .9);
+    text-decoration: none;
+    margin: 0 5px;
+    letter-spacing: 1.8px;
+
+    &:hover {
+      color: #fff;
+    }
+  }
+
+  .active {
+    color: #fff;
+  }
+}
+
+.info {
+  position: absolute;
+  top: 0;
+  right: 20px;
+  height: 100%;
+
+  @media #{$mobile-only} {
+    right: 10px;
+  }
+
+  img {
+    opacity: 0.8;
+    width: 25px;
+    margin-top: 21.5px;
+    display: block;
+
+    &:hover {
+      opacity: 1;
+      cursor: pointer;
+    }
+
+    @media #{$mobile-only} {
+      margin-top: 15px;
+    }
+  }
+}

--- a/react/src/components/Header.scss
+++ b/react/src/components/Header.scss
@@ -97,7 +97,7 @@ h1 {
   }
 }
 
-.header-nav {
+#header .header-nav {
   display: inline-block;
   margin-left: 20px;
 

--- a/react/src/components/Header.test.tsx
+++ b/react/src/components/Header.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ReactNode } from 'react';
+
+import Header from './Header';
+import { SettingsProvider } from '../context/SettingsContext';
+
+function mockMatchMedia() {
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+    }));
+}
+
+function renderHeader(children: ReactNode = <Header />, initialEntries = ['/news/1']) {
+    return render(
+        <MemoryRouter initialEntries={initialEntries}>
+            <SettingsProvider>{children}</SettingsProvider>
+        </MemoryRouter>,
+    );
+}
+
+describe('Header', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        mockMatchMedia();
+    });
+
+    afterEach(() => {
+        cleanup();
+        vi.restoreAllMocks();
+    });
+
+    it('renders the logo linking to /news/1', () => {
+        renderHeader();
+        const logo = screen.getByAltText('Logo');
+        expect(logo).toBeTruthy();
+        expect(logo.closest('a')?.getAttribute('href')).toBe('/news/1');
+    });
+
+    it('renders nav links to newest, show, ask and jobs', () => {
+        renderHeader();
+        expect(screen.getByText('new').getAttribute('href')).toBe('/newest/1');
+        expect(screen.getByText('show').getAttribute('href')).toBe('/show/1');
+        expect(screen.getByText('ask').getAttribute('href')).toBe('/ask/1');
+        expect(screen.getByText('jobs').getAttribute('href')).toBe('/jobs/1');
+    });
+
+    it('marks the current feed link as active', () => {
+        renderHeader(<Header />, ['/newest/1']);
+        expect(screen.getByText('new').className).toContain('active');
+        expect(screen.getByText('show').className).not.toContain('active');
+    });
+
+    it('scrolls to top when a nav link is clicked', () => {
+        const scrollTo = vi.fn();
+        window.scrollTo = scrollTo;
+        renderHeader();
+        fireEvent.click(screen.getByText('new'));
+        expect(scrollTo).toHaveBeenCalledWith(0, 0);
+    });
+
+    it('toggles the settings panel when the cog is clicked', () => {
+        const { container } = renderHeader();
+        expect(container.querySelector('.overlay')).toBeNull();
+        fireEvent.click(screen.getByAltText('Settings'));
+        expect(container.querySelector('.overlay')).not.toBeNull();
+        fireEvent.click(screen.getByAltText('Settings'));
+        expect(container.querySelector('.overlay')).toBeNull();
+    });
+});

--- a/react/src/components/Header.tsx
+++ b/react/src/components/Header.tsx
@@ -1,5 +1,42 @@
+import { NavLink } from 'react-router-dom';
+import SettingsPanel from './SettingsPanel';
+import { useSettings } from '../context/useSettings';
+import './Header.scss';
+
 function Header() {
-    return <header></header>;
+    const { settings, toggleSettings } = useSettings();
+
+    const scrollTop = () => {
+        window.scrollTo(0, 0);
+    };
+
+    return (
+        <header>
+            <div id="header">
+                <NavLink className="home-link" to="/news/1" onClick={scrollTop}>
+                    <div className="logo-inner"></div>
+                    <img className="logo" src="/assets/images/logo.svg" alt="Logo" />
+                </NavLink>
+                <div className="header-text">
+                    <div className="left">
+                        <span className="header-nav">
+                            <NavLink to="/newest/1" onClick={scrollTop}>new</NavLink>
+                            {' | '}
+                            <NavLink to="/show/1" onClick={scrollTop}>show</NavLink>
+                            {' | '}
+                            <NavLink to="/ask/1" onClick={scrollTop}>ask</NavLink>
+                            {' | '}
+                            <NavLink to="/jobs/1" onClick={scrollTop}>jobs</NavLink>
+                        </span>
+                    </div>
+                </div>
+                <div className="info">
+                    <img className="settings" src="/assets/images/cog.svg" alt="Settings" onClick={toggleSettings} />
+                </div>
+            </div>
+            {settings.showSettings && <SettingsPanel />}
+        </header>
+    );
 }
 
 export default Header;


### PR DESCRIPTION
## Summary
Ports the Angular core Header/Footer components (`src/app/core/header/`, `src/app/core/footer/`) into the React app, replacing the empty stubs in `react/src/components/`:

- `Header.tsx` — logo `NavLink` to `/news/1`, nav `NavLink`s (`new`/`show`/`ask`/`jobs` → `/{feed}/1`) each calling `window.scrollTo(0, 0)` on click (Angular `scrollTop()`), and a cog icon that calls `toggleSettings()` from `useSettings()`. Renders `<SettingsPanel />` when `settings.showSettings` (Angular `*ngIf`). `NavLink`'s default `active` class matches the Angular `routerLinkActive="active"` styling.
- `Footer.tsx` — GitHub link footer, `target="_blank" rel="noopener noreferrer"`.
- `Header.scss` / `Footer.scss` — 1:1 port of the Angular component SCSS, imports pointing to `react/src/styles/` (`media`, `theme_variables`); theme colors were already handled in `_themes.scss`.
- `Header.test.tsx` / `Footer.test.tsx` — vitest + testing-library tests: links/hrefs, active-link class, scroll-to-top on nav click, settings panel toggle via the cog, and footer link attrs.

Angular source untouched; changes confined to `react/`.

`npm run lint`, `typecheck`, `test` (27 passing), and `build` all green.

Link to Devin session: https://app.devin.ai/sessions/4b753e69e71b4086b5b5adb77f671089
Requested by: @eashansinha
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| 🟢 Reviewed | [`512a143`](https://github.com/cog-gtm/angular2-hn/pull/512/commits/512a14322d0f7352edcbccf8f241f4ed5bf256ee) |

<a href="https://staging.itsdev.in/review/cog-gtm/angular2-hn/pull/512" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->