### PR TITLE
[3/5] React migration: feed pages (news/newest/show/ask/jobs) and story item

### DIFF
--- a/src/components/Item/Item.scss
+++ b/src/components/Item/Item.scss
@@ -6,65 +6,65 @@
         margin: 2px 0;
 
         @media #{$mobile-only} {
-          margin-bottom: 5px;
-          margin-top: 0;
-       }
-      }
+            margin-bottom: 5px;
+            margin-top: 0;
+        }
+    }
 
-      a {
+    a {
         cursor: pointer;
         text-decoration: none;
-      }
+    }
 
-      .title {
+    .title {
         font-size: 16px;
         font-family: Verdana, Geneva, sans-serif;
-      }
+    }
 
-      .subtext-laptop {
+    .subtext-laptop {
         font-size: 12px;
         font-weight: bold;
         letter-spacing: 0.5px;
 
         a {
-          &:hover {
-            text-decoration: underline;
-          };
+            &:hover {
+                text-decoration: underline;
+            }
         }
         @media #{$mobile-only} {
-          display: none;
+            display: none;
         }
-      }
+    }
 
-      .subtext-palm {
+    .subtext-palm {
         font-size: 13px;
         font-weight: bold;
         letter-spacing: 0.5px;
 
         a {
-          &:hover {
-            text-decoration: underline;
-          };
+            &:hover {
+                text-decoration: underline;
+            }
         }
 
         .details {
-          margin-top: 5px;
+            margin-top: 5px;
 
-          .right {
-            float: right;
-          }
+            .right {
+                float: right;
+            }
         }
         @media #{$laptop-only} {
-          display: none;
+            display: none;
         }
-      }
+    }
 
-      .domain {
+    .domain {
         color: #696969;
         letter-spacing: 0.5px;
-      }
+    }
 
-      .item-details {
+    .item-details {
         padding: 10px;
-      }
+    }
 }

--- a/src/components/Item/Item.scss
+++ b/src/components/Item/Item.scss
@@ -1,0 +1,70 @@
+@import '../../styles/media';
+@import '../../styles/theme_variables';
+
+.item-block {
+    p {
+        margin: 2px 0;
+
+        @media #{$mobile-only} {
+          margin-bottom: 5px;
+          margin-top: 0;
+       }
+      }
+
+      a {
+        cursor: pointer;
+        text-decoration: none;
+      }
+
+      .title {
+        font-size: 16px;
+        font-family: Verdana, Geneva, sans-serif;
+      }
+
+      .subtext-laptop {
+        font-size: 12px;
+        font-weight: bold;
+        letter-spacing: 0.5px;
+
+        a {
+          &:hover {
+            text-decoration: underline;
+          };
+        }
+        @media #{$mobile-only} {
+          display: none;
+        }
+      }
+
+      .subtext-palm {
+        font-size: 13px;
+        font-weight: bold;
+        letter-spacing: 0.5px;
+
+        a {
+          &:hover {
+            text-decoration: underline;
+          };
+        }
+
+        .details {
+          margin-top: 5px;
+
+          .right {
+            float: right;
+          }
+        }
+        @media #{$laptop-only} {
+          display: none;
+        }
+      }
+
+      .domain {
+        color: #696969;
+        letter-spacing: 0.5px;
+      }
+
+      .item-details {
+        padding: 10px;
+      }
+}

