### PR TITLE
[2/5] React migration: app shell — router, header, footer, settings modal, loader/error

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { Outlet } from 'react-router-dom';
+import { Outlet } from 'react-router';
 
 import { Footer } from './components/Footer/Footer';
 import { Header } from './components/Header/Header';

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,7 @@
+import { Outlet } from 'react-router-dom';
+
+import { Footer } from './components/Footer/Footer';
+import { Header } from './components/Header/Header';
 import { useSettings } from './context/settingsContext';
 
 import './App.scss';
@@ -8,7 +12,11 @@ export function App() {
     return (
         <div className={settings.theme}>
             <div className="body-cover" />
-            <div className="wrapper" />
+            <div className="wrapper">
+                <Header />
+                <Outlet />
+                <Footer />
+            </div>
         </div>
     );
 }

--- a/src/components/ErrorMessage/ErrorMessage.scss
+++ b/src/components/ErrorMessage/ErrorMessage.scss
@@ -1,0 +1,115 @@
+@import '../../styles/media';
+@import '../../styles/theme_variables';
+
+.error-section {
+  height: 300px;
+  margin: 200px;
+
+  @media #{$mobile-only} {
+    height: 0;
+    display: block;
+    position: relative;
+    margin: 30vh 0;
+  }
+
+  p {
+    text-align: center;
+    padding: 0 25px;
+
+    &.strong {
+      margin-top: 25px;
+      font-weight: bold;
+    }
+  }
+
+  .skull {
+    width: $skull-size;
+    height: $skull-size;
+    position: relative;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    margin: auto;
+
+    .head {
+      width: 100%;
+      height: 75%;
+      border-radius: 15% / 20%;
+      position: absolute;
+      top: 0;
+      left: 0;
+      &:before, &:after {
+        content: "";
+        position: absolute;
+        border-radius: 50%;
+        width: 20%;
+        height: 30%;
+        bottom: 10%;
+      }
+      &:before {
+        left: 10%;
+      }
+      &:after {
+        right: 10%;
+      }
+      .crack {
+        width: 10%;
+        height: 10%;
+        position: absolute;
+        top: 0;
+        right: 25%;
+        transform: skew(-15deg);
+
+        &:before {
+          content: "";
+          position: absolute;
+          top: 100%;
+          left: $skull-size * 0.0667;
+          border-right: $skull-size * 0.05 solid transparent;
+          border-left: $skull-size * 0.025 solid transparent;
+        }
+      }
+    }
+    .mouth {
+      width: 40%;
+      height: 25%;
+      position: absolute;
+      top: 75%;
+      left: 30%;
+      border-radius: 0 0 $skull-size * 0.1 $skull-size * 0.1;
+      &:before {
+        content: "";
+        position: absolute;
+        width: 15%;
+        height: 50%;
+        border-radius: 50% / 30%;
+        left: 42.5%;
+        top: -25%;
+      }
+      .teeth {
+        position: absolute;
+        bottom: 0;
+        left: 45%;
+        width: 10%;
+        height: 50%;
+        margin-bottom: -5%;
+        border-radius: 50% / 20%;
+
+        &:before, &:after {
+          content: "";
+          position: absolute;
+          width: 100%;
+          height: 100%;
+          border-radius: 50% / 20%;
+        }
+        &:before {
+          left: -250%;
+        }
+        &:after {
+          right: -250%;
+        }
+      }
+    }
+  }
+}

--- a/src/components/ErrorMessage/ErrorMessage.tsx
+++ b/src/components/ErrorMessage/ErrorMessage.tsx
@@ -1,0 +1,21 @@
+import './ErrorMessage.scss';
+
+export function ErrorMessage({ message }: { message: string }) {
+    return (
+        <div className="error-section">
+            <div className="skull">
+                <div className="head">
+                    <div className="crack" />
+                </div>
+                <div className="mouth">
+                    <div className="teeth" />
+                </div>
+            </div>
+            <p className="strong">{message}</p>
+            <p>
+                If you are offline viewing, you&apos;ll need to visit this page with a network connection first before
+                it can work offline.
+            </p>
+        </div>
+    );
+}

