### PR TITLE
Encode route params before interpolating into HN API request paths

### DIFF
--- a/src/app/shared/services/hackernews-api.service.ts
+++ b/src/app/shared/services/hackernews-api.service.ts
@@ -17,7 +17,7 @@ export class HackerNewsAPIService {
   }
 
   fetchFeed(feedType: string, page: number): Observable<Story[]> {
-    return lazyFetch(`${this.baseUrl}/${feedType}?page=${page}`);
+    return lazyFetch(`${this.baseUrl}/${encodeURIComponent(feedType)}?page=${encodeURIComponent(String(page))}`);
   }
 
   fetchItemContent(id: number): Observable<Story> {
@@ -41,7 +41,7 @@ export class HackerNewsAPIService {
   }
 
   fetchUser(id: string): Observable<User> {
-    return lazyFetch(`${this.baseUrl}/user/${id}`);
+    return lazyFetch(`${this.baseUrl}/user/${encodeURIComponent(id)}`);
   }
 }
 

--- a/src/app/user/user.component.ts
+++ b/src/app/user/user.component.ts
@@ -6,6 +6,8 @@ import { Subscription } from 'rxjs/Subscription';
 import { HackerNewsAPIService } from '../shared/services/hackernews-api.service';
 import { User } from '../shared/models/user';
 
+const USERNAME_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
+
 @Component({
   selector: 'app-user',
   templateUrl: './user.component.html',
@@ -25,6 +27,11 @@ export class UserComponent implements OnInit {
   ngOnInit() {
     this.sub = this.route.params.subscribe(params => {
       let userID = params['id'];
+      if (!USERNAME_PATTERN.test(userID)) {
+        this.user = undefined;
+        this.errorMessage = 'Could not load user ' + userID + '.';
+        return;
+      }
       this._hackerNewsAPIService.fetchUser(userID).subscribe(data => {
         this.user = data;
       }, error => this.errorMessage = 'Could not load user ' + userID + '.');


### PR DESCRIPTION
## Summary

The `:id` route segment reached the upstream request URL verbatim, so a crafted link (`/user/x?foo=bar`, `/user/x/../item/1`) let an attacker shape extra path/query segments of the request the victim's browser sends to `node-hnapi.herokuapp.com`.

Fix is input encoding at the sink plus a whitelist check at the source:

```diff
- lazyFetch(`${this.baseUrl}/user/${id}`)
+ lazyFetch(`${this.baseUrl}/user/${encodeURIComponent(id)}`)

- lazyFetch(`${this.baseUrl}/${feedType}?page=${page}`)
+ lazyFetch(`${this.baseUrl}/${encodeURIComponent(feedType)}?page=${encodeURIComponent(String(page))}`)
```

`user.component.ts` now rejects any `:id` not matching `/^[A-Za-z0-9_-]{1,64}$/` before calling the service, showing the existing "Could not load user" message instead of issuing a request. `fetchItemContent`/`fetchPollContent` take `number` ids and are unaffected.


Link to Devin session: https://app.devin.ai/sessions/97dcdb5cbc89400895573f12ed79d391
Requested by: @vibhaseshadri-cognition
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/534?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/534" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->