### PR TITLE
[4/7] Migrate the feed feature to React

### DIFF
--- a/react-app/src/App.test.tsx
+++ b/react-app/src/App.test.tsx
@@ -2,11 +2,18 @@ import { screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import App from './App';
+import { fetchFeed } from './shared/api/hackernews-api';
 import { renderWithProviders } from './test/renderWithProviders';
+
+vi.mock('./shared/api/hackernews-api', () => ({
+    fetchFeed: vi.fn(),
+}));
 
 describe('App', () => {
     beforeEach(() => {
         localStorage.clear();
+        vi.mocked(fetchFeed).mockResolvedValue([]);
+        vi.stubGlobal('scrollTo', vi.fn());
     });
 
     afterEach(() => {
@@ -20,7 +27,7 @@ describe('App', () => {
 
         expect(container.querySelector('.night')).not.toBeNull();
         expect(screen.getByRole('img', { name: 'Logo' })).toBeInTheDocument();
-        expect(screen.getByTestId('feed-page')).toBeInTheDocument();
+        expect(screen.getByText('Loading...')).toBeInTheDocument();
         expect(screen.getByRole('link', { name: 'GitHub' })).toBeInTheDocument();
     });
 

--- a/react-app/src/features/feed/FeedItem.scss
+++ b/react-app/src/features/feed/FeedItem.scss
@@ -1,0 +1,68 @@
+@import '../../styles/media';
+@import '../../styles/theme_variables';
+
+p {
+    margin: 2px 0;
+
+    @media #{$mobile-only} {
+        margin-bottom: 5px;
+        margin-top: 0;
+    }
+}
+
+a {
+    cursor: pointer;
+    text-decoration: none;
+}
+
+.title {
+    font-size: 16px;
+    font-family: Verdana, Geneva, sans-serif;
+}
+
+.subtext-laptop {
+    font-size: 12px;
+    font-weight: bold;
+    letter-spacing: 0.5px;
+
+    a {
+        &:hover {
+            text-decoration: underline;
+        }
+    }
+    @media #{$mobile-only} {
+        display: none;
+    }
+}
+
+.subtext-palm {
+    font-size: 13px;
+    font-weight: bold;
+    letter-spacing: 0.5px;
+
+    a {
+        &:hover {
+            text-decoration: underline;
+        }
+    }
+
+    .details {
+        margin-top: 5px;
+
+        .right {
+            float: right;
+        }
+    }
+    @media #{$laptop-only} {
+        display: none;
+    }
+}
+
+.domain {
+    color: #696969;
+    letter-spacing: 0.5px;
+}
+
+.item-details {
+    padding: 10px;
+}

--- a/react-app/src/features/feed/FeedItem.test.tsx
+++ b/react-app/src/features/feed/FeedItem.test.tsx
@@ -1,0 +1,69 @@
+import { screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { makeStory } from '../../test/fixtures';
+import { renderWithProviders } from '../../test/renderWithProviders';
+import FeedItem from './FeedItem';
+
+describe('FeedItem', () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    it('links the title to the story url and shows its domain', () => {
+        renderWithProviders(<FeedItem item={makeStory()} />);
+
+        const title = screen.getByRole('link', { name: /My YC app/ });
+        expect(title).toHaveAttribute('href', 'http://www.getdropbox.com/u/2/screencast.html');
+        expect(title).not.toHaveAttribute('target');
+        expect(screen.getByText('(getdropbox.com)')).toBeInTheDocument();
+    });
+
+    it('opens external links in a new tab when the setting is enabled', () => {
+        localStorage.setItem('openLinkInNewTab', 'true');
+
+        renderWithProviders(<FeedItem item={makeStory()} />);
+
+        const title = screen.getByRole('link', { name: /My YC app/ });
+        expect(title).toHaveAttribute('target', '_blank');
+        expect(title).toHaveAttribute('rel', 'noopener');
+    });
+
+    it('links the title to the item page for stories without a url', () => {
+        renderWithProviders(<FeedItem item={makeStory({ url: 'item?id=8863', title: 'Ask HN: anything?' })} />);
+
+        expect(screen.getByRole('link', { name: 'Ask HN: anything?' })).toHaveAttribute('href', '/item/8863');
+    });
+
+    it('renders points, author and comment count', () => {
+        renderWithProviders(<FeedItem item={makeStory()} />);
+
+        expect(screen.getAllByRole('link', { name: 'dhouston' })[0]).toHaveAttribute('href', '/user/dhouston');
+        expect(screen.getAllByRole('link', { name: /71 comments/ })[0]).toHaveAttribute('href', '/item/8863');
+        expect(screen.getByText('111 ★')).toBeInTheDocument();
+    });
+
+    it('renders "discuss" when a story has no comments', () => {
+        renderWithProviders(<FeedItem item={makeStory({ comments_count: 0 })} />);
+
+        expect(screen.getAllByRole('link', { name: /discuss/ })).not.toHaveLength(0);
+    });
+
+    it('hides author, points and comments for jobs', () => {
+        renderWithProviders(<FeedItem item={makeStory({ type: 'job', comments_count: 0 })} />);
+
+        expect(screen.queryByRole('link', { name: 'dhouston' })).not.toBeInTheDocument();
+        expect(screen.queryByText(/111/)).not.toBeInTheDocument();
+        expect(screen.queryByRole('link', { name: /discuss/ })).not.toBeInTheDocument();
+    });
+
+    it('applies the title font size and list spacing settings', () => {
+        localStorage.setItem('titleFontSize', '22');
+        localStorage.setItem('listSpacing', '7');
+
+        const { container } = renderWithProviders(<FeedItem item={makeStory()} />);
+
+        expect(screen.getByRole('link', { name: /My YC app/ })).toHaveStyle({ fontSize: '22px' });
+        expect(container.firstElementChild).toHaveStyle({ marginBottom: '7px' });
+    });
+});

--- a/react-app/src/features/feed/FeedItem.tsx
+++ b/react-app/src/features/feed/FeedItem.tsx
@@ -1,0 +1,76 @@
+import { Link } from 'react-router-dom';
+
+import type { Story } from '../../shared/models/story';
+import { useSettings } from '../../shared/settings/useSettings';
+import { formatCommentCount } from '../../shared/utils/comment-count';
+import './FeedItem.scss';
+
+interface FeedItemProps {
+    item: Story;
+}
+
+export default function FeedItem({ item }: FeedItemProps) {
+    const settings = useSettings();
+    const hasUrl = item.url?.indexOf('http') === 0;
+    const isJob = item.type === 'job';
+    const externalLinkProps = settings.openLinkInNewTab ? { target: '_blank', rel: 'noopener' } : {};
+
+    return (
+        <div style={{ marginBottom: `${settings.listSpacing}px` }}>
+            {hasUrl ? (
+                <p>
+                    <a
+                        className="title"
+                        style={{ fontSize: `${settings.titleFontSize}px` }}
+                        href={item.url}
+                        {...externalLinkProps}
+                    >
+                        {item.title}
+                    </a>
+                    {item.domain && <span className="domain">({item.domain})</span>}
+                </p>
+            ) : (
+                <p>
+                    <Link className="title" style={{ fontSize: `${settings.titleFontSize}px` }} to={`/item/${item.id}`}>
+                        {item.title}
+                    </Link>
+                </p>
+            )}
+            <div className="subtext-palm">
+                {!isJob && (
+                    <div className="details">
+                        <span className="name">
+                            <Link to={`/user/${item.user}`}>{item.user}</Link>
+                        </span>
+                        <span className="right">{item.points} ★</span>
+                    </div>
+                )}
+                <div className="details">
+                    {item.time_ago}
+                    {!isJob && (
+                        <Link to={`/item/${item.id}`} className="comment-number">
+                            {' • '}
+                            {formatCommentCount(item.comments_count)}
+                        </Link>
+                    )}
+                </div>
+            </div>
+            <div className="subtext-laptop">
+                {!isJob && (
+                    <span>
+                        {item.points} points by <Link to={`/user/${item.user}`}>{item.user}</Link>
+                    </span>
+                )}
+                <span className={isJob ? undefined : 'item-details'}>
+                    {item.time_ago}
+                    {!isJob && (
+                        <span>
+                            {' | '}
+                            <Link to={`/item/${item.id}`}>{formatCommentCount(item.comments_count)}</Link>
+                        </span>
+                    )}
+                </span>
+            </div>
+        </div>
+    );
+}

--- a/react-app/src/features/feed/FeedPage.scss
+++ b/react-app/src/features/feed/FeedPage.scss
@@ -1,0 +1,107 @@
+@import '../../styles/media';
+@import '../../styles/theme_variables';
+
+a {
+    text-decoration: none;
+    font-weight: bold;
+
+    &:hover {
+        text-decoration: underline;
+    }
+}
+
+ol {
+    padding: 0 40px;
+    margin: 0;
+
+    @media #{$mobile-only} {
+        box-sizing: border-box;
+        list-style: none;
+        padding: 0 10px;
+    }
+
+    li {
+        position: relative;
+        -webkit-transition: background-color 0.2s ease;
+        transition: background-color 0.2s ease;
+    }
+}
+
+.list-margin {
+    @media #{$mobile-only} {
+        margin-top: 55px;
+    }
+}
+
+.main-content {
+    position: relative;
+    width: 100%;
+    min-height: 100vh;
+    -webkit-transition: opacity 0.2s ease;
+    transition: opacity 0.2s ease;
+    box-sizing: border-box;
+    padding: 8px 0;
+    z-index: 0;
+}
+
+.post {
+    padding: 10px 0 10px 5px;
+    transition: background-color 0.2s ease;
+    border-bottom: 1px solid #cececb;
+
+    .itemNum {
+        color: #696969;
+        position: absolute;
+        width: 30px;
+        text-align: right;
+        left: 0;
+        top: 4px;
+    }
+}
+
+.item-block {
+    display: block;
+}
+
+.nav {
+    padding: 10px 40px;
+    margin-top: 10px;
+    font-size: 17px;
+
+    a {
+        @media #{$mobile-only} {
+            text-decoration: none;
+        }
+    }
+
+    @media #{$mobile-only} {
+        margin: 20px 0;
+        text-align: center;
+        padding: 10px 80px;
+        height: 20px;
+    }
+
+    .prev {
+        padding-right: 20px;
+
+        @media #{$mobile-only} {
+            float: left;
+            padding-right: 0;
+        }
+    }
+
+    .more {
+        @media #{$mobile-only} {
+            float: right;
+        }
+    }
+}
+
+.job-header {
+    font-size: 15px;
+    padding: 0 40px 10px;
+
+    @media #{$mobile-only} {
+        padding: 60px 15px 25px 15px;
+    }
+}

