### PR TITLE
[4/5] React migration: item details, recursive comment tree and user profile

### DIFF
--- a/src/components/CommentThread/CommentThread.scss
+++ b/src/components/CommentThread/CommentThread.scss
@@ -1,0 +1,87 @@
+@import '../../styles/media';
+@import '../../styles/theme_variables';
+
+.comment {
+    & {
+      a {
+        font-weight: bold;
+        text-decoration: none;
+        &:hover {
+          text-decoration: underline;
+        }
+      }
+    }
+
+    .meta {
+      font-size: 13px;
+      color: #696969;
+      font-weight: bold;
+      letter-spacing: 0.5px;
+      margin-bottom: 8px;
+      a {
+        text-decoration: none;
+
+        &:hover {
+          text-decoration: underline;
+        }
+      }
+      .time {
+        padding-left: 5px;
+      }
+    }
+
+    @media #{$mobile-only} {
+      .meta {
+        font-size: 14px;
+        margin-bottom: 10px;
+        .time {
+          padding: 0;
+          float: right;
+        }
+      }
+    }
+
+    .meta-collapse {
+      margin-bottom: 20px;
+    }
+
+    .deleted-meta {
+      font-size: 12px;
+      font-weight: bold;
+      letter-spacing: 0.5px;
+      margin: 30px 0;
+      a {
+        text-decoration: none;
+      }
+    }
+
+    .collapse {
+      font-size: 13px;
+      letter-spacing: 2px;
+      cursor: pointer;
+    }
+
+    .comment-tree {
+      margin-left: 24px;
+    }
+
+    @media #{$tablet-only} {
+      .comment-tree {
+        margin-left: 8px;
+      }
+    }
+
+    .comment-text {
+      font-size: 15px;
+      margin-top: 0;
+      margin-bottom: 20px;
+      word-wrap: break-word;
+      line-height: 1.5em;
+    }
+
+    .subtree {
+      margin-left: 0;
+      padding: 0;
+      list-style-type: none;
+    }
+}

