### PR TITLE
[3/7] Migrate shared and core UI components to React

### DIFF
--- a/react-app/src/App.test.tsx
+++ b/react-app/src/App.test.tsx
@@ -1,0 +1,40 @@
+import { screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import App from './App';
+import { renderWithProviders } from './test/renderWithProviders';
+
+describe('App', () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('applies the current theme to the shell and renders header, routes and footer', () => {
+        localStorage.setItem('theme', 'night');
+
+        const { container } = renderWithProviders(<App />, { route: '/news/1' });
+
+        expect(container.querySelector('.night')).not.toBeNull();
+        expect(screen.getByRole('img', { name: 'Logo' })).toBeInTheDocument();
+        expect(screen.getByTestId('feed-page')).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: 'GitHub' })).toBeInTheDocument();
+    });
+
+    it('sends a Google Analytics pageview for the current route', () => {
+        const ga = vi.fn();
+        vi.stubGlobal('ga', ga);
+
+        renderWithProviders(<App />, { route: '/user/pg' });
+
+        expect(ga).toHaveBeenCalledWith('set', 'page', '/user/pg');
+        expect(ga).toHaveBeenCalledWith('send', 'pageview');
+    });
+
+    it('does not break when Google Analytics is unavailable', () => {
+        expect(() => renderWithProviders(<App />, { route: '/news/1' })).not.toThrow();
+    });
+});

--- a/react-app/src/App.tsx
+++ b/react-app/src/App.tsx
@@ -1,12 +1,21 @@
+import Footer from './core/Footer';
+import Header from './core/Header';
+import { usePageViews } from './core/usePageViews';
 import AppRoutes from './router/AppRoutes';
+import { useSettings } from './shared/settings/useSettings';
 import './App.scss';
 
 export default function App() {
+    const settings = useSettings();
+    usePageViews();
+
     return (
-        <div className="default">
+        <div className={settings.theme}>
             <div className="body-cover"></div>
             <div className="wrapper">
+                <Header />
                 <AppRoutes />
+                <Footer />
             </div>
         </div>
     );

--- a/react-app/src/core/Footer.scss
+++ b/react-app/src/core/Footer.scss
@@ -1,0 +1,23 @@
+@import '../styles/media';
+@import '../styles/theme_variables';
+
+#footer {
+    position: relative;
+    padding: 10px;
+    height: 60px;
+    letter-spacing: 0.7px;
+    text-align: center;
+
+    a {
+        font-weight: bold;
+        text-decoration: none;
+
+        &:hover {
+            text-decoration: underline;
+        }
+    }
+
+    @media #{$mobile-only} {
+        display: none;
+    }
+}

--- a/react-app/src/core/Footer.test.tsx
+++ b/react-app/src/core/Footer.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import Footer from './Footer';
+
+describe('Footer', () => {
+    it('links to the project on GitHub in a new tab', () => {
+        render(<Footer />);
+
+        const link = screen.getByRole('link', { name: 'GitHub' });
+        expect(link).toHaveAttribute('href', 'https://github.com/hdjirdeh/angular2-hn');
+        expect(link).toHaveAttribute('target', '_blank');
+        expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'));
+    });
+});

--- a/react-app/src/core/Footer.tsx
+++ b/react-app/src/core/Footer.tsx
@@ -1,0 +1,14 @@
+import './Footer.scss';
+
+export default function Footer() {
+    return (
+        <div id="footer">
+            <p>
+                Show this project some ❤ on{' '}
+                <a href="https://github.com/hdjirdeh/angular2-hn" target="_blank" rel="noopener noreferrer">
+                    GitHub
+                </a>
+            </p>
+        </div>
+    );
+}