--- a/src/components/Item/Item.tsx
+++ b/src/components/Item/Item.tsx
@@ -1,0 +1,70 @@
+import { Link } from 'react-router';
+
+import { useSettings } from '../../context/settingsContext';
+import { Story } from '../../types';
+import { formatCommentCount } from '../../utils/formatCommentCount';
+
+import './Item.scss';
+
+export function Item({ item }: { item: Story }) {
+    const { settings } = useSettings();
+
+    const hasUrl = item.url?.startsWith('http') ?? false;
+    const isJob = item.type === 'job';
+    const linkTarget = settings.openLinkInNewTab ? { target: '_blank', rel: 'noopener noreferrer' } : {};
+    const titleStyle = { fontSize: `${settings.titleFontSize}px` };
+
+    return (
+        <div className="item-block" style={{ marginBottom: `${settings.listSpacing}px` }}>
+            {hasUrl ? (
+                <p>
+                    <a className="title" style={titleStyle} href={item.url} {...linkTarget}>
+                        {item.title}
+                    </a>
+                    {item.domain && <span className="domain">({item.domain})</span>}
+                </p>
+            ) : (
+                <p>
+                    <Link className="title" style={titleStyle} to={`/item/${item.id}`}>
+                        {item.title}
+                    </Link>
+                </p>
+            )}
+            <div className="subtext-palm">
+                {!isJob && (
+                    <div className="details">
+                        <span className="name">
+                            <Link to={`/user/${item.user}`}>{item.user}</Link>
+                        </span>
+                        <span className="right">{item.points} ★</span>
+                    </div>
+                )}
+                <div className="details">
+                    {item.time_ago}
+                    {!isJob && (
+                        <Link to={`/item/${item.id}`} className="comment-number">
+                            {' '}
+                            • {formatCommentCount(item.comments_count)}
+                        </Link>
+                    )}
+                </div>
+            </div>
+            <div className="subtext-laptop">
+                {!isJob && (
+                    <span>
+                        {item.points} points by <Link to={`/user/${item.user}`}>{item.user}</Link>
+                    </span>
+                )}
+                <span className={isJob ? undefined : 'item-details'}>
+                    {item.time_ago}
+                    {!isJob && (
+                        <span>
+                            {' '}
+                            | <Link to={`/item/${item.id}`}>{formatCommentCount(item.comments_count)}</Link>
+                        </span>
+                    )}
+                </span>
+            </div>
+        </div>
+    );
+}

--- a/src/components/Item/Item.tsx
+++ b/src/components/Item/Item.tsx
@@ -21,7 +21,12 @@ export function Item({ item }: { item: Story }) {
                     <a className="title" style={titleStyle} href={item.url} {...linkTarget}>
                         {item.title}
                     </a>
-                    {item.domain && <span className="domain">({item.domain})</span>}
+                    {item.domain && (
+                        <>
+                            {' '}
+                            <span className="domain">({item.domain})</span>
+                        </>
+                    )}
                 </p>
             ) : (
                 <p>

--- a/src/pages/Feed/Feed.scss
+++ b/src/pages/Feed/Feed.scss
@@ -1,0 +1,107 @@
+@import '../../styles/media';
+@import '../../styles/theme_variables';
+
+.main-content {
+  position: relative;
+  width: 100%;
+  min-height: 100vh;
+  -webkit-transition: opacity .2s ease;
+  transition: opacity .2s ease;
+  box-sizing: border-box;
+  padding: 8px 0;
+  z-index: 0;
+
+  a {
+    text-decoration: none;
+    font-weight: bold;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  ol {
+    padding: 0 40px;
+    margin: 0;
+
+    @media #{$mobile-only} {
+      box-sizing: border-box;
+      list-style: none;
+      padding: 0 10px;
+    }
+
+    li {
+      position: relative;
+      -webkit-transition: background-color .2s ease;
+      transition: background-color .2s ease;
+    }
+  }
+
+  .list-margin {
+    @media #{$mobile-only} {
+      margin-top: 55px;
+    }
+  }
+
+  .post {
+    padding: 10px 0 10px 5px;
+    transition: background-color 0.2s ease;
+    border-bottom: 1px solid #CECECB;
+
+    .itemNum {
+      color: #696969;
+      position: absolute;
+      width: 30px;
+      text-align: right;
+      left: 0;
+      top: 4px;
+    }
+  }
+
+  .item-block {
+    display: block;
+  }
+
+  .nav {
+    padding: 10px 40px;
+    margin-top: 10px;
+    font-size: 17px;
+
+    a {
+      @media #{$mobile-only} {
+        text-decoration: none;
+      }
+    }
+
+    @media #{$mobile-only} {
+      margin: 20px 0;
+      text-align: center;
+      padding: 10px 80px;
+      height: 20px;
+    }
+
+    .prev {
+      padding-right: 20px;
+
+      @media #{$mobile-only} {
+        float: left;
+        padding-right: 0;
+      }
+    }
+
+    .more {
+      @media #{$mobile-only} {
+        float: right;
+      }
+    }
+  }
+
+  .job-header {
+    font-size: 15px;
+    padding: 0 40px 10px;
+
+    @media #{$mobile-only} {
+      padding: 60px 15px 25px 15px;
+    }
+  }
+}