--- a/src/components/CommentThread/CommentThread.tsx
+++ b/src/components/CommentThread/CommentThread.tsx
@@ -10,8 +10,10 @@ export function CommentThread({ comment }: { comment: Comment }) {
 
     if (comment.deleted) {
         return (
-            <div className="deleted-meta">
-                <span className="collapse">[deleted]</span> | Comment Deleted
+            <div className="comment">
+                <div className="deleted-meta">
+                    <span className="collapse">[deleted]</span> | Comment Deleted
+                </div>
             </div>
         );
     }

--- a/src/components/CommentThread/CommentThread.tsx
+++ b/src/components/CommentThread/CommentThread.tsx
@@ -1,0 +1,42 @@
+import { useState } from 'react';
+import { Link } from 'react-router';
+
+import { Comment } from '../../types';
+
+import './CommentThread.scss';
+
+export function CommentThread({ comment }: { comment: Comment }) {
+    const [collapsed, setCollapsed] = useState(false);
+
+    if (comment.deleted) {
+        return (
+            <div className="deleted-meta">
+                <span className="collapse">[deleted]</span> | Comment Deleted
+            </div>
+        );
+    }
+
+    return (
+        <div className="comment">
+            <div className={collapsed ? 'meta meta-collapse' : 'meta'}>
+                <span className="collapse" onClick={() => setCollapsed(!collapsed)}>
+                    [{collapsed ? '+' : '-'}]
+                </span>{' '}
+                <Link to={`/user/${comment.user}`}>{comment.user}</Link>
+                <span className="time">{comment.time_ago}</span>
+            </div>
+            <div className="comment-tree">
+                <div hidden={collapsed}>
+                    <p className="comment-text" dangerouslySetInnerHTML={{ __html: comment.content }} />
+                    <ul className="subtree">
+                        {comment.comments?.map((subComment) => (
+                            <li key={subComment.id}>
+                                <CommentThread comment={subComment} />
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/pages/ItemDetails/ItemDetails.scss
+++ b/src/pages/ItemDetails/ItemDetails.scss
@@ -46,9 +46,7 @@
     }
 
     .item-header a,
-    .laptop a,
-    .subject a,
-    .pollContent a {
+    .laptop a {
         cursor: pointer;
         text-decoration: none;
     }

--- a/src/pages/ItemDetails/ItemDetails.scss
+++ b/src/pages/ItemDetails/ItemDetails.scss
@@ -40,7 +40,7 @@
         margin: 2px 0;
     }
 
-    .subject {
+    .item > p.subject {
         word-wrap: break-word;
         margin-top: 20px;
     }

--- a/src/pages/ItemDetails/ItemDetails.scss
+++ b/src/pages/ItemDetails/ItemDetails.scss
@@ -1,7 +1,7 @@
 @import '../../styles/media';
 @import '../../styles/theme_variables';
 
-.main-content {
+.main-content.item-page {
   position: relative;
   width: 100%;
   min-height: 100vh;

--- a/src/pages/ItemDetails/ItemDetails.scss
+++ b/src/pages/ItemDetails/ItemDetails.scss
@@ -2,150 +2,155 @@
 @import '../../styles/theme_variables';
 
 .main-content.item-page {
-  position: relative;
-  width: 100%;
-  min-height: 100vh;
-  -webkit-transition: opacity .2s ease;
-  transition: opacity .2s ease;
-  box-sizing: border-box;
-  padding: 8px 0;
-  z-index: 0;
+    position: relative;
+    width: 100%;
+    min-height: 100vh;
+    -webkit-transition: opacity 0.2s ease;
+    transition: opacity 0.2s ease;
+    box-sizing: border-box;
+    padding: 8px 0;
+    z-index: 0;
 
     .item {
-      box-sizing: border-box;
-      padding: 10px 40px 0 40px;
-      z-index: 0;
+        box-sizing: border-box;
+        padding: 10px 40px 0 40px;
+        z-index: 0;
     }
 
     @media #{$tablet-only} {
-      .item {
-        padding: 10px 20px 0 40px;
-      }
+        .item {
+            padding: 10px 20px 0 40px;
+        }
     }
 
     @media #{$mobile-only} {
-      .item {
-        box-sizing: border-box;
-        padding: 110px 15px 0 15px;
-      }
+        .item {
+            box-sizing: border-box;
+            padding: 110px 15px 0 15px;
+        }
     }
 
     .head-margin {
-      margin-bottom: 15px;
+        margin-bottom: 15px;
     }
 
-    p {
-      margin: 2px 0;
+    .item > p,
+    .item-header > p,
+    .laptop > p {
+        margin: 2px 0;
     }
 
     .subject {
-      word-wrap: break-word;
-      margin-top: 20px;
+        word-wrap: break-word;
+        margin-top: 20px;
     }
 
-    a {
-      cursor: pointer;
-      text-decoration: none;
+    .item-header a,
+    .laptop a,
+    .subject a,
+    .pollContent a {
+        cursor: pointer;
+        text-decoration: none;
     }
 
     @media #{$mobile-only} {
-      .laptop {
-        display: none;
-      }
+        .laptop {
+            display: none;
+        }
     }
 
     @media #{$laptop-only} {
-      .mobile {
-        display: none;
-      }
+        .mobile {
+            display: none;
+        }
     }
 
     .title {
-      font-size: 16px;
-      font-family: Verdana, Geneva, sans-serif;
+        font-size: 16px;
+        font-family: Verdana, Geneva, sans-serif;
     }
 
     .title-block {
-      text-align: center;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      overflow: hidden;
-      margin: 0 75px;
+        text-align: center;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        overflow: hidden;
+        margin: 0 75px;
     }
 
     @media #{$mobile-only} {
-      .title {
-        font-size: 15px;
-      }
-      .back-button {
-        position: absolute;
-        top: 52%;
-        width: 0.6rem;
-        height: 0.6rem;
-        background: transparent;
-        box-shadow: 0 0 0 lightgray;
-        transition: all 200ms ease;
-        left: 4%;
-        transform: translate3d(0, -50%, 0) rotate(-135deg);
-      }
+        .title {
+            font-size: 15px;
+        }
+        .back-button {
+            position: absolute;
+            top: 52%;
+            width: 0.6rem;
+            height: 0.6rem;
+            background: transparent;
+            box-shadow: 0 0 0 lightgray;
+            transition: all 200ms ease;
+            left: 4%;
+            transform: translate3d(0, -50%, 0) rotate(-135deg);
+        }
     }
 
     .subtext {
-      font-size: 12px;
-      font-weight: bold;
-      letter-spacing: 0.5px;
+        font-size: 12px;
+        font-weight: bold;
+        letter-spacing: 0.5px;
     }
 
     .domain {
-      letter-spacing: 0.5px;
+        letter-spacing: 0.5px;
     }
 
     .subtext a {
-      &:hover {
-        text-decoration: underline;
-      }
+        &:hover {
+            text-decoration: underline;
+        }
     }
 
     .item-details {
-      padding: 10px;
+        padding: 10px;
     }
 
     .item-header {
-      padding-bottom: 10px;
+        padding-bottom: 10px;
     }
 
     @media #{$mobile-only} {
-      .item-header {
-        padding: 10px 0 10px 0;
-        position: fixed;
-        width: 100%;
-        left: 0;
-        top: 62px;
-      }
+        .item-header {
+            padding: 10px 0 10px 0;
+            position: fixed;
+            width: 100%;
+            left: 0;
+            top: 62px;
+        }
     }
 
     .pollResults {
-      margin-bottom: 1em;
+        margin-bottom: 1em;
     }
 
     .pollContent {
-      * {
-        padding-bottom: 0;
-        margin-bottom: -1em;
-        margin-top: 1em;
-      }
-      .pollBar {
-        height: 10px;
-        margin-bottom: 1em;
-      }
+        * {
+            padding-bottom: 0;
+            margin-bottom: -1em;
+            margin-top: 1em;
+        }
+        .pollBar {
+            height: 10px;
+            margin-bottom: 1em;
+        }
     }
 
-    ul {
-      list-style-type: none;
-      padding: 10px 0;
-    }
+    .comment-list {
+        list-style-type: none;
+        padding: 10px 0;
 
-    li {
-      display: list-item;
+        > li {
+            display: list-item;
+        }
     }
 }

--- a/src/pages/ItemDetails/ItemDetails.scss
+++ b/src/pages/ItemDetails/ItemDetails.scss
@@ -1,0 +1,151 @@
+@import '../../styles/media';
+@import '../../styles/theme_variables';
+
+.main-content {
+  position: relative;
+  width: 100%;
+  min-height: 100vh;
+  -webkit-transition: opacity .2s ease;
+  transition: opacity .2s ease;
+  box-sizing: border-box;
+  padding: 8px 0;
+  z-index: 0;
+
+    .item {
+      box-sizing: border-box;
+      padding: 10px 40px 0 40px;
+      z-index: 0;
+    }
+
+    @media #{$tablet-only} {
+      .item {
+        padding: 10px 20px 0 40px;
+      }
+    }
+
+    @media #{$mobile-only} {
+      .item {
+        box-sizing: border-box;
+        padding: 110px 15px 0 15px;
+      }
+    }
+
+    .head-margin {
+      margin-bottom: 15px;
+    }
+
+    p {
+      margin: 2px 0;
+    }
+
+    .subject {
+      word-wrap: break-word;
+      margin-top: 20px;
+    }
+
+    a {
+      cursor: pointer;
+      text-decoration: none;
+    }
+
+    @media #{$mobile-only} {
+      .laptop {
+        display: none;
+      }
+    }
+
+    @media #{$laptop-only} {
+      .mobile {
+        display: none;
+      }
+    }
+
+    .title {
+      font-size: 16px;
+      font-family: Verdana, Geneva, sans-serif;
+    }
+
+    .title-block {
+      text-align: center;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      overflow: hidden;
+      margin: 0 75px;
+    }
+
+    @media #{$mobile-only} {
+      .title {
+        font-size: 15px;
+      }
+      .back-button {
+        position: absolute;
+        top: 52%;
+        width: 0.6rem;
+        height: 0.6rem;
+        background: transparent;
+        box-shadow: 0 0 0 lightgray;
+        transition: all 200ms ease;
+        left: 4%;
+        transform: translate3d(0, -50%, 0) rotate(-135deg);
+      }
+    }
+
+    .subtext {
+      font-size: 12px;
+      font-weight: bold;
+      letter-spacing: 0.5px;
+    }
+
+    .domain {
+      letter-spacing: 0.5px;
+    }
+
+    .subtext a {
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+
+    .item-details {
+      padding: 10px;
+    }
+
+    .item-header {
+      padding-bottom: 10px;
+    }
+
+    @media #{$mobile-only} {
+      .item-header {
+        padding: 10px 0 10px 0;
+        position: fixed;
+        width: 100%;
+        left: 0;
+        top: 62px;
+      }
+    }
+
+    .pollResults {
+      margin-bottom: 1em;
+    }
+
+    .pollContent {
+      * {
+        padding-bottom: 0;
+        margin-bottom: -1em;
+        margin-top: 1em;
+      }
+      .pollBar {
+        height: 10px;
+        margin-bottom: 1em;
+      }
+    }
+
+    ul {
+      list-style-type: none;
+      padding: 10px 0;
+    }
+
+    li {
+      display: list-item;
+    }
+}