--- a/react-app/src/core/Header.scss
+++ b/react-app/src/core/Header.scss
@@ -1,0 +1,149 @@
+@import '../styles/media';
+@import '../styles/theme_variables';
+
+#header {
+    color: #fff;
+    padding: 6px 0;
+    line-height: 18px;
+    vertical-align: middle;
+    position: relative;
+    z-index: 1;
+    width: 100%;
+
+    @media #{$mobile-only} {
+        height: 50px;
+        position: fixed;
+        top: 0;
+    }
+
+    a {
+        display: inline;
+    }
+}
+
+.home-link {
+    width: 50px;
+    height: 66px;
+}
+
+.logo-inner {
+    width: 32px;
+    position: absolute;
+    left: 17px;
+    top: 18px;
+    z-index: -1;
+    height: 32px;
+    border-radius: 50%;
+
+    @media #{$mobile-only} {
+        left: 16px;
+        top: 12px;
+    }
+}
+
+.logo {
+    width: 50px;
+    padding: 3px 8px 0;
+
+    @media #{$mobile-only} {
+        width: 45px;
+        padding: 0 0 0 10px;
+    }
+}
+
+h1 {
+    font-weight: normal;
+    display: inline-block;
+    vertical-align: middle;
+    margin: 0;
+    font-size: 16px;
+
+    a {
+        color: #fff;
+        text-decoration: none;
+    }
+}
+
+.name {
+    margin-right: 30px;
+    margin-bottom: 2px;
+
+    @media #{$mobile-only} {
+        display: none;
+    }
+}
+
+.header-text {
+    position: absolute;
+    width: inherit;
+    height: 20px;
+    left: 10px;
+    top: 27px;
+    z-index: -1;
+
+    @media #{$mobile-only} {
+        top: 22px;
+    }
+}
+
+.left {
+    position: absolute;
+    left: 60px;
+    font-size: 16px;
+
+    @media #{$mobile-only} {
+        width: 100%;
+        left: 0;
+    }
+}
+
+.header-nav {
+    display: inline-block;
+    margin-left: 20px;
+
+    @media #{$mobile-only} {
+        margin-left: 60px;
+    }
+
+    a {
+        color: hsla(0, 0%, 100%, 0.9);
+        text-decoration: none;
+        margin: 0 5px;
+        letter-spacing: 1.8px;
+
+        &:hover {
+            color: #fff;
+        }
+    }
+
+    .active {
+        color: #fff;
+    }
+}
+
+.info {
+    position: absolute;
+    top: 0;
+    right: 20px;
+    height: 100%;
+
+    @media #{$mobile-only} {
+        right: 10px;
+    }
+
+    img {
+        opacity: 0.8;
+        width: 25px;
+        margin-top: 21.5px;
+        display: block;
+
+        &:hover {
+            opacity: 1;
+            cursor: pointer;
+        }
+
+        @media #{$mobile-only} {
+            margin-top: 15px;
+        }
+    }
+}

--- a/react-app/src/core/Header.test.tsx
+++ b/react-app/src/core/Header.test.tsx
@@ -1,0 +1,51 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { renderWithProviders } from '../test/renderWithProviders';
+import Header from './Header';
+
+describe('Header', () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    it('renders the feed navigation', () => {
+        renderWithProviders(<Header />);
+
+        expect(screen.getByRole('link', { name: 'new' })).toHaveAttribute('href', '/newest/1');
+        expect(screen.getByRole('link', { name: 'show' })).toHaveAttribute('href', '/show/1');
+        expect(screen.getByRole('link', { name: 'ask' })).toHaveAttribute('href', '/ask/1');
+        expect(screen.getByRole('link', { name: 'jobs' })).toHaveAttribute('href', '/jobs/1');
+        expect(screen.getByRole('img', { name: 'Logo' }).closest('a')).toHaveAttribute('href', '/news/1');
+    });
+
+    it('marks the link of the current feed as active', () => {
+        renderWithProviders(<Header />, { route: '/show/1' });
+
+        expect(screen.getByRole('link', { name: 'show' })).toHaveClass('active');
+        expect(screen.getByRole('link', { name: 'ask' })).not.toHaveClass('active');
+    });
+
+    it('scrolls to the top when a feed link is clicked', async () => {
+        const scrollTo = vi.fn();
+        vi.stubGlobal('scrollTo', scrollTo);
+        renderWithProviders(<Header />);
+
+        await userEvent.click(screen.getByRole('link', { name: 'new' }));
+
+        expect(scrollTo).toHaveBeenCalledWith(0, 0);
+        vi.unstubAllGlobals();
+    });
+
+    it('toggles the settings panel through the store', async () => {
+        const { store } = renderWithProviders(<Header />);
+
+        expect(screen.queryByRole('heading', { name: 'Settings' })).not.toBeInTheDocument();
+
+        await userEvent.click(screen.getByRole('img', { name: 'Settings' }));
+
+        expect(store.getSettings().showSettings).toBe(true);
+        expect(screen.getByRole('heading', { name: 'Settings' })).toBeInTheDocument();
+    });
+});