--- a/src/pages/Feed/Feed.scss
+++ b/src/pages/Feed/Feed.scss
@@ -11,7 +11,8 @@
   padding: 8px 0;
   z-index: 0;
 
-  a {
+  .nav a,
+  .job-header a {
     text-decoration: none;
     font-weight: bold;
 

--- a/src/pages/Feed/Feed.scss
+++ b/src/pages/Feed/Feed.scss
@@ -1,108 +1,108 @@
 @import '../../styles/media';
 @import '../../styles/theme_variables';
 
-.main-content {
-  position: relative;
-  width: 100%;
-  min-height: 100vh;
-  -webkit-transition: opacity .2s ease;
-  transition: opacity .2s ease;
-  box-sizing: border-box;
-  padding: 8px 0;
-  z-index: 0;
+.main-content.feed-page {
+    position: relative;
+    width: 100%;
+    min-height: 100vh;
+    -webkit-transition: opacity 0.2s ease;
+    transition: opacity 0.2s ease;
+    box-sizing: border-box;
+    padding: 8px 0;
+    z-index: 0;
 
-  .nav a,
-  .job-header a {
-    text-decoration: none;
-    font-weight: bold;
-
-    &:hover {
-      text-decoration: underline;
-    }
-  }
-
-  ol {
-    padding: 0 40px;
-    margin: 0;
-
-    @media #{$mobile-only} {
-      box-sizing: border-box;
-      list-style: none;
-      padding: 0 10px;
-    }
-
-    li {
-      position: relative;
-      -webkit-transition: background-color .2s ease;
-      transition: background-color .2s ease;
-    }
-  }
-
-  .list-margin {
-    @media #{$mobile-only} {
-      margin-top: 55px;
-    }
-  }
-
-  .post {
-    padding: 10px 0 10px 5px;
-    transition: background-color 0.2s ease;
-    border-bottom: 1px solid #CECECB;
-
-    .itemNum {
-      color: #696969;
-      position: absolute;
-      width: 30px;
-      text-align: right;
-      left: 0;
-      top: 4px;
-    }
-  }
-
-  .item-block {
-    display: block;
-  }
-
-  .nav {
-    padding: 10px 40px;
-    margin-top: 10px;
-    font-size: 17px;
-
-    a {
-      @media #{$mobile-only} {
+    .nav a,
+    .job-header a {
         text-decoration: none;
-      }
+        font-weight: bold;
+
+        &:hover {
+            text-decoration: underline;
+        }
     }
 
-    @media #{$mobile-only} {
-      margin: 20px 0;
-      text-align: center;
-      padding: 10px 80px;
-      height: 20px;
+    ol {
+        padding: 0 40px;
+        margin: 0;
+
+        @media #{$mobile-only} {
+            box-sizing: border-box;
+            list-style: none;
+            padding: 0 10px;
+        }
+
+        li {
+            position: relative;
+            -webkit-transition: background-color 0.2s ease;
+            transition: background-color 0.2s ease;
+        }
     }
 
-    .prev {
-      padding-right: 20px;
-
-      @media #{$mobile-only} {
-        float: left;
-        padding-right: 0;
-      }
+    .list-margin {
+        @media #{$mobile-only} {
+            margin-top: 55px;
+        }
     }
 
-    .more {
-      @media #{$mobile-only} {
-        float: right;
-      }
-    }
-  }
+    .post {
+        padding: 10px 0 10px 5px;
+        transition: background-color 0.2s ease;
+        border-bottom: 1px solid #cececb;
 
-  .job-header {
-    font-size: 15px;
-    padding: 0 40px 10px;
-
-    @media #{$mobile-only} {
-      padding: 60px 15px 25px 15px;
+        .itemNum {
+            color: #696969;
+            position: absolute;
+            width: 30px;
+            text-align: right;
+            left: 0;
+            top: 4px;
+        }
     }
-  }
+
+    .item-block {
+        display: block;
+    }
+
+    .nav {
+        padding: 10px 40px;
+        margin-top: 10px;
+        font-size: 17px;
+
+        a {
+            @media #{$mobile-only} {
+                text-decoration: none;
+            }
+        }
+
+        @media #{$mobile-only} {
+            margin: 20px 0;
+            text-align: center;
+            padding: 10px 80px;
+            height: 20px;
+        }
+
+        .prev {
+            padding-right: 20px;
+
+            @media #{$mobile-only} {
+                float: left;
+                padding-right: 0;
+            }
+        }
+
+        .more {
+            @media #{$mobile-only} {
+                float: right;
+            }
+        }
+    }
+
+    .job-header {
+        font-size: 15px;
+        padding: 0 40px 10px;
+
+        @media #{$mobile-only} {
+            padding: 60px 15px 25px 15px;
+        }
+    }
 }