--- a/src/pages/ItemDetails/ItemDetails.tsx
+++ b/src/pages/ItemDetails/ItemDetails.tsx
@@ -1,0 +1,111 @@
+import { useEffect } from 'react';
+import { Link, useNavigate, useParams } from 'react-router';
+
+import { CommentThread } from '../../components/CommentThread/CommentThread';
+import { ErrorMessage } from '../../components/ErrorMessage/ErrorMessage';
+import { Loader } from '../../components/Loader/Loader';
+import { useSettings } from '../../context/settingsContext';
+import { useApiRequest } from '../../hooks/useApiRequest';
+import { fetchItemContent } from '../../services/hackerNewsApi';
+import { formatCommentCount } from '../../utils/formatCommentCount';
+
+import './ItemDetails.scss';
+
+export function ItemDetails() {
+    const { id } = useParams();
+    const itemId = Number(id);
+    const navigate = useNavigate();
+    const { settings } = useSettings();
+
+    const { data: item, error } = useApiRequest(
+        (signal) => fetchItemContent(itemId, signal),
+        'Could not load item comments.',
+        [itemId]
+    );
+
+    useEffect(() => {
+        window.scrollTo(0, 0);
+    }, [itemId]);
+
+    if (!item) {
+        return <div className="main-content">{error === '' ? <Loader /> : <ErrorMessage message={error} />}</div>;
+    }
+
+    const hasUrl = item.url?.startsWith('http') ?? false;
+    const isJob = item.type === 'job';
+    const linkTarget = settings.openLinkInNewTab ? { target: '_blank', rel: 'noopener noreferrer' } : {};
+    const titleLink = hasUrl ? (
+        <a className="title" href={item.url} {...linkTarget}>
+            {item.title}
+        </a>
+    ) : (
+        <Link className="title" to={`/item/${item.id}`}>
+            {item.title}
+        </Link>
+    );
+
+    const laptopClasses = ['laptop'];
+    if (item.comments_count > 0 || isJob) {
+        laptopClasses.push('item-header');
+    }
+    if (item.content) {
+        laptopClasses.push('head-margin');
+    }
+
+    return (
+        <div className="main-content">
+            <div className="item">
+                <div className="mobile item-header">
+                    <p className="title-block">
+                        <span className="back-button" onClick={() => navigate(-1)} />
+                        {titleLink}
+                    </p>
+                </div>
+                <div className={laptopClasses.join(' ')}>
+                    <p>
+                        {titleLink}
+                        {hasUrl && item.domain && <span className="domain">({item.domain})</span>}
+                    </p>
+                    <div className="subtext">
+                        {!isJob && (
+                            <span>
+                                {item.points} points by <Link to={`/user/${item.user}`}>{item.user}</Link>
+                            </span>
+                        )}
+                        <span className={isJob ? undefined : 'item-details'}>
+                            {item.time_ago}
+                            {!isJob && (
+                                <span>
+                                    {' '}
+                                    | <Link to={`/item/${item.id}`}>{formatCommentCount(item.comments_count)}</Link>
+                                </span>
+                            )}
+                        </span>
+                    </div>
+                </div>
+                {item.type === 'poll' && (
+                    <div className="pollResults">
+                        {item.poll.map((pollResult, index) => (
+                            <div className="pollContent" key={index}>
+                                <div dangerouslySetInnerHTML={{ __html: pollResult.content }} />
+                                <div className="subtext">{pollResult.points} points</div>
+                                <div
+                                    className="pollBar"
+                                    style={{ width: `${(pollResult.points / item.poll_votes_count) * 100}%` }}
+                                />
+                            </div>
+                        ))}
+                    </div>
+                )}
+                <p className="subject" dangerouslySetInnerHTML={{ __html: item.content }} />
+                <ul className="comment-list">
+                    {item.comments?.map((comment) => (
+                        <li key={comment.id}>
+                            <CommentThread comment={comment} />
+                        </li>
+                    ))}
+                </ul>
+            </div>
+        </div>
+    );
+}