--- a/react-app/src/core/Header.tsx
+++ b/react-app/src/core/Header.tsx
@@ -1,0 +1,57 @@
+import { NavLink } from 'react-router-dom';
+
+import { useSettings, useSettingsStore } from '../shared/settings/useSettings';
+import Settings from './Settings';
+import './Header.scss';
+
+const feedLinks = [
+    { to: '/newest/1', label: 'new' },
+    { to: '/show/1', label: 'show' },
+    { to: '/ask/1', label: 'ask' },
+    { to: '/jobs/1', label: 'jobs' },
+];
+
+const activeClassName = ({ isActive }: { isActive: boolean }) => (isActive ? 'active' : undefined);
+
+function scrollTop() {
+    window.scrollTo(0, 0);
+}
+
+export default function Header() {
+    const settings = useSettings();
+    const store = useSettingsStore();
+
+    return (
+        <header>
+            <div id="header">
+                <NavLink className="home-link" to="/news/1" onClick={scrollTop}>
+                    <div className="logo-inner"></div>
+                    <img className="logo" src="/assets/images/logo.svg" alt="Logo" />
+                </NavLink>
+                <div className="header-text">
+                    <div className="left">
+                        <span className="header-nav">
+                            {feedLinks.map(({ to, label }, index) => (
+                                <span key={to}>
+                                    {index > 0 && ' | '}
+                                    <NavLink to={to} className={activeClassName} onClick={scrollTop}>
+                                        {label}
+                                    </NavLink>
+                                </span>
+                            ))}
+                        </span>
+                    </div>
+                </div>
+                <div className="info">
+                    <img
+                        className="settings"
+                        src="/assets/images/cog.svg"
+                        alt="Settings"
+                        onClick={() => store.toggleSettings()}
+                    />
+                </div>
+            </div>
+            {settings.showSettings && <Settings />}
+        </header>
+    );
+}

--- a/react-app/src/core/Settings.scss
+++ b/react-app/src/core/Settings.scss
@@ -1,0 +1,75 @@
+@import '../styles/media';
+@import '../styles/theme_variables';
+
+.overlay {
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background: rgba(0, 0, 0, 0.7);
+    opacity: 1;
+    z-index: 1;
+}
+
+.popup {
+    margin: 70px auto;
+    padding: 30px;
+    border-radius: 5px;
+    width: 30%;
+    position: relative;
+    h1 {
+        margin-top: 0;
+        margin-bottom: 0px;
+        color: #fff;
+        text-align: center;
+        letter-spacing: 1px;
+    }
+    h2 {
+        padding-top: 10px;
+    }
+    hr {
+        width: 40%;
+        margin-bottom: 20px;
+    }
+    .close {
+        position: absolute;
+        top: 12px;
+        right: 20px;
+        font-size: 30px;
+        font-weight: bold;
+        text-decoration: none;
+        color: rgba(255, 255, 255, 0.8);
+        &:hover {
+            color: #fff;
+            cursor: pointer;
+        }
+    }
+    .content {
+        max-height: 30%;
+        color: #fff;
+        letter-spacing: 1px;
+        overflow: auto;
+    }
+    input[type='number'] {
+        display: block;
+        width: 80%;
+        height: 20px;
+        margin-bottom: 15px;
+        border-radius: 5px;
+        padding: 2px;
+    }
+}
+
+.control-section {
+    margin-bottom: 15px;
+    padding-bottom: 15px;
+    border-bottom: 1px solid white;
+}
+
+@media screen and (max-width: 700px) {
+    .box,
+    .popup {
+        width: 70%;
+    }
+}