--- a/src/components/Footer/Footer.scss
+++ b/src/components/Footer/Footer.scss
@@ -1,0 +1,23 @@
+@import '../../styles/media';
+@import '../../styles/theme_variables';
+
+#footer {
+  position: relative;
+  padding: 10px;
+  height: 60px;
+  letter-spacing: 0.7px;
+  text-align: center;
+
+  a {
+  	font-weight: bold;
+  	text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  @media #{$mobile-only} {
+    display: none;
+  }
+}

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,0 +1,14 @@
+import './Footer.scss';
+
+export function Footer() {
+    return (
+        <div id="footer">
+            <p>
+                Show this project some ❤ on{' '}
+                <a href="https://github.com/hdjirdeh/angular2-hn" target="_blank" rel="noopener noreferrer">
+                    GitHub
+                </a>
+            </p>
+        </div>
+    );
+}

--- a/src/components/Header/Header.scss
+++ b/src/components/Header/Header.scss
@@ -1,0 +1,151 @@
+@import '../../styles/media';
+@import '../../styles/theme_variables';
+
+.app-header {
+    #header {
+      color: #fff;
+      padding: 6px 0;
+      line-height: 18px;
+      vertical-align: middle;
+      position: relative;
+      z-index: 1;
+      width: 100%;
+
+      @media #{$mobile-only} {
+        height: 50px;
+        position: fixed;
+        top: 0;
+      }
+
+      a {
+        display: inline;
+      }
+    }
+
+    .home-link {
+      width: 50px;
+      height: 66px;
+    }
+
+    .logo-inner {
+      width: 32px;
+      position: absolute;
+      left: 17px;
+      top: 18px;
+      z-index: -1;
+      height: 32px;
+      border-radius: 50%;
+
+      @media #{$mobile-only} {
+        left: 16px;
+        top: 12px;
+      }
+    }
+
+    .logo {
+      width: 50px;
+      padding: 3px 8px 0;
+
+      @media #{$mobile-only} {
+        width: 45px;
+        padding: 0 0 0 10px;
+      }
+    }
+
+    h1 {
+      font-weight: normal;
+      display: inline-block;
+      vertical-align:middle;
+      margin: 0;
+      font-size: 16px;
+
+      a {
+        color: #fff;
+        text-decoration: none;
+      }
+    }
+
+    .name {
+      margin-right: 30px;
+      margin-bottom: 2px;
+
+      @media #{$mobile-only} {
+        display: none;
+      }
+    }
+
+    .header-text {
+      position: absolute;
+      width: inherit;
+      height: 20px;
+      left: 10px;
+      top: 27px;
+      z-index: -1;
+
+      @media #{$mobile-only} {
+        top: 22px;
+      }
+    }
+
+    .left {
+      position: absolute;
+      left: 60px;
+      font-size: 16px;
+
+      @media #{$mobile-only} {
+        width: 100%;
+        left: 0;
+      }
+    }
+
+    .header-nav {
+      display: inline-block;
+      margin-left: 20px;
+
+      @media #{$mobile-only} {
+        margin-left: 60px;
+      }
+
+      a {
+        color: hsla(0,0%,100%,.9);
+        text-decoration: none;
+        margin: 0 5px;
+        letter-spacing: 1.8px;
+
+        &:hover {
+          color: #fff;
+        }
+      }
+
+      .active {
+        color: #fff;
+      }
+    }
+
+    .info {
+      position: absolute;
+      top: 0;
+      right: 20px;
+      height: 100%;
+
+      @media #{$mobile-only} {
+        right: 10px;
+      }
+
+      img {
+        opacity: 0.8;
+        width: 25px;
+        margin-top: 21.5px;
+        display: block;
+
+        &:hover {
+          opacity: 1;
+          cursor: pointer;
+        }
+
+        @media #{$mobile-only} {
+          margin-top: 15px;
+        }
+      }
+    }
+}

--- a/src/components/Header/Header.scss
+++ b/src/components/Header/Header.scss
@@ -20,131 +20,131 @@
       a {
         display: inline;
       }
-    }
 