--- a/src/pages/Feed/Feed.tsx
+++ b/src/pages/Feed/Feed.tsx
@@ -13,7 +13,7 @@ const PAGE_SIZE = 30;
 
 export function Feed({ feedType }: { feedType: string }) {
     const { page } = useParams();
-    const pageNum = Number(page) || 1;
+    const pageNum = Math.max(1, Math.floor(Number(page)) || 1);
 
     const { data: items, error } = useApiRequest(
         (signal) => fetchFeed(feedType, pageNum, signal),

--- a/src/pages/Feed/Feed.tsx
+++ b/src/pages/Feed/Feed.tsx
@@ -28,7 +28,7 @@ export function Feed({ feedType }: { feedType: string }) {
     const listStart = (pageNum - 1) * PAGE_SIZE + 1;
 
     return (
-        <div className="main-content">
+        <div className="main-content feed-page">
             {!items && !error && <Loader />}
             {!items && error !== '' && <ErrorMessage message={error} />}
 

--- a/src/pages/Feed/Feed.tsx
+++ b/src/pages/Feed/Feed.tsx
@@ -1,0 +1,66 @@
+import { useEffect } from 'react';
+import { Link, useParams } from 'react-router';
+
+import { ErrorMessage } from '../../components/ErrorMessage/ErrorMessage';
+import { Item } from '../../components/Item/Item';
+import { Loader } from '../../components/Loader/Loader';
+import { useApiRequest } from '../../hooks/useApiRequest';
+import { fetchFeed } from '../../services/hackerNewsApi';
+
+import './Feed.scss';
+
+const PAGE_SIZE = 30;
+
+export function Feed({ feedType }: { feedType: string }) {
+    const { page } = useParams();
+    const pageNum = Number(page) || 1;
+
+    const { data: items, error } = useApiRequest(
+        (signal) => fetchFeed(feedType, pageNum, signal),
+        `Could not load ${feedType} stories.`,
+        [feedType, pageNum]
+    );
+
+    useEffect(() => {
+        window.scrollTo(0, 0);
+    }, [feedType, pageNum]);
+
+    const listStart = (pageNum - 1) * PAGE_SIZE + 1;
+
+    return (
+        <div className="main-content">
+            {!items && !error && <Loader />}
+            {!items && error !== '' && <ErrorMessage message={error} />}
+
+            {items && (
+                <div>
+                    {feedType === 'jobs' && (
+                        <p className="job-header">
+                            These are jobs at startups that were funded by Y Combinator. You can also get a job at a YC
+                            startup through <a href="https://triplebyte.com/?ref=yc_jobs">Triplebyte</a>.
+                        </p>
+                    )}
+                    <ol className={feedType !== 'jobs' ? 'list-margin' : undefined} start={listStart}>
+                        {items.map((item) => (
+                            <li key={item.id} className="post">
+                                <Item item={item} />
+                            </li>
+                        ))}
+                    </ol>
+                    <div className="nav">
+                        {listStart !== 1 && (
+                            <Link to={`/${feedType}/${pageNum - 1}`} className="prev">
+                                ‹ Prev
+                            </Link>
+                        )}
+                        {items.length === PAGE_SIZE && (
+                            <Link to={`/${feedType}/${pageNum + 1}`} className="more">
+                                More ›
+                            </Link>
+                        )}
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,11 +1,20 @@
 import { createBrowserRouter, Navigate } from 'react-router';
 
 import { App } from './App';
+import { Feed } from './pages/Feed/Feed';
+
+const FEED_TYPES = ['news', 'newest', 'show', 'ask', 'jobs'];
 
 export const router = createBrowserRouter([
     {
         path: '/',
         element: <App />,
-        children: [{ index: true, element: <Navigate to="/news/1" replace /> }],
+        children: [
+            { index: true, element: <Navigate to="/news/1" replace /> },
+            ...FEED_TYPES.map((feedType) => ({
+                path: `${feedType}/:page`,
+                element: <Feed feedType={feedType} />,
+            })),
+        ],
     },
 ]);


### PR DESCRIPTION
## Summary

Third of the 5-PR Angular → React stack (on top of #522). Ports `FeedComponent` + `ItemComponent`, which makes all five feeds usable end to end; `/item/:id` and `/user/:id` links still 404 until PR 4.

**Feed type comes from props, not route data.** Angular attached `data: {feedType}` to five parent routes and read it via a second `ActivatedRoute` subscription; React passes it straight in:

```tsx
...FEED_TYPES.map((feedType) => ({ path: `${feedType}/:page`, element: <Feed feedType={feedType} /> }))
```

so the component's two `Subscription`s (`typeSub`, `pageSub`) collapse into `useParams()` + one `useApiRequest(fetchFeed, ..., [feedType, pageNum])`, which also aborts the in-flight request on navigation — the Angular version left the previous page's fetch running and let it win the race.

**`listStart`** is now derived during render (`(pageNum - 1) * 30 + 1`) instead of being assigned in the observable's completion callback, so `‹ Prev` / `More ›` never render against a stale page number. `window.scrollTo(0, 0)` moves to an effect keyed on `[feedType, pageNum]`.

**Item**: `CommentPipe` → `formatCommentCount()`, `[ngStyle]` → inline `style` for the user-configured title size and list spacing, and `routerLink`/`href` selection is unchanged except that the URL test is null-safe:

```ts
const hasUrl = item.url?.startsWith('http') ?? false;   // was: item.url.indexOf('http') === 0
```

`ItemComponent`'s host element carried the `item-block` class from the feed template; the React component applies it on its own root div so `Feed.scss` keeps matching. Both stylesheets are nested under their root class (`.main-content`, `.item-block`) to replace Angular's view encapsulation.


Link to Devin session: https://app.devin.ai/sessions/6490dc100d5b47f3adeb4684a88dd7bd
Requested by: @charityquinn-cognition
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/523?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/523" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/angular2-hn/pull/523" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->