--- a/src/pages/ItemDetails/ItemDetails.tsx
+++ b/src/pages/ItemDetails/ItemDetails.tsx
@@ -85,7 +85,7 @@ export function ItemDetails() {
                 </div>
                 {item.type === 'poll' && (
                     <div className="pollResults">
-                        {item.poll.map((pollResult, index) => (
+                        {item.poll?.map((pollResult, index) => (
                             <div className="pollContent" key={index}>
                                 <div dangerouslySetInnerHTML={{ __html: pollResult.content }} />
                                 <div className="subtext">{pollResult.points} points</div>

--- a/src/pages/ItemDetails/ItemDetails.tsx
+++ b/src/pages/ItemDetails/ItemDetails.tsx
@@ -28,7 +28,9 @@ export function ItemDetails() {
     }, [itemId]);
 
     if (!item) {
-        return <div className="main-content">{error === '' ? <Loader /> : <ErrorMessage message={error} />}</div>;
+        return (
+            <div className="main-content item-page">{error === '' ? <Loader /> : <ErrorMessage message={error} />}</div>
+        );
     }
 
     const hasUrl = item.url?.startsWith('http') ?? false;
@@ -53,7 +55,7 @@ export function ItemDetails() {
     }
 
     return (
-        <div className="main-content">
+        <div className="main-content item-page">
             <div className="item">
                 <div className="mobile item-header">
                     <p className="title-block">
@@ -96,7 +98,11 @@ export function ItemDetails() {
                                 <div className="subtext">{pollResult.points} points</div>
                                 <div
                                     className="pollBar"
-                                    style={{ width: `${(pollResult.points / item.poll_votes_count) * 100}%` }}
+                                    style={{
+                                        width: item.poll_votes_count
+                                            ? `${(pollResult.points / item.poll_votes_count) * 100}%`
+                                            : 0,
+                                    }}
                                 />
                             </div>
                         ))}

--- a/src/pages/ItemDetails/ItemDetails.tsx
+++ b/src/pages/ItemDetails/ItemDetails.tsx
@@ -64,7 +64,12 @@ export function ItemDetails() {
                 <div className={laptopClasses.join(' ')}>
                     <p>
                         {titleLink}
-                        {hasUrl && item.domain && <span className="domain">({item.domain})</span>}
+                        {hasUrl && item.domain && (
+                            <>
+                                {' '}
+                                <span className="domain">({item.domain})</span>
+                            </>
+                        )}
                     </p>
                     <div className="subtext">
                         {!isJob && (

--- a/src/pages/User/User.scss
+++ b/src/pages/User/User.scss
@@ -1,0 +1,89 @@
+@import '../../styles/media';
+@import '../../styles/theme_variables';
+
+.profile pre {
+  white-space: pre-wrap;
+}
+
+.profile {
+  padding: 30px;
+}
+
+@media #{$mobile-only} {
+  .profile {
+    padding: 110px 15px 0 15px;
+  }
+  .title-block {
+    font-size: 15px;
+    text-align: center;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    margin: 0 75px;
+  }
+  .back-button {
+    position: absolute;
+    top: 52%;
+    width: 0.6rem;
+    height: 0.6rem;
+    background: transparent;
+    box-shadow: 0 0 0 lightgray;
+    transition: all 200ms ease;
+    left: 4%;
+    transform: translate3d(0, -50%, 0) rotate(-135deg);
+  }
+  .item-header {
+    padding-bottom: 10px;
+    background-color: #fff;
+    padding: 10px 0 10px 0;
+    position: fixed;
+    width: 100%;
+    left: 0;
+    top: 62px;
+    height: 20px;
+  }
+}
+
+@media #{$laptop-only} {
+  .mobile {
+    display: none;
+  }
+}
+
+.main-details {
+  .name {
+    font-weight: bold;
+    font-size: 32px;
+    letter-spacing: 2px;
+  }
+  .age {
+    font-weight: bold;
+    color: #696969;
+    padding-bottom: 0;
+  }
+  .right {
+    float: right;
+    font-weight: bold;
+    font-size: 32px;
+    letter-spacing: 2px;
+  }
+}
+
+@media #{$mobile-only} {
+  .main-details {
+    margin-top: 20px;
+    .name {
+      font-size: 18px;
+    }
+  }
+}
+
+@media #{$mobile-only} {
+  .main-details .right {
+    font-size: 18px;
+  }
+}
+
+.other-details {
+  word-wrap: break-word;
+}

--- a/src/pages/User/User.scss
+++ b/src/pages/User/User.scss
@@ -1,89 +1,86 @@
 @import '../../styles/media';
 @import '../../styles/theme_variables';
 
-.profile pre {
-  white-space: pre-wrap;
-}
-
 .profile {
   padding: 30px;
-}
 
-@media #{$mobile-only} {
-  .profile {
+  pre {
+    white-space: pre-wrap;
+  }
+
+  @media #{$mobile-only} {
     padding: 110px 15px 0 15px;
-  }
-  .title-block {
-    font-size: 15px;
-    text-align: center;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    overflow: hidden;
-    margin: 0 75px;
-  }
-  .back-button {
-    position: absolute;
-    top: 52%;
-    width: 0.6rem;
-    height: 0.6rem;
-    background: transparent;
-    box-shadow: 0 0 0 lightgray;
-    transition: all 200ms ease;
-    left: 4%;
-    transform: translate3d(0, -50%, 0) rotate(-135deg);
-  }
-  .item-header {
-    padding-bottom: 10px;
-    background-color: #fff;
-    padding: 10px 0 10px 0;
-    position: fixed;
-    width: 100%;
-    left: 0;
-    top: 62px;
-    height: 20px;
-  }
-}
 
-@media #{$laptop-only} {
-  .mobile {
-    display: none;
-  }
-}
+    .title-block {
+      font-size: 15px;
+      text-align: center;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      overflow: hidden;
+      margin: 0 75px;
+    }
 
-.main-details {
-  .name {
-    font-weight: bold;
-    font-size: 32px;
-    letter-spacing: 2px;
-  }
-  .age {
-    font-weight: bold;
-    color: #696969;
-    padding-bottom: 0;
-  }
-  .right {
-    float: right;
-    font-weight: bold;
-    font-size: 32px;
-    letter-spacing: 2px;
-  }
-}
+    .back-button {
+      position: absolute;
+      top: 52%;
+      width: 0.6rem;
+      height: 0.6rem;
+      background: transparent;
+      box-shadow: 0 0 0 lightgray;
+      transition: all 200ms ease;
+      left: 4%;
+      transform: translate3d(0, -50%, 0) rotate(-135deg);
+    }
 
-@media #{$mobile-only} {
-  .main-details {
-    margin-top: 20px;
-    .name {
-      font-size: 18px;
+    .item-header {
+      padding-bottom: 10px;
+      background-color: #fff;
+      padding: 10px 0 10px 0;
+      position: fixed;
+      width: 100%;
+      left: 0;
+      top: 62px;
+      height: 20px;
     }
   }
-}
 
-@media #{$mobile-only} {
-  .main-details .right {
-    font-size: 18px;
+  @media #{$laptop-only} {
+    .mobile {
+      display: none;
+    }
   }
-}
 
-.other-details {
-  word-wrap: break-word;
+  .main-details {
+    .name {
+      font-weight: bold;
+      font-size: 32px;
+      letter-spacing: 2px;
+    }
+    .age {
+      font-weight: bold;
+      color: #696969;
+      padding-bottom: 0;
+    }
+    .right {
+      float: right;
+      font-weight: bold;
+      font-size: 32px;
+      letter-spacing: 2px;
+    }
+
+    @media #{$mobile-only} {
+      margin-top: 20px;
+
+      .name {
+        font-size: 18px;
+      }
+      .right {
+        font-size: 18px;
+      }
+    }
+  }
+
+  .other-details {
+    word-wrap: break-word;
+  }
 }

--- a/src/pages/User/User.tsx
+++ b/src/pages/User/User.tsx
@@ -1,0 +1,40 @@
+import { useNavigate, useParams } from 'react-router';
+
+import { ErrorMessage } from '../../components/ErrorMessage/ErrorMessage';
+import { Loader } from '../../components/Loader/Loader';
+import { useApiRequest } from '../../hooks/useApiRequest';
+import { fetchUser } from '../../services/hackerNewsApi';
+
+import './User.scss';
+
+export function User() {
+    const { id = '' } = useParams();
+    const navigate = useNavigate();
+
+    const { data: user, error } = useApiRequest((signal) => fetchUser(id, signal), `Could not load user ${id}.`, [id]);
+
+    if (!user) {
+        return error === '' ? <Loader /> : <ErrorMessage message={error} />;
+    }
+
+    return (
+        <div className="profile">
+            <div className="mobile item-header">
+                <p className="title-block">
+                    <span className="back-button" onClick={() => navigate(-1)} />
+                    Profile: {user.id}
+                </p>
+            </div>
+            <div className="main-details">
+                <span className="name">{user.id}</span>
+                <span className="right">{user.karma} ★</span>
+                <p className="age">Created {user.created}</p>
+            </div>
+            {user.about && (
+                <div className="other-details">
+                    <p dangerouslySetInnerHTML={{ __html: user.about }} />
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -2,6 +2,8 @@ import { createBrowserRouter, Navigate } from 'react-router';
 
 import { App } from './App';
 import { Feed } from './pages/Feed/Feed';
+import { ItemDetails } from './pages/ItemDetails/ItemDetails';
+import { User } from './pages/User/User';
 
 const FEED_TYPES = ['news', 'newest', 'show', 'ask', 'jobs'];
 
@@ -15,6 +17,8 @@ export const router = createBrowserRouter([
                 path: `${feedType}/:page`,
                 element: <Feed feedType={feedType} />,
             })),
+            { path: 'item/:id', element: <ItemDetails /> },
+            { path: 'user/:id', element: <User /> },
         ],
     },
 ]);

--- a/src/types/story.ts
+++ b/src/types/story.ts
@@ -15,7 +15,7 @@ export interface Story {
     content: string;
     comments: Comment[];
     comments_count: number;
-    poll: PollResult[];
+    poll?: PollResult[];
     poll_votes_count: number;
     deleted: boolean;
     dead: boolean;


### PR DESCRIPTION
## Summary

Fourth of the 5-PR Angular → React stack (on top of #523). Ports `ItemDetailsModule` and `UserModule`, so `/item/:id` and `/user/:id` resolve and the app is functionally complete; PR 5 covers the PWA/service worker and docs.

- `ItemDetailsComponent` → `pages/ItemDetails`: one `useApiRequest(fetchItemContent, ..., [itemId])` replaces the nested route-params → API subscription, `Location.back()` → `useNavigate()(-1)`, and `[innerHTML]` → `dangerouslySetInnerHTML` for the API's pre-rendered HTML (story text, poll options, comment bodies) — same trust boundary as before, the HN API is the only source.
- `CommentComponent` → `components/CommentThread`: recursion is now the component calling itself, and the `collapse` field becomes `useState`. Collapsed subtrees keep using `hidden` rather than unmounting, so expanding restores each child's own collapse state exactly like the Angular version.
- `UserComponent` → `pages/User`. One difference: Angular rendered `Created {{ (user.created | amFromUnix) | amTimeAgo }}`, but `created` is already a humanised string in the payload, so the pipes would have formatted a non-timestamp; the port renders it verbatim.
- Poll bars keep the `points / poll_votes_count` width computation, guarded against a zero divisor; with PR 1's per-option error tolerance a missing option contributes a 0-width bar instead of failing the page.

Route table gains the two leaf routes:

```tsx
{ path: 'item/:id', element: <ItemDetails /> },
{ path: 'user/:id', element: <User /> },
```

Styles are the delicate part, since Angular's view encapsulation no longer keeps one page's stylesheet off another's markup. Each page now carries its own root class — item details renders `main-content item-page` with its stylesheet under `.main-content.item-page`, user styles nest under `.profile`, comment styles under `.comment` — and the item page's bare element rules are narrowed to its own markup (`.item > p`, `.item-header a`, `.comment-list`) so they can't outrank `.comment-text`/`.subtree`.

One intentional behaviour change: Angular bound `head-margin` to `item.text`, a field the model never had, so the class was dead. It now keys off `item.content`, so stories with body text get the 15px header margin the rule was written for.

Unrelated to this port: `node-hnapi.herokuapp.com` no longer serves `/user/:id` (404), so profile pages show the error state — the same endpoint, and the same result, as on `master`.

Link to Devin session: https://app.devin.ai/sessions/6490dc100d5b47f3adeb4684a88dd7bd
Requested by: @charityquinn-cognition
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/524?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/524" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/angular2-hn/pull/524" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->