--- a/react-app/src/core/Settings.test.tsx
+++ b/react-app/src/core/Settings.test.tsx
@@ -1,0 +1,55 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { renderWithProviders } from '../test/renderWithProviders';
+import Settings from './Settings';
+
+describe('Settings', () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    it('closes the panel through the store', async () => {
+        const { store } = renderWithProviders(<Settings />);
+        store.toggleSettings();
+
+        await userEvent.click(screen.getByRole('button', { name: 'Close settings' }));
+
+        expect(store.getSettings().showSettings).toBe(false);
+    });
+
+    it('toggles opening links in a new tab', async () => {
+        const { store } = renderWithProviders(<Settings />);
+
+        await userEvent.click(screen.getByRole('checkbox', { name: /open links in a new tab/i }));
+
+        expect(store.getSettings().openLinkInNewTab).toBe(true);
+        expect(localStorage.getItem('openLinkInNewTab')).toBe('true');
+    });
+
+    it('selects a theme', async () => {
+        const { store } = renderWithProviders(<Settings />);
+
+        expect(screen.getByRole('radio', { name: 'Default' })).toBeChecked();
+
+        await userEvent.click(screen.getByRole('radio', { name: 'Black (AMOLED)' }));
+
+        expect(store.getSettings().theme).toBe('amoledblack');
+        expect(screen.getByRole('radio', { name: 'Black (AMOLED)' })).toBeChecked();
+    });
+
+    it('changes the title font size and the list spacing', async () => {
+        const { store } = renderWithProviders(<Settings />);
+
+        const fontSize = screen.getByRole('spinbutton', { name: /font size/i });
+        await userEvent.clear(fontSize);
+        await userEvent.type(fontSize, '20');
+        expect(store.getSettings().titleFontSize).toBe('20');
+
+        const spacing = screen.getByRole('spinbutton', { name: /list spacing/i });
+        await userEvent.clear(spacing);
+        await userEvent.type(spacing, '5');
+        expect(store.getSettings().listSpacing).toBe('5');
+    });
+});