--- a/react-app/src/features/feed/FeedPage.test.tsx
+++ b/react-app/src/features/feed/FeedPage.test.tsx
@@ -1,0 +1,101 @@
+import { screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Route, Routes } from 'react-router-dom';
+
+import { fetchFeed } from '../../shared/api/hackernews-api';
+import { makeStories } from '../../test/fixtures';
+import { renderWithProviders } from '../../test/renderWithProviders';
+import FeedPage from './FeedPage';
+
+vi.mock('../../shared/api/hackernews-api', () => ({
+    fetchFeed: vi.fn(),
+}));
+
+const fetchFeedMock = vi.mocked(fetchFeed);
+
+function renderFeed(route: string, feedType: 'news' | 'jobs' = 'news') {
+    return renderWithProviders(
+        <Routes>
+            <Route path={`/${feedType}/:page`} element={<FeedPage feedType={feedType} />} />
+        </Routes>,
+        { route }
+    );
+}
+
+describe('FeedPage', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        fetchFeedMock.mockReset();
+        vi.stubGlobal('scrollTo', vi.fn());
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('shows the loader until the feed resolves, then the stories', async () => {
+        fetchFeedMock.mockResolvedValue(makeStories(2));
+
+        renderFeed('/news/1');
+        expect(screen.getByText('Loading...')).toBeInTheDocument();
+
+        expect(await screen.findByText('Story 1')).toBeInTheDocument();
+        expect(screen.getByText('Story 2')).toBeInTheDocument();
+        expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+        expect(fetchFeedMock).toHaveBeenCalledWith('news', 1);
+    });
+
+    it('scrolls back to the top once the feed is loaded', async () => {
+        fetchFeedMock.mockResolvedValue(makeStories(1));
+
+        renderFeed('/news/3');
+
+        await waitFor(() => expect(window.scrollTo).toHaveBeenCalledWith(0, 0));
+    });
+
+    it('numbers the list from the requested page', async () => {
+        fetchFeedMock.mockResolvedValue(makeStories(30));
+
+        const { container } = renderFeed('/news/4');
+
+        await screen.findByText('Story 1');
+        expect(container.querySelector('ol')).toHaveAttribute('start', '91');
+        expect(fetchFeedMock).toHaveBeenCalledWith('news', 4);
+    });
+
+    it('links to the next page while a full page of stories is returned', async () => {
+        fetchFeedMock.mockResolvedValue(makeStories(30));
+
+        renderFeed('/news/2');
+
+        expect(await screen.findByRole('link', { name: /More/ })).toHaveAttribute('href', '/news/3');
+        expect(screen.getByRole('link', { name: /Prev/ })).toHaveAttribute('href', '/news/1');
+    });
+
+    it('hides both pagination links on a short first page', async () => {
+        fetchFeedMock.mockResolvedValue(makeStories(12));
+
+        renderFeed('/news/1');
+
+        await screen.findByText('Story 1');
+        expect(screen.queryByRole('link', { name: /More/ })).not.toBeInTheDocument();
+        expect(screen.queryByRole('link', { name: /Prev/ })).not.toBeInTheDocument();
+    });
+
+    it('shows an error message when the feed cannot be loaded', async () => {
+        fetchFeedMock.mockRejectedValue(new Error('offline'));
+
+        renderFeed('/news/1');
+
+        expect(await screen.findByText('Could not load news stories.')).toBeInTheDocument();
+        expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+    });
+
+    it('shows the Y Combinator blurb on the jobs feed', async () => {
+        fetchFeedMock.mockResolvedValue(makeStories(1, { type: 'job' }));
+
+        renderFeed('/jobs/1', 'jobs');
+
+        expect(await screen.findByText(/jobs at startups that were funded by Y Combinator/)).toBeInTheDocument();
+    });
+});