-    .home-link {
-      width: 50px;
-      height: 66px;
-    }
-
-    .logo-inner {
-      width: 32px;
-      position: absolute;
-      left: 17px;
-      top: 18px;
-      z-index: -1;
-      height: 32px;
-      border-radius: 50%;
-
-      @media #{$mobile-only} {
-        left: 16px;
-        top: 12px;
-      }
-    }
-
-    .logo {
-      width: 50px;
-      padding: 3px 8px 0;
-
-      @media #{$mobile-only} {
-        width: 45px;
-        padding: 0 0 0 10px;
-      }
-    }
-
-    h1 {
-      font-weight: normal;
-      display: inline-block;
-      vertical-align:middle;
-      margin: 0;
-      font-size: 16px;
-
-      a {
-        color: #fff;
-        text-decoration: none;
-      }
-    }
-
-    .name {
-      margin-right: 30px;
-      margin-bottom: 2px;
-
-      @media #{$mobile-only} {
-        display: none;
-      }
-    }
-
-    .header-text {
-      position: absolute;
-      width: inherit;
-      height: 20px;
-      left: 10px;
-      top: 27px;
-      z-index: -1;
-
-      @media #{$mobile-only} {
-        top: 22px;
-      }
-    }
-
-    .left {
-      position: absolute;
-      left: 60px;
-      font-size: 16px;
-
-      @media #{$mobile-only} {
-        width: 100%;
-        left: 0;
-      }
-    }
-
-    .header-nav {
-      display: inline-block;
-      margin-left: 20px;
-
-      @media #{$mobile-only} {
-        margin-left: 60px;
+      .home-link {
+        width: 50px;
+        height: 66px;
       }
 
-      a {
-        color: hsla(0,0%,100%,.9);
-        text-decoration: none;
-        margin: 0 5px;
-        letter-spacing: 1.8px;
+      .logo-inner {
+        width: 32px;
+        position: absolute;
+        left: 17px;
+        top: 18px;
+        z-index: -1;
+        height: 32px;
+        border-radius: 50%;
 
-        &:hover {
+        @media #{$mobile-only} {
+          left: 16px;
+          top: 12px;
+        }
+      }
+
+      .logo {
+        width: 50px;
+        padding: 3px 8px 0;
+
+        @media #{$mobile-only} {
+          width: 45px;
+          padding: 0 0 0 10px;
+        }
+      }
+
+      h1 {
+        font-weight: normal;
+        display: inline-block;
+        vertical-align:middle;
+        margin: 0;
+        font-size: 16px;
+
+        a {
+          color: #fff;
+          text-decoration: none;
+        }
+      }
+
+      .name {
+        margin-right: 30px;
+        margin-bottom: 2px;
+
+        @media #{$mobile-only} {
+          display: none;
+        }
+      }
+
+      .header-text {
+        position: absolute;
+        width: inherit;
+        height: 20px;
+        left: 10px;
+        top: 27px;
+        z-index: -1;
+
+        @media #{$mobile-only} {
+          top: 22px;
+        }
+      }
+
+      .left {
+        position: absolute;
+        left: 60px;
+        font-size: 16px;
+
+        @media #{$mobile-only} {
+          width: 100%;
+          left: 0;
+        }
+      }
+
+      .header-nav {
+        display: inline-block;
+        margin-left: 20px;
+
+        @media #{$mobile-only} {
+          margin-left: 60px;
+        }
+
+        a {
+          color: hsla(0,0%,100%,.9);
+          text-decoration: none;
+          margin: 0 5px;
+          letter-spacing: 1.8px;
+
+          &:hover {
+            color: #fff;
+          }
+        }
+
+        .active {
           color: #fff;
         }
       }
 
-      .active {
-        color: #fff;
-      }
-    }
-
-    .info {
-      position: absolute;
-      top: 0;
-      right: 20px;
-      height: 100%;
-
-      @media #{$mobile-only} {
-        right: 10px;
-      }
-
-      img {
-        opacity: 0.8;
-        width: 25px;
-        margin-top: 21.5px;
-        display: block;
-
-        &:hover {
-          opacity: 1;
-          cursor: pointer;
-        }
+      .info {
+        position: absolute;
+        top: 0;
+        right: 20px;
+        height: 100%;
 
         @media #{$mobile-only} {
-          margin-top: 15px;
+          right: 10px;
+        }
+
+        img {
+          opacity: 0.8;
+          width: 25px;
+          margin-top: 21.5px;
+          display: block;
+
+          &:hover {
+            opacity: 1;
+            cursor: pointer;
+          }
+
+          @media #{$mobile-only} {
+            margin-top: 15px;
+          }
         }
       }
     }

--- a/src/components/Header/Header.scss
+++ b/src/components/Header/Header.scss
@@ -51,28 +51,6 @@
         }
       }
 