--- a/react-app/src/core/Settings.tsx
+++ b/react-app/src/core/Settings.tsx
@@ -1,0 +1,89 @@
+import { useSettings, useSettingsStore } from '../shared/settings/useSettings';
+import './Settings.scss';
+
+const themes = [
+    { value: 'default', label: 'Default' },
+    { value: 'night', label: 'Night' },
+    { value: 'amoledblack', label: 'Black (AMOLED)' },
+];
+
+export default function Settings() {
+    const settings = useSettings();
+    const store = useSettingsStore();
+
+    return (
+        <div id="popup1" className="overlay">
+            <div className="popup">
+                <h1>Settings</h1>
+                <hr />
+                <span
+                    className="close"
+                    role="button"
+                    aria-label="Close settings"
+                    onClick={() => store.toggleSettings()}
+                >
+                    &times;
+                </span>
+                <div className="content">
+                    <div className="control-section">
+                        <h2>Links</h2>
+                        <label>
+                            <input
+                                type="checkbox"
+                                checked={settings.openLinkInNewTab}
+                                onChange={() => store.toggleOpenLinksInNewTab()}
+                            />
+                            Open links in a new tab
+                        </label>
+                    </div>
+                    <div className="theme-controls">
+                        <div className="control-section">
+                            <h2>Select a theme</h2>
+                            {themes.map(({ value, label }) => (
+                                <div key={value}>
+                                    <label>
+                                        <input
+                                            name="theme"
+                                            type="radio"
+                                            value={value}
+                                            checked={settings.theme === value}
+                                            onChange={() => store.setTheme(value)}
+                                        />
+                                        {label}
+                                    </label>
+                                </div>
+                            ))}
+                        </div>
+                        <div className="control-section">
+                            <h2>Change Font</h2>
+                            <div>
+                                <label>
+                                    Font size:
+                                    <input
+                                        min="1"
+                                        name="titleFontSize"
+                                        type="number"
+                                        value={settings.titleFontSize}
+                                        onChange={(event) => store.setFont(event.target.value)}
+                                    />
+                                </label>
+                            </div>
+                            <div>
+                                <label>
+                                    List spacing:
+                                    <input
+                                        min="0"
+                                        name="listSpacing"
+                                        type="number"
+                                        value={settings.listSpacing}
+                                        onChange={(event) => store.setSpacing(event.target.value)}
+                                    />
+                                </label>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/react-app/src/core/usePageViews.ts
+++ b/react-app/src/core/usePageViews.ts
@@ -1,0 +1,13 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+/** Sends a Google Analytics pageview whenever navigation settles, as the Angular app did on NavigationEnd. */
+export function usePageViews(): void {
+    const location = useLocation();
+
+    useEffect(() => {
+        const page = `${location.pathname}${location.search}${location.hash}`;
+        window.ga?.('set', 'page', page);
+        window.ga?.('send', 'pageview');
+    }, [location.pathname, location.search, location.hash]);
+}

--- a/react-app/src/main.tsx
+++ b/react-app/src/main.tsx
@@ -3,12 +3,15 @@ import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 
 import App from './App';
+import { SettingsProvider } from './shared/settings/SettingsProvider';
 import './styles/global.scss';
 
 createRoot(document.getElementById('root') as HTMLElement).render(
     <StrictMode>
-        <BrowserRouter>
-            <App />
-        </BrowserRouter>
+        <SettingsProvider>
+            <BrowserRouter>
+                <App />
+            </BrowserRouter>
+        </SettingsProvider>
     </StrictMode>
 );

--- a/react-app/src/shared/components/ErrorMessage.scss
+++ b/react-app/src/shared/components/ErrorMessage.scss
@@ -1,0 +1,117 @@
+@import '../../styles/media';
+@import '../../styles/theme_variables';
+
+.error-section {
+    height: 300px;
+    margin: 200px;
+
+    @media #{$mobile-only} {
+        height: 0;
+        display: block;
+        position: relative;
+        margin: 30vh 0;
+    }
+
+    p {
+        text-align: center;
+        padding: 0 25px;
+
+        &.strong {
+            margin-top: 25px;
+            font-weight: bold;
+        }
+    }
+
+    .skull {
+        width: $skull-size;
+        height: $skull-size;
+        position: relative;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        margin: auto;
+
+        .head {
+            width: 100%;
+            height: 75%;
+            border-radius: 15% / 20%;
+            position: absolute;
+            top: 0;
+            left: 0;
+            &:before,
+            &:after {
+                content: '';
+                position: absolute;
+                border-radius: 50%;
+                width: 20%;
+                height: 30%;
+                bottom: 10%;
+            }
+            &:before {
+                left: 10%;
+            }
+            &:after {
+                right: 10%;
+            }
+            .crack {
+                width: 10%;
+                height: 10%;
+                position: absolute;
+                top: 0;
+                right: 25%;
+                transform: skew(-15deg);
+
+                &:before {
+                    content: '';
+                    position: absolute;
+                    top: 100%;
+                    left: $skull-size / 15;
+                    border-right: $skull-size / 20 solid transparent;
+                    border-left: $skull-size / 40 solid transparent;
+                }
+            }
+        }
+        .mouth {
+            width: 40%;
+            height: 25%;
+            position: absolute;
+            top: 75%;
+            left: 30%;
+            border-radius: 0 0 $skull-size / 10 $skull-size / 10;
+            &:before {
+                content: '';
+                position: absolute;
+                width: 15%;
+                height: 50%;
+                border-radius: 50% / 30%;
+                left: 42.5%;
+                top: -25%;
+            }
+            .teeth {
+                position: absolute;
+                bottom: 0;
+                left: 45%;
+                width: 10%;
+                height: 50%;
+                margin-bottom: -5%;
+                border-radius: 50% / 20%;
+
+                &:before,
+                &:after {
+                    content: '';
+                    position: absolute;
+                    width: 100%;
+                    height: 100%;
+                    border-radius: 50% / 20%;
+                }
+                &:before {
+                    left: -250%;
+                }
+                &:after {
+                    right: -250%;
+                }
+            }
+        }
+    }
+}

--- a/react-app/src/shared/components/ErrorMessage.test.tsx
+++ b/react-app/src/shared/components/ErrorMessage.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import ErrorMessage from './ErrorMessage';
+
+describe('ErrorMessage', () => {
+    it('renders the given message and the offline hint', () => {
+        render(<ErrorMessage message="Could not load news stories." />);
+
+        expect(screen.getByText('Could not load news stories.')).toBeInTheDocument();
+        expect(screen.getByText(/you'll need to visit this page with a network connection/i)).toBeInTheDocument();
+    });
+});

--- a/react-app/src/shared/components/ErrorMessage.tsx
+++ b/react-app/src/shared/components/ErrorMessage.tsx
@@ -1,0 +1,25 @@
+import './ErrorMessage.scss';
+
+interface ErrorMessageProps {
+    message: string;
+}
+
+export default function ErrorMessage({ message }: ErrorMessageProps) {
+    return (
+        <div className="error-section">
+            <div className="skull">
+                <div className="head">
+                    <div className="crack"></div>
+                </div>
+                <div className="mouth">
+                    <div className="teeth"></div>
+                </div>
+            </div>
+            <p className="strong">{message}</p>
+            <p>
+                If you are offline viewing, you&apos;ll need to visit this page with a network connection first before
+                it can work offline.
+            </p>
+        </div>
+    );
+}

--- a/react-app/src/shared/components/Loader.scss
+++ b/react-app/src/shared/components/Loader.scss
@@ -1,0 +1,111 @@
+@import '../../styles/media';
+@import '../../styles/theme_variables';
+
+.loader {
+    -webkit-animation: load1 1s infinite ease-in-out;
+    animation: load1 1s infinite ease-in-out;
+    width: 1em;
+    height: 4em;
+    &:before,
+    &:after {
+        -webkit-animation: load1 1s infinite ease-in-out;
+        animation: load1 1s infinite ease-in-out;
+        width: 1em;
+        height: 4em;
+    }
+    &:before,
+    &:after {
+        position: absolute;
+        top: 0;
+        content: '';
+    }
+    &:before {
+        left: -1.5em;
+        -webkit-animation-delay: -0.32s;
+        animation-delay: -0.32s;
+    }
+}
+
+.loading-section {
+    height: 70px;
+    margin: 40px 0 40px 40px;
+
+    @media #{$mobile-only} {
+        display: block;
+        position: relative;
+        margin: 45vh 0;
+    }
+}
+
+.loader {
+    text-indent: -9999em;
+    margin: 20px 20px;
+    position: relative;
+    font-size: 11px;
+    -webkit-transform: translateZ(0);
+    -ms-transform: translateZ(0);
+    transform: translateZ(0);
+    -webkit-animation-delay: -0.16s;
+    animation-delay: -0.16s;
+    &:after {
+        left: 1.5em;
+    }
+
+    @media #{$mobile-only} {
+        margin: 20px auto;
+    }
+}
+
+@-webkit-keyframes load1 {
+    0%,
+    80%,
+    100% {
+        box-shadow: 0 0;
+        height: 2em;
+    }
+    40% {
+        box-shadow: 0 -2em;
+        height: 3em;
+    }
+}
+
+@keyframes load1 {
+    0%,
+    80%,
+    100% {
+        box-shadow: 0 0;
+        height: 2em;
+    }
+    40% {
+        box-shadow: 0 -2em;
+        height: 3em;
+    }
+}
+
+@media #{$mobile-only} {
+    @-webkit-keyframes load1 {
+        0%,
+        80%,
+        100% {
+            box-shadow: 0 0;
+            height: 4em;
+        }
+        40% {
+            box-shadow: 0 -2em;
+            height: 5em;
+        }
+    }
+
+    @keyframes load1 {
+        0%,
+        80%,
+        100% {
+            box-shadow: 0 0;
+            height: 3em;
+        }
+        40% {
+            box-shadow: 0 -2em;
+            height: 4em;
+        }
+    }
+}