--- a/react-app/src/features/feed/FeedPage.tsx
+++ b/react-app/src/features/feed/FeedPage.tsx
@@ -1,9 +1,86 @@
+import { useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+
+import { fetchFeed } from '../../shared/api/hackernews-api';
+import ErrorMessage from '../../shared/components/ErrorMessage';
+import Loader from '../../shared/components/Loader';
 import type { FeedName } from '../../shared/models/feed-name.type';
+import type { Story } from '../../shared/models/story';
+import FeedItem from './FeedItem';
+import './FeedPage.scss';
+
+export const ITEMS_PER_PAGE = 30;
 
 interface FeedPageProps {
     feedType: FeedName;
 }
 
 export default function FeedPage({ feedType }: FeedPageProps) {
-    return <div className="main-content" data-testid="feed-page" data-feed-type={feedType}></div>;
+    const { page } = useParams<{ page: string }>();
+    const pageNum = page ? Number(page) : 1;
+    const [items, setItems] = useState<Story[] | null>(null);
+    const [errorMessage, setErrorMessage] = useState('');
+
+    useEffect(() => {
+        let cancelled = false;
+        setItems(null);
+        setErrorMessage('');
+
+        fetchFeed(feedType, pageNum)
+            .then((stories) => {
+                if (cancelled) {
+                    return;
+                }
+                setItems(stories);
+                window.scrollTo(0, 0);
+            })
+            .catch(() => {
+                if (!cancelled) {
+                    setErrorMessage(`Could not load ${feedType} stories.`);
+                }
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [feedType, pageNum]);
+
+    const listStart = (pageNum - 1) * ITEMS_PER_PAGE + 1;
+
+    return (
+        <div className="main-content">
+            {!items && !errorMessage && <Loader />}
+            {!items && errorMessage !== '' && <ErrorMessage message={errorMessage} />}
+
+            {items && (
+                <div>
+                    {feedType === 'jobs' && (
+                        <p className="job-header">
+                            These are jobs at startups that were funded by Y Combinator. You can also get a job at a YC
+                            startup through <a href="https://triplebyte.com/?ref=yc_jobs">Triplebyte</a>.
+                        </p>
+                    )}
+                    <ol className={feedType !== 'jobs' ? 'list-margin' : undefined} start={listStart}>
+                        {items.map((item) => (
+                            <li key={item.id} className="post">
+                                <FeedItem item={item} />
+                            </li>
+                        ))}
+                    </ol>
+                    <div className="nav">
+                        {listStart !== 1 && (
+                            <Link to={`/${feedType}/${pageNum - 1}`} className="prev">
+                                ‹ Prev
+                            </Link>
+                        )}
+                        {items.length === ITEMS_PER_PAGE && (
+                            <Link to={`/${feedType}/${pageNum + 1}`} className="more">
+                                More ›
+                            </Link>
+                        )}
+                    </div>
+                </div>
+            )}
+        </div>
+    );
 }

--- a/react-app/src/router/AppRoutes.test.tsx
+++ b/react-app/src/router/AppRoutes.test.tsx
@@ -1,44 +1,54 @@
-import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
-import { describe, expect, it } from 'vitest';
+import { screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { fetchFeed } from '../shared/api/hackernews-api';
+import { renderWithProviders } from '../test/renderWithProviders';
 import AppRoutes from './AppRoutes';
 
-function renderAt(path: string) {
-    return render(
-        <MemoryRouter initialEntries={[path]}>
-            <AppRoutes />
-        </MemoryRouter>
-    );
-}
+vi.mock('../shared/api/hackernews-api', () => ({
+    fetchFeed: vi.fn(),
+}));
+
+const fetchFeedMock = vi.mocked(fetchFeed);
 
 describe('AppRoutes', () => {
-    it('redirects the root path to the first news page', () => {
-        renderAt('/');
+    beforeEach(() => {
+        localStorage.clear();
+        fetchFeedMock.mockReset();
+        fetchFeedMock.mockResolvedValue([]);
+        vi.stubGlobal('scrollTo', vi.fn());
+    });
 
-        expect(screen.getByTestId('feed-page')).toHaveAttribute('data-feed-type', 'news');
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('redirects the root path to the first news page', () => {
+        renderWithProviders(<AppRoutes />, { route: '/' });
+
+        expect(fetchFeedMock).toHaveBeenCalledWith('news', 1);
     });
 
     it.each([
-        ['/news/2', 'news'],
-        ['/newest/1', 'newest'],
-        ['/show/3', 'show'],
-        ['/ask/1', 'ask'],
-        ['/jobs/1', 'jobs'],
-    ])('renders the feed page for %s with its feed type', (path, feedType) => {
-        renderAt(path);
+        ['/news/2', 'news', 2],
+        ['/newest/1', 'newest', 1],
+        ['/show/3', 'show', 3],
+        ['/ask/1', 'ask', 1],
+        ['/jobs/1', 'jobs', 1],
+    ])('renders the feed page for %s with its feed type and page', (route, feedType, page) => {
+        renderWithProviders(<AppRoutes />, { route });
 
-        expect(screen.getByTestId('feed-page')).toHaveAttribute('data-feed-type', feedType);
+        expect(fetchFeedMock).toHaveBeenCalledWith(feedType, page);
     });
 
     it('renders the item details page with the item id', () => {
-        renderAt('/item/8863');
+        renderWithProviders(<AppRoutes />, { route: '/item/8863' });
 
         expect(screen.getByTestId('item-details-page')).toHaveAttribute('data-item-id', '8863');
     });
 
     it('renders the user page with the user id', () => {
-        renderAt('/user/pg');
+        renderWithProviders(<AppRoutes />, { route: '/user/pg' });
 
         expect(screen.getByTestId('user-page')).toHaveAttribute('data-user-id', 'pg');
     });

--- a/react-app/src/test/fixtures.ts
+++ b/react-app/src/test/fixtures.ts
@@ -1,0 +1,41 @@
+import type { Story } from '../shared/models/story';
+import type { User } from '../shared/models/user';
+
+export function makeStory(overrides: Partial<Story> = {}): Story {
+    return {
+        id: 8863,
+        title: 'My YC app: Dropbox - Throw away your USB drive',
+        points: 111,
+        user: 'dhouston',
+        time: 1175714200,
+        time_ago: '9 years ago',
+        type: 'story',
+        url: 'http://www.getdropbox.com/u/2/screencast.html',
+        domain: 'getdropbox.com',
+        comments: [],
+        comments_count: 71,
+        poll: [],
+        poll_votes_count: 0,
+        deleted: false,
+        dead: false,
+        ...overrides,
+    };
+}
+
+export function makeStories(count: number, overrides: Partial<Story> = {}): Story[] {
+    return Array.from({ length: count }, (_unused, index) =>
+        makeStory({ id: 1000 + index, title: `Story ${index + 1}`, ...overrides })
+    );
+}
+
+export function makeUser(overrides: Partial<User> = {}): User {
+    return {
+        id: 'pg',
+        crated_time: 1160418092,
+        created: 'October 9, 2006',
+        karma: 155111,
+        avg: 0,
+        about: 'Bug fixer.',
+        ...overrides,
+    };
+}


### PR DESCRIPTION
## Summary

Fourth PR of the Angular→React stack (on top of #546). The news/newest/show/ask/jobs feeds now render real data; item and user pages are still placeholders.

**`FeedPage`** replaces the two `route.data`/`route.params` subscriptions with one effect keyed on `[feedType, pageNum]`, guarded against out-of-order responses:

```ts
useEffect(() => {
    let cancelled = false;
    setItems(null); setErrorMessage('');
    fetchFeed(feedType, pageNum)
        .then((stories) => { if (!cancelled) { setItems(stories); window.scrollTo(0, 0); } })
        .catch(() => { if (!cancelled) setErrorMessage(`Could not load ${feedType} stories.`); });
    return () => { cancelled = true; };
}, [feedType, pageNum]);

const listStart = (pageNum - 1) * ITEMS_PER_PAGE + 1;   // 30 per page, as before
```

`listStart` is derived rather than stored (Angular set it in the observable's complete handler, so it lagged one render behind), and pagination keeps the same rules: `Prev` when `listStart !== 1`, `More` while a full page of 30 comes back. Two dead conditionals from the template are dropped: `*ngIf="feedType !== 'new'"` (no feed is ever named `new`) and `[class.list-margin]` is now applied directly since it is equivalent to `feedType !== 'jobs'`.

**`FeedItem`** is a straight port of `item.component`: `hasUrl` is still `url.indexOf('http') === 0` (null-safe now), `target`/`rel` are only set when `openLinkInNewTab` is on, `titleFontSize`/`listSpacing` drive inline styles, jobs hide author/points/comments, and `comments_count` goes through `formatCommentCount`.

**Tests** — 14 new (61 total): loader→stories transition, `fetchFeed` arguments, scroll-to-top, `start="91"` for page 4, both pagination links, short-page case, feed-specific error copy, jobs blurb; and for the row: external vs. internal title link, new-tab setting, points/author/comment-count rendering, `discuss` fallback, job variant, font-size/spacing settings. `src/test/fixtures.ts` adds story/user builders. `AppRoutes`/`App` tests now assert routing via the mocked `fetchFeed` since the feed placeholder is gone.


Link to Devin session: https://app.devin.ai/sessions/d8dbf31831b94e208654e841c16cc384
Requested by: @vibhaseshadri-cognition
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/547?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/547" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->