-      h1 {
-        font-weight: normal;
-        display: inline-block;
-        vertical-align:middle;
-        margin: 0;
-        font-size: 16px;
-
-        a {
-          color: #fff;
-          text-decoration: none;
-        }
-      }
-
-      .name {
-        margin-right: 30px;
-        margin-bottom: 2px;
-
-        @media #{$mobile-only} {
-          display: none;
-        }
-      }
-
       .header-text {
         position: absolute;
         width: inherit;

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,0 +1,50 @@
+import { Link, NavLink } from 'react-router-dom';
+
+import { useSettings } from '../../context/settingsContext';
+import { Settings } from '../Settings/Settings';
+
+import './Header.scss';
+
+const FEEDS = [
+    { path: 'newest', label: 'new' },
+    { path: 'show', label: 'show' },
+    { path: 'ask', label: 'ask' },
+    { path: 'jobs', label: 'jobs' },
+];
+
+function scrollTop() {
+    window.scrollTo(0, 0);
+}
+
+export function Header() {
+    const { settings, toggleSettings } = useSettings();
+
+    return (
+        <header className="app-header">
+            <div id="header">
+                <Link className="home-link" to="/news/1" onClick={scrollTop}>
+                    <div className="logo-inner" />
+                    <img className="logo" src="/assets/images/logo.svg" alt="Logo" />
+                </Link>
+                <div className="header-text">
+                    <div className="left">
+                        <span className="header-nav">
+                            {FEEDS.map((feed, index) => (
+                                <span key={feed.path}>
+                                    {index > 0 && ' | '}
+                                    <NavLink to={`/${feed.path}/1`} onClick={scrollTop}>
+                                        {feed.label}
+                                    </NavLink>
+                                </span>
+                            ))}
+                        </span>
+                    </div>
+                </div>
+                <div className="info">
+                    <img className="settings" src="/assets/images/cog.svg" alt="Settings" onClick={toggleSettings} />
+                </div>
+            </div>
+            {settings.showSettings && <Settings />}
+        </header>
+    );
+}

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,4 +1,4 @@
-import { Link, NavLink } from 'react-router-dom';
+import { Link, NavLink } from 'react-router';
 
 import { useSettings } from '../../context/settingsContext';
 import { Settings } from '../Settings/Settings';

--- a/src/components/Loader/Loader.scss
+++ b/src/components/Loader/Loader.scss
@@ -1,0 +1,109 @@
+@import '../../styles/media';
+@import '../../styles/theme_variables';
+
+.loader {
+  -webkit-animation: load1 1s infinite ease-in-out;
+  animation: load1 1s infinite ease-in-out;
+  width: 1em;
+  height: 4em;
+  &:before, &:after {
+    -webkit-animation: load1 1s infinite ease-in-out;
+    animation: load1 1s infinite ease-in-out;
+    width: 1em;
+    height: 4em;
+  }
+  &:before, &:after {
+    position: absolute;
+    top: 0;
+    content: '';
+  }
+  &:before {
+    left: -1.5em;
+    -webkit-animation-delay: -0.32s;
+    animation-delay: -0.32s;
+  }
+}
+
+.loading-section {
+    height: 70px;
+    margin: 40px 0 40px 40px;
+
+  @media #{$mobile-only} {
+    display: block;
+    position: relative;
+    margin: 45vh 0;
+  }
+}
+
+.loader {
+  text-indent: -9999em;
+  margin: 20px 20px;
+  position: relative;
+  font-size: 11px;
+  -webkit-transform: translateZ(0);
+  -ms-transform: translateZ(0);
+  transform: translateZ(0);
+  -webkit-animation-delay: -0.16s;
+  animation-delay: -0.16s;
+  &:after {
+    left: 1.5em;
+  }
+
+  @media #{$mobile-only} {
+    margin: 20px auto;
+  }
+}
+
+@-webkit-keyframes load1 {
+  0%,
+    80%,
+    100% {
+    box-shadow: 0 0;
+    height: 2em;
+  }
+  40% {
+    box-shadow: 0 -2em;
+    height: 3em;
+  }
+}
+
+@keyframes load1 {
+  0%,
+    80%,
+    100% {
+    box-shadow: 0 0;
+    height: 2em;
+  }
+  40% {
+    box-shadow: 0 -2em;
+    height: 3em;
+  }
+}
+
+@media #{$mobile-only} {
+  @-webkit-keyframes load1 {
+    0%,
+      80%,
+      100% {
+      box-shadow: 0 0;
+      height: 4em;
+    }
+    40% {
+      box-shadow: 0 -2em;
+      height: 5em;
+    }
+  }
+
+  @keyframes load1 {
+    0%,
+      80%,
+      100% {
+      box-shadow: 0 0;
+      height: 3em;
+    }
+    40% {
+      box-shadow: 0 -2em;
+      height: 4em;
+    }
+  }
+}