--- a/react-app/src/shared/components/Loader.test.tsx
+++ b/react-app/src/shared/components/Loader.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import Loader from './Loader';
+
+describe('Loader', () => {
+    it('renders the loading indicator', () => {
+        render(<Loader />);
+
+        expect(screen.getByText('Loading...')).toBeInTheDocument();
+    });
+});

--- a/react-app/src/shared/components/Loader.tsx
+++ b/react-app/src/shared/components/Loader.tsx
@@ -1,0 +1,9 @@
+import './Loader.scss';
+
+export default function Loader() {
+    return (
+        <div className="loading-section">
+            <div className="loader">Loading...</div>
+        </div>
+    );
+}

--- a/react-app/src/test/renderWithProviders.tsx
+++ b/react-app/src/test/renderWithProviders.tsx
@@ -1,0 +1,27 @@
+import { render, type RenderOptions, type RenderResult } from '@testing-library/react';
+import type { ReactElement, ReactNode } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { SettingsProvider } from '../shared/settings/SettingsProvider';
+import { createSettingsStore, type SettingsStore } from '../shared/settings/settings-store';
+
+interface ProvidersOptions extends Omit<RenderOptions, 'wrapper'> {
+    route?: string;
+    store?: SettingsStore;
+}
+
+export interface RenderWithProvidersResult extends RenderResult {
+    store: SettingsStore;
+}
+
+export function renderWithProviders(ui: ReactElement, options: ProvidersOptions = {}): RenderWithProvidersResult {
+    const { route = '/', store = createSettingsStore(), ...renderOptions } = options;
+
+    const Wrapper = ({ children }: { children: ReactNode }) => (
+        <SettingsProvider store={store}>
+            <MemoryRouter initialEntries={[route]}>{children}</MemoryRouter>
+        </SettingsProvider>
+    );
+
+    return { ...render(ui, { wrapper: Wrapper, ...renderOptions }), store };
+}

