### PR TITLE
Task 5e: ItemDetails page + recursive Comment

### DIFF
--- a/react/src/components/Comment.scss
+++ b/react/src/components/Comment.scss
@@ -1,0 +1,83 @@
+@import "../styles/media";
+@import "../styles/theme_variables";
+
+.comment-text a {
+  font-weight: bold;
+  text-decoration: none;
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.meta {
+  font-size: 13px;
+  color: #696969;
+  font-weight: bold;
+  letter-spacing: 0.5px;
+  margin-bottom: 8px;
+  a {
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+  .time {
+    padding-left: 5px;
+  }
+}
+
+@media #{$mobile-only} {
+  .meta {
+    font-size: 14px;
+    margin-bottom: 10px;
+    .time {
+      padding: 0;
+      float: right;
+    }
+  }
+}
+
+.meta-collapse {
+  margin-bottom: 20px;
+}
+
+.deleted-meta {
+  font-size: 12px;
+  font-weight: bold;
+  letter-spacing: 0.5px;
+  margin: 30px 0;
+  a {
+    text-decoration: none;
+  }
+}
+
+.collapse {
+  font-size: 13px;
+  letter-spacing: 2px;
+  cursor: pointer;
+}
+
+.comment-tree {
+  margin-left: 24px;
+}
+
+@media #{$tablet-only} {
+  .comment-tree {
+    margin-left: 8px;
+  }
+}
+
+.comment-text {
+  font-size: 15px;
+  margin-top: 0;
+  margin-bottom: 20px;
+  word-wrap: break-word;
+  line-height: 1.5em;
+}
+
+.subtree {
+  margin-left: 0;
+  padding: 0;
+  list-style-type: none;
+}

--- a/react/src/components/Comment.test.tsx
+++ b/react/src/components/Comment.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+
+import type { Comment as CommentModel } from '../models';
+import Comment from './Comment';
+
+function makeComment(overrides: Partial<CommentModel> = {}): CommentModel {
+    return {
+        id: 1,
+        level: 0,
+        user: 'pg',
+        time: 0,
+        time_ago: '2 hours ago',
+        content: '<p>hello world</p>',
+        deleted: false,
+        comments: [],
+        ...overrides,
+    };
+}
+
+function renderComment(comment: CommentModel) {
+    return render(
+        <MemoryRouter>
+            <Comment comment={comment} />
+        </MemoryRouter>
+    );
+}
+
+describe('Comment', () => {
+    function getToggle(container: HTMLElement): HTMLElement {
+        const toggle = container.querySelector('.meta .collapse');
+        expect(toggle).not.toBeNull();
+        return toggle as HTMLElement;
+    }
+
+    it('renders user link, time and content', () => {
+        const { container } = renderComment(makeComment());
+        const userLink = screen.getByRole('link', { name: 'pg' });
+        expect(userLink.getAttribute('href')).toBe('/user/pg');
+        expect(screen.getByText('2 hours ago')).toBeTruthy();
+        expect(screen.getByText('hello world')).toBeTruthy();
+        expect(getToggle(container).textContent).toBe('[-]');
+    });
+
+    it('renders deleted block for deleted comments', () => {
+        const { container } = renderComment(makeComment({ deleted: true }));
+        expect(container.querySelector('.deleted-meta .collapse')?.textContent).toBe('[deleted]');
+        expect(container.querySelector('a')).toBeNull();
+    });
+
+    it('collapses and expands the comment subtree on toggle', () => {
+        const { container } = renderComment(makeComment());
+        const toggle = getToggle(container);
+        fireEvent.click(toggle);
+        expect(toggle.textContent).toBe('[+]');
+        const hiddenDiv = container.querySelector('.comment-tree > div');
+        expect(hiddenDiv?.hasAttribute('hidden')).toBe(true);
+        fireEvent.click(toggle);
+        expect(hiddenDiv?.hasAttribute('hidden')).toBe(false);
+    });
+
+    it('renders nested comments recursively', () => {
+        renderComment(
+            makeComment({
+                comments: [
+                    makeComment({ id: 2, user: 'child', content: '<p>nested</p>' }),
+                ],
+            })
+        );
+        expect(screen.getByText('nested')).toBeTruthy();
+        expect(screen.getByRole('link', { name: 'child' })).toBeTruthy();
+    });
+});

--- a/react/src/components/Comment.tsx
+++ b/react/src/components/Comment.tsx
@@ -1,11 +1,52 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+
 import type { Comment as CommentModel } from '../models';
+import './Comment.scss';
 
 interface CommentProps {
     comment: CommentModel;
 }
 
 function Comment({ comment }: CommentProps) {
-    return <div>{comment.user}</div>;
+    const [collapse, setCollapse] = useState(false);
+
+    if (comment.deleted) {
+        return (
+            <div>
+                <div className="deleted-meta">
+                    <span className="collapse">[deleted]</span> | Comment Deleted
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div>
+            <div className={collapse ? 'meta meta-collapse' : 'meta'}>
+                <span className="collapse" onClick={() => setCollapse(!collapse)}>
+                    [{collapse ? '+' : '-'}]
+                </span>{' '}
+                <Link to={`/user/${comment.user}`}>{comment.user}</Link>
+                <span className="time">{comment.time_ago}</span>
+            </div>
+            <div className="comment-tree">
+                <div hidden={collapse}>
+                    <p
+                        className="comment-text"
+                        dangerouslySetInnerHTML={{ __html: comment.content }}
+                    ></p>
+                    <ul className="subtree">
+                        {comment.comments.map((subComment) => (
+                            <li key={subComment.id}>
+                                <Comment comment={subComment} />
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            </div>
+        </div>
+    );
 }
 
 export default Comment;

--- a/react/src/models/story.ts
+++ b/react/src/models/story.ts
@@ -16,6 +16,8 @@ export interface Story {
     comments_count: number;
     poll: PollResult[];
     poll_votes_count: number;
+    content: string;
+    text?: string;
     deleted: boolean;
     dead: boolean;
 }

--- a/react/src/pages/ItemDetails.scss
+++ b/react/src/pages/ItemDetails.scss
@@ -1,0 +1,151 @@
+@import "../styles/media";
+@import "../styles/theme_variables";
+
+.main-content {
+  position: relative;
+  width: 100%;
+  min-height: 100vh;
+  -webkit-transition: opacity .2s ease;
+  transition: opacity .2s ease;
+  box-sizing: border-box;
+  padding: 8px 0;
+  z-index: 0;
+}
+
+.item {
+  box-sizing: border-box;
+  padding: 10px 40px 0 40px;
+  z-index: 0;
+}
+
+@media #{$tablet-only} {
+  .item {
+    padding: 10px 20px 0 40px;
+  }
+}
+
+@media #{$mobile-only} {
+  .item {
+    box-sizing: border-box;
+    padding: 110px 15px 0 15px;
+  }
+}
+
+.head-margin {
+  margin-bottom: 15px;
+}
+
+p {
+  margin: 2px 0;
+}
+
+.subject {
+  word-wrap: break-word;
+  margin-top: 20px;
+}
+
+a {
+  cursor: pointer;
+  text-decoration: none;
+}
+
+@media #{$mobile-only} {
+  .laptop {
+    display: none;
+  }
+}
+
+@media #{$laptop-only} {
+  .mobile {
+    display: none;
+  }
+}
+
+.title {
+  font-size: 16px;
+  font-family: Verdana, Geneva, sans-serif;
+}
+
+.title-block {
+  text-align: center;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  margin: 0 75px;
+}
+
+@media #{$mobile-only} {
+  .title {
+    font-size: 15px;
+  }
+  .back-button {
+    position: absolute;
+    top: 52%;
+    width: 0.6rem;
+    height: 0.6rem;
+    background: transparent;
+    box-shadow: 0 0 0 lightgray;
+    transition: all 200ms ease;
+    left: 4%;
+    transform: translate3d(0, -50%, 0) rotate(-135deg);
+  }
+}
+
+.subtext {
+  font-size: 12px;
+  font-weight: bold;
+  letter-spacing: 0.5px;
+}
+
+.domain {
+  letter-spacing: 0.5px;
+}
+
+.subtext a {
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.item-details {
+  padding: 10px;
+}
+
+.item-header {
+  padding-bottom: 10px;
+}
+
+@media #{$mobile-only} {
+  .item-header {
+    padding: 10px 0 10px 0;
+    position: fixed;
+    width: 100%;
+    left: 0;
+    top: 62px;
+  }
+}
+
+.pollResults {
+  margin-bottom: 1em;
+}
+
+.pollContent {
+  * {
+    padding-bottom: 0;
+    margin-bottom: -1em;
+    margin-top: 1em;
+  }
+  .pollBar {
+    height: 10px;
+    margin-bottom: 1em;
+  }
+}
+
+ul {
+  list-style-type: none;
+  padding: 10px 0;
+}
+
+li {
+  display: list-item;
+}

--- a/react/src/pages/ItemDetails.test.tsx
+++ b/react/src/pages/ItemDetails.test.tsx
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import type { Story } from '../models';
+import { fetchItemContent } from '../api/hackernews';
+import { SettingsProvider } from '../context/SettingsContext';
+import ItemDetails from './ItemDetails';
+
+vi.mock('../api/hackernews', () => ({
+    fetchItemContent: vi.fn(),
+}));
+
+const mockedFetchItemContent = vi.mocked(fetchItemContent);
+
+function makeStory(overrides: Partial<Story> = {}): Story {
+    return {
+        id: 42,
+        title: 'A story',
+        points: 100,
+        user: 'pg',
+        time: 0,
+        time_ago: 0,
+        type: 'story',
+        url: 'https://example.com/article',
+        domain: 'example.com',
+        comments: [],
+        comments_count: 3,
+        poll: [],
+        poll_votes_count: 0,
+        content: '',
+        deleted: false,
+        dead: false,
+        ...overrides,
+    };
+}
+
+function renderItemDetails() {
+    return render(
+        <SettingsProvider>
+            <MemoryRouter initialEntries={['/item/42']}>
+                <Routes>
+                    <Route path="/item/:id" element={<ItemDetails />} />
+                </Routes>
+            </MemoryRouter>
+        </SettingsProvider>
+    );
+}
+
+describe('ItemDetails', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+            matches: false,
+            media: query,
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+        }));
+        window.scrollTo = vi.fn();
+        mockedFetchItemContent.mockReset();
+    });
+
+    it('shows a loader while fetching', () => {
+        mockedFetchItemContent.mockReturnValue(new Promise(() => {}));
+        renderItemDetails();
+        expect(screen.getByText('Loading...')).toBeTruthy();
+    });
+
+    it('renders the item title, subtext and comments after loading', async () => {
+        mockedFetchItemContent.mockResolvedValue(
+            makeStory({
+                comments: [
+                    {
+                        id: 7,
+                        level: 0,
+                        user: 'commenter',
+                        time: 0,
+                        time_ago: '1 hour ago',
+                        content: '<p>nice article</p>',
+                        deleted: false,
+                        comments: [],
+                    },
+                ],
+            })
+        );
+        renderItemDetails();
+        await waitFor(() => {
+            expect(screen.getAllByText('A story').length).toBeGreaterThan(0);
+        });
+        expect(mockedFetchItemContent).toHaveBeenCalledWith(42);
+        expect(screen.getByRole('link', { name: 'pg' })).toBeTruthy();
+        expect(screen.getByRole('link', { name: '3 comments' })).toBeTruthy();
+        expect(screen.getByText('nice article')).toBeTruthy();
+        expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
+    });
+
+    it('renders poll results with proportional bars', async () => {
+        mockedFetchItemContent.mockResolvedValue(
+            makeStory({
+                type: 'poll',
+                url: 'item?id=42',
+                poll: [
+                    { content: 'Option A', points: 30 },
+                    { content: 'Option B', points: 10 },
+                ],
+                poll_votes_count: 40,
+            })
+        );
+        const { container } = renderItemDetails();
+        await waitFor(() => {
+            expect(screen.getByText('Option A')).toBeTruthy();
+        });
+        const bars = container.querySelectorAll('.pollBar');
+        expect(bars.length).toBe(2);
+        expect((bars[0] as HTMLElement).style.width).toBe('75%');
+        expect((bars[1] as HTMLElement).style.width).toBe('25%');
+    });
+
+    it('shows an error message when the fetch fails', async () => {
+        mockedFetchItemContent.mockRejectedValue(new Error('boom'));
+        renderItemDetails();
+        await waitFor(() => {
+            expect(screen.getByText('Could not load item comments.')).toBeTruthy();
+        });
+    });
+});

--- a/react/src/pages/ItemDetails.tsx
+++ b/react/src/pages/ItemDetails.tsx
@@ -1,8 +1,143 @@
-import { useParams } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+
+import { fetchItemContent } from '../api/hackernews';
+import Comment from '../components/Comment';
+import ErrorMessage from '../components/ErrorMessage';
+import Loader from '../components/Loader';
+import { useSettings } from '../context/useSettings';
+import type { Story } from '../models';
+import { commentLabel } from '../utils/commentLabel';
+import './ItemDetails.scss';
 
 function ItemDetails() {
     const { id } = useParams();
-    return <div className="main-content">{id}</div>;
+    const navigate = useNavigate();
+    const { settings } = useSettings();
+    const [item, setItem] = useState<Story | null>(null);
+    const [errorMessage, setErrorMessage] = useState('');
+
+    useEffect(() => {
+        let cancelled = false;
+        setItem(null);
+        setErrorMessage('');
+        fetchItemContent(Number(id))
+            .then((fetchedItem) => {
+                if (!cancelled) {
+                    setItem(fetchedItem);
+                }
+            })
+            .catch(() => {
+                if (!cancelled) {
+                    setErrorMessage('Could not load item comments.');
+                }
+            });
+        window.scrollTo(0, 0);
+        return () => {
+            cancelled = true;
+        };
+    }, [id]);
+
+    const hasUrl = item ? item.url.indexOf('http') === 0 : false;
+
+    return (
+        <div className="main-content">
+            {!item && !errorMessage && <Loader />}
+            {!item && errorMessage !== '' && <ErrorMessage message={errorMessage} />}
+
+            {item && (
+                <div className="item">
+                    <div className="mobile item-header">
+                        <p className="title-block">
+                            <span className="back-button" onClick={() => navigate(-1)}></span>
+                            {hasUrl ? (
+                                <a
+                                    className="title"
+                                    href={item.url}
+                                    target={settings.openLinkInNewTab ? '_blank' : undefined}
+                                    rel={settings.openLinkInNewTab ? 'noopener' : undefined}
+                                >
+                                    {item.title}
+                                </a>
+                            ) : (
+                                <Link className="title" to={`/item/${item.id}`}>
+                                    {item.title}
+                                </Link>
+                            )}
+                        </p>
+                    </div>
+                    <div
+                        className={[
+                            'laptop',
+                            item.comments_count > 0 || item.type === 'job' ? 'item-header' : '',
+                            item.text ? 'head-margin' : '',
+                        ].filter(Boolean).join(' ')}
+                    >
+                        {hasUrl ? (
+                            <p>
+                                <a
+                                    className="title"
+                                    href={item.url}
+                                    target={settings.openLinkInNewTab ? '_blank' : undefined}
+                                    rel={settings.openLinkInNewTab ? 'noopener' : undefined}
+                                >
+                                    {item.title}
+                                </a>
+                                {item.domain && <span className="domain">({item.domain})</span>}
+                            </p>
+                        ) : (
+                            <p>
+                                <Link className="title" to={`/item/${item.id}`}>
+                                    {item.title}
+                                </Link>
+                            </p>
+                        )}
+                        <div className="subtext">
+                            {item.type !== 'job' && (
+                                <span>
+                                    {item.points} points by{' '}
+                                    <Link to={`/user/${item.user}`}>{item.user}</Link>
+                                </span>
+                            )}
+                            <span className={item.type !== 'job' ? 'item-details' : undefined}>
+                                {item.time_ago}
+                                {item.type !== 'job' && (
+                                    <span>
+                                        {' '}|{' '}
+                                        <Link to={`/item/${item.id}`}>
+                                            {commentLabel(item.comments_count)}
+                                        </Link>
+                                    </span>
+                                )}
+                            </span>
+                        </div>
+                    </div>
+                    {item.type === 'poll' && (
+                        <div className="pollResults">
+                            {item.poll.map((pollResult, index) => (
+                                <div className="pollContent" key={index}>
+                                    <div dangerouslySetInnerHTML={{ __html: pollResult.content }}></div>
+                                    <div className="subtext">{pollResult.points} points</div>
+                                    <div
+                                        className="pollBar"
+                                        style={{ width: (pollResult.points / item.poll_votes_count) * 100 + '%' }}
+                                    ></div>
+                                </div>
+                            ))}
+                        </div>
+                    )}
+                    <p className="subject" dangerouslySetInnerHTML={{ __html: item.content }}></p>
+                    <ul className="comment-list">
+                        {item.comments.map((comment) => (
+                            <li key={comment.id}>
+                                <Comment comment={comment} />
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            )}
+        </div>
+    );
 }
 
 export default ItemDetails;


### PR DESCRIPTION
## Summary
Replaces the `ItemDetails.tsx` and `Comment.tsx` stubs with full ports of the Angular `item-details` and `comment` components.

- `ItemDetails`: fetches via `fetchItemContent(Number(id))` on `useParams()` change (with cancel flag), sets `errorMessage = 'Could not load item comments.'` on failure, `window.scrollTo(0, 0)` per param change. Back button uses `navigate(-1)`; new-tab behavior via `useSettings()`. Faithful template port: mobile/laptop headers with conditional `item-header`/`head-margin` classes, subtext with `commentLabel()`, poll section with `pollBar` width `points / poll_votes_count * 100 + '%'`, `subject` via `dangerouslySetInnerHTML`, and `ul.comment-list` of `<Comment/>`.
- `Comment`: recursive with `useState(false)` collapse; deleted-meta block for deleted comments; collapsed subtree kept via `hidden` attribute (mirrors Angular `[hidden]`).
- SCSS ported to `ItemDetails.scss` / `Comment.scss` with `@import` paths fixed to `../styles/...`. The Angular `:host >>> a` rule became `.comment-text a` (React has no view encapsulation, so it's scoped to the rendered comment HTML instead of globally).
- `Story` model gained `content: string` and `text?: string` — the Angular template referenced these fields but the interface (like the Angular one) didn't declare them; TS port requires them.
- Added vitest suites `ItemDetails.test.tsx` (loader, loaded render, poll bars, error state) and `Comment.test.tsx` (render, deleted, collapse toggle, recursion).

Lint, typecheck, build, and tests (29) all pass in `react/`.

Link to Devin session: https://app.devin.ai/sessions/33414e465c2b4fffb236781c82f6ca36
Requested by: @eashansinha
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| 🟢 Reviewed | [`d634855`](https://github.com/cog-gtm/angular2-hn/pull/513/commits/d634855f684317abc21a6e94b9dd779c83c27a1b) |

<a href="https://staging.itsdev.in/review/cog-gtm/angular2-hn/pull/513" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->