--- a/src/components/Loader/Loader.tsx
+++ b/src/components/Loader/Loader.tsx
@@ -1,0 +1,9 @@
+import './Loader.scss';
+
+export function Loader() {
+    return (
+        <div className="loading-section">
+            <div className="loader">Loading...</div>
+        </div>
+    );
+}

--- a/src/components/Settings/Settings.scss
+++ b/src/components/Settings/Settings.scss
@@ -1,0 +1,74 @@
+@import '../../styles/media';
+@import '../../styles/theme_variables';
+
+.overlay {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: rgba(0, 0, 0, 0.7);
+  opacity: 1;
+  z-index: 1;
+}
+
+.popup {
+  margin: 70px auto;
+  padding: 30px;
+  border-radius: 5px;
+  width: 30%;
+  position: relative;
+  h1 {
+    margin-top: 0;
+    margin-bottom: 0px;
+    color: #fff;
+    text-align: center;
+    letter-spacing: 1px;
+  }
+  h2 {
+    padding-top: 10px;
+  }
+  hr {
+    width: 40%;
+    margin-bottom: 20px;
+  }
+  .close {
+    position: absolute;
+    top: 12px;
+    right: 20px;
+    font-size: 30px;
+    font-weight: bold;
+    text-decoration: none;
+    color: rgba(255,255,255,0.8);
+    &:hover {
+      color: #fff;
+      cursor: pointer;
+    }
+  }
+  .content {
+    max-height: 30%;
+    color: #fff;
+    letter-spacing: 1px;
+    overflow: auto;
+  }
+  input[type=number] {
+      display: block;
+      width: 80%;
+      height: 20px;
+      margin-bottom: 15px;
+      border-radius: 5px;
+      padding: 2px;
+  }
+}
+
+.control-section {
+    margin-bottom: 15px;
+    padding-bottom: 15px;
+    border-bottom: 1px solid white;
+}
+
+@media screen and (max-width: 700px) {
+  .box, .popup {
+    width: 70%;
+  }
+}

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -1,0 +1,84 @@
+import { Theme } from '../../types';
+import { useSettings } from '../../context/settingsContext';
+
+import './Settings.scss';
+
+const THEMES: { value: Theme; label: string }[] = [
+    { value: 'default', label: 'Default' },
+    { value: 'night', label: 'Night' },
+    { value: 'amoledblack', label: 'Black (AMOLED)' },
+];
+
+export function Settings() {
+    const { settings, toggleSettings, toggleOpenLinksInNewTab, setTheme, setTitleFontSize, setListSpacing } =
+        useSettings();
+
+    return (
+        <div id="popup1" className="overlay">
+            <div className="popup">
+                <h1>Settings</h1>
+                <hr />
+                <span className="close" onClick={toggleSettings}>
+                    &times;
+                </span>
+                <div className="content">
+                    <div className="control-section">
+                        <h2>Links</h2>
+                        <label>
+                            <input
+                                type="checkbox"
+                                checked={settings.openLinkInNewTab}
+                                onChange={toggleOpenLinksInNewTab}
+                            />
+                            Open links in a new tab
+                        </label>
+                    </div>
+                    <div className="theme-controls">
+                        <div className="control-section">
+                            <h2>Select a theme</h2>
+                            {THEMES.map((theme) => (
+                                <div key={theme.value}>
+                                    <label>
+                                        <input
+                                            name="theme"
+                                            type="radio"
+                                            value={theme.value}
+                                            checked={settings.theme === theme.value}
+                                            onChange={() => setTheme(theme.value)}
+                                        />
+                                        {theme.label}
+                                    </label>
+                                </div>
+                            ))}
+                        </div>
+                        <div className="control-section">
+                            <h2>Change Font</h2>
+                            <div>
+                                <label>
+                                    Font size:
+                                    <input
+                                        min="1"
+                                        type="number"
+                                        value={settings.titleFontSize}
+                                        onChange={(event) => setTitleFontSize(event.target.value)}
+                                    />
+                                </label>
+                            </div>
+                            <div>
+                                <label>
+                                    List spacing:
+                                    <input
+                                        min="0"
+                                        type="number"
+                                        value={settings.listSpacing}
+                                        onChange={(event) => setListSpacing(event.target.value)}
+                                    />
+                                </label>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -36,6 +36,8 @@ export function Settings() {
                     <div className="theme-controls">
                         <div className="control-section">
                             <h2>Select a theme</h2>
+                            {/* onClick also fires when the checked radio is re-selected, which is how a
+                                visitor pins the theme the system colour scheme picked for them. */}
                             {THEMES.map((theme) => (
                                 <div key={theme.value}>
                                     <label>

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -45,6 +45,7 @@ export function Settings() {
                                             value={theme.value}
                                             checked={settings.theme === theme.value}
                                             onChange={() => setTheme(theme.value)}
+                                            onClick={() => setTheme(theme.value)}
                                         />
                                         {theme.label}
                                     </label>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,6 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import { RouterProvider } from 'react-router-dom';
+import { RouterProvider } from 'react-router';
 
 import { SettingsProvider } from './context/SettingsProvider';
 import { router } from './routes';

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,8 +1,9 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import { RouterProvider } from 'react-router-dom';
 
-import { App } from './App';
 import { SettingsProvider } from './context/SettingsProvider';
+import { router } from './routes';
 
 import './styles/global.scss';
 
@@ -15,7 +16,7 @@ if (!container) {
 createRoot(container).render(
     <StrictMode>
         <SettingsProvider>
-            <App />
+            <RouterProvider router={router} />
         </SettingsProvider>
     </StrictMode>
 );

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,0 +1,11 @@
+import { createBrowserRouter, Navigate } from 'react-router-dom';
+
+import { App } from './App';
+
+export const router = createBrowserRouter([
+    {
+        path: '/',
+        element: <App />,
+        children: [{ index: true, element: <Navigate to="/news/1" replace /> }],
+    },
+]);

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,4 +1,4 @@
-import { createBrowserRouter, Navigate } from 'react-router-dom';
+import { createBrowserRouter, Navigate } from 'react-router';
 
 import { App } from './App';
 


### PR DESCRIPTION
## Summary

Second of the 5-PR Angular → React stack (on top of #521). Ports the Angular `CoreModule` + `SharedComponentsModule` chrome: `Header`, `Footer`, `Settings`, `Loader`, `ErrorMessage`, plus the router that replaces `app.routes.ts`. Only `/` → `/news/1` is routed here; the feed/item/user routes are added by PRs 3–4, so `/news/1` renders header+footer with an empty outlet until then.

**Routing**: `RouterModule.forRoot` with a `data: {feedType}` per branch becomes a `createBrowserRouter` config in `src/routes.tsx`, with `App` as the layout route (`<router-outlet>` → `<Outlet/>`):

```tsx
createBrowserRouter([{ path: '/', element: <App />, children: [{ index: true, element: <Navigate to="/news/1" replace /> }] }])
```

**Nav links**: `routerLink` + `routerLinkActive="active"` → `NavLink` (which applies the same `active` class the theme SCSS targets); the four feed links are generated from a `FEEDS` array instead of hand-repeated markup with `|` separators.

**Settings**: the Angular template read values back out of template reference variables (`#titleFont`, `#default`, ...) and fired on `keyup`/`click`; these become ordinary controlled inputs driven by `useSettings()`, so the radio/checkbox/number state comes from context rather than the DOM. Checkbox and radios now sit inside their `<label>` so the text is clickable.

**Component styles**: each Angular component's SCSS moves next to its component and is imported from the `.tsx`. Angular's emulated view encapsulation is gone, so `Header.scss` — the only file with bare element selectors (`h1`, `a`, `img`) — is nested under a `.app-header` scope; the others were already class-scoped. Theme selectors (`.default .wrapper #header`, ...) are untouched and still match.

`react-router` is imported as `react-router` rather than the deprecated `react-router-dom` re-export (v8 consolidated the DOM bindings into the base package).


Link to Devin session: https://app.devin.ai/sessions/6490dc100d5b47f3adeb4684a88dd7bd
Requested by: @charityquinn-cognition
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/522?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/522" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/angular2-hn/pull/522" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->