--- a/react-app/src/types/globals.d.ts
+++ b/react-app/src/types/globals.d.ts
@@ -1,0 +1,7 @@
+declare global {
+    interface Window {
+        ga?: (...args: unknown[]) => void;
+    }
+}
+
+export {};


### PR DESCRIPTION
## Summary

Third PR of the Angular→React stack (on top of #543): the app shell and the presentational components, with tests. Feed/item/user pages are still placeholders.

- **`Loader`, `ErrorMessage`** — direct ports of the shared components, markup and SCSS unchanged (SCSS `@import` paths retargeted at `src/styles/`).
- **`Header`** — logo link plus the `new | show | ask | jobs` nav as `NavLink`s (`routerLinkActive="active"` → `isActive` class), `scrollTop()` on click, cog image toggling `showSettings`; renders `<Settings />` when the panel is open.
- **`Settings`** — same overlay markup, wired to `toggleSettings`, `toggleOpenLinksInNewTab`, `setTheme`, `setFont`, `setSpacing`. Angular used template refs plus `[checked]`/`(click)` and `(keyup)`; here the inputs are controlled off the store (`checked={settings.theme === value}`, `value={settings.titleFontSize}` + `onChange`), and the theme radios/close button gained accessible labels so tests (and screen readers) can address them.
- **`App`** — themed shell (`<div className={settings.theme}>` → `.body-cover` → `.wrapper` → header/routes/footer). The `router.events` + `NavigationEnd` GA subscription becomes `usePageViews()`, which fires on every settled location:

```ts
window.ga?.('set', 'page', `${pathname}${search}${hash}`);
window.ga?.('send', 'pageview');
```

  `ga` is optional-called (declared on `Window` in `src/types/globals.d.ts`) so the app still works when the analytics script is blocked — the Angular version threw on every navigation in that case.
- **`main.tsx`** now mounts `SettingsProvider` → `BrowserRouter` → `App`.
- **Tests** — 14 new tests covering each component and its store interactions (settings toggle flows, theme selection, font/spacing updates, active nav link, scroll-to-top, GA pageview with and without `ga` present), plus `src/test/renderWithProviders.tsx` which wraps a component in a settings store and a `MemoryRouter` and returns the store for assertions. 47 tests total.


Link to Devin session: https://app.devin.ai/sessions/d8dbf31831b94e208654e841c16cc384
Requested by: @vibhaseshadri-cognition
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/546?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/546" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->