### PR TITLE
[5/7] Migrate the item details and comments feature to React

### DIFF
--- a/react-app/src/features/item-details/CommentThread.scss
+++ b/react-app/src/features/item-details/CommentThread.scss
@@ -1,0 +1,86 @@
+@import '../../styles/media';
+@import '../../styles/theme_variables';
+
+// `:host >>> a` in Angular; scoping is global here so the selector applies directly
+.comment-thread {
+    a {
+        font-weight: bold;
+        text-decoration: none;
+        &:hover {
+            text-decoration: underline;
+        }
+    }
+}
+
+.meta {
+    font-size: 13px;
+    color: #696969;
+    font-weight: bold;
+    letter-spacing: 0.5px;
+    margin-bottom: 8px;
+    a {
+        text-decoration: none;
+
+        &:hover {
+            text-decoration: underline;
+        }
+    }
+    .time {
+        padding-left: 5px;
+    }
+}
+
+@media #{$mobile-only} {
+    .meta {
+        font-size: 14px;
+        margin-bottom: 10px;
+        .time {
+            padding: 0;
+            float: right;
+        }
+    }
+}
+
+.meta-collapse {
+    margin-bottom: 20px;
+}
+
+.deleted-meta {
+    font-size: 12px;
+    font-weight: bold;
+    letter-spacing: 0.5px;
+    margin: 30px 0;
+    a {
+        text-decoration: none;
+    }
+}
+
+.collapse {
+    font-size: 13px;
+    letter-spacing: 2px;
+    cursor: pointer;
+}
+
+.comment-tree {
+    margin-left: 24px;
+}
+
+@media #{$tablet-only} {
+    .comment-tree {
+        margin-left: 8px;
+    }
+}
+
+.comment-text {
+    font-size: 15px;
+    margin-top: 0;
+    margin-bottom: 20px;
+    word-wrap: break-word;
+    line-height: 1.5em;
+}
+
+.subtree {
+    margin-left: 0;
+    padding: 0;
+    list-style-type: none;
+}

--- a/react-app/src/features/item-details/CommentThread.test.tsx
+++ b/react-app/src/features/item-details/CommentThread.test.tsx
@@ -1,0 +1,93 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+
+import type { Comment } from '../../shared/models/comment';
+import { renderWithProviders } from '../../test/renderWithProviders';
+import CommentThread from './CommentThread';
+
+function makeComment(overrides: Partial<Comment> = {}): Comment {
+    return {
+        id: 1,
+        level: 0,
+        user: 'pg',
+        time: 1175714200,
+        time_ago: '2 hours ago',
+        content: '<p>Top level</p>',
+        deleted: false,
+        comments: [],
+        ...overrides,
+    };
+}
+
+describe('CommentThread', () => {
+    it('renders the author, age and html content', () => {
+        renderWithProviders(<CommentThread comment={makeComment()} />);
+
+        expect(screen.getByRole('link', { name: 'pg' })).toHaveAttribute('href', '/user/pg');
+        expect(screen.getByText('2 hours ago')).toBeInTheDocument();
+        expect(screen.getByText('Top level')).toBeInTheDocument();
+    });
+
+    it('renders nested comments recursively', () => {
+        const comment = makeComment({
+            comments: [
+                makeComment({
+                    id: 2,
+                    user: 'dhouston',
+                    content: '<p>Reply</p>',
+                    comments: [makeComment({ id: 3, user: 'jl', content: '<p>Nested reply</p>' })],
+                }),
+            ],
+        });
+
+        renderWithProviders(<CommentThread comment={comment} />);
+
+        expect(screen.getByText('Reply')).toBeInTheDocument();
+        expect(screen.getByText('Nested reply')).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: 'jl' })).toBeInTheDocument();
+    });
+
+    it('collapses and expands its subtree', async () => {
+        const comment = makeComment({ comments: [makeComment({ id: 2, content: '<p>Reply</p>' })] });
+
+        const { container } = renderWithProviders(<CommentThread comment={comment} />);
+        const [toggle] = screen.getAllByRole('button', { name: 'Collapse comment' });
+
+        expect(toggle).toHaveTextContent('[-]');
+        expect(screen.getByText('Reply')).toBeVisible();
+
+        await userEvent.click(toggle);
+
+        expect(screen.getByRole('button', { name: 'Expand comment' })).toHaveTextContent('[+]');
+        expect(screen.getByText('Reply')).not.toBeVisible();
+        expect(container.querySelector('.meta-collapse')).not.toBeNull();
+
+        await userEvent.click(screen.getByRole('button', { name: 'Expand comment' }));
+
+        expect(screen.getByText('Reply')).toBeVisible();
+    });
+
+    it('collapses only the comment that was clicked', async () => {
+        const comment = makeComment({
+            content: '<p>Parent</p>',
+            comments: [makeComment({ id: 2, content: '<p>Child</p>' })],
+        });
+
+        renderWithProviders(<CommentThread comment={comment} />);
+
+        const [, childToggle] = screen.getAllByRole('button', { name: 'Collapse comment' });
+        await userEvent.click(childToggle);
+
+        expect(screen.getByText('Parent')).toBeVisible();
+        expect(screen.getByText('Child')).not.toBeVisible();
+    });
+
+    it('renders a placeholder for deleted comments', () => {
+        renderWithProviders(<CommentThread comment={makeComment({ deleted: true })} />);
+
+        expect(screen.getByText('[deleted]')).toBeInTheDocument();
+        expect(screen.getByText(/Comment Deleted/)).toBeInTheDocument();
+        expect(screen.queryByRole('link', { name: 'pg' })).not.toBeInTheDocument();
+    });
+});

--- a/react-app/src/features/item-details/CommentThread.tsx
+++ b/react-app/src/features/item-details/CommentThread.tsx
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+
+import type { Comment } from '../../shared/models/comment';
+import './CommentThread.scss';
+
+interface CommentThreadProps {
+    comment: Comment;
+}
+
+export default function CommentThread({ comment }: CommentThreadProps) {
+    const [collapsed, setCollapsed] = useState(false);
+
+    if (comment.deleted) {
+        return (
+            <div className="comment-thread">
+                <div className="deleted-meta">
+                    <span className="collapse">[deleted]</span> | Comment Deleted
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="comment-thread">
+            <div className={collapsed ? 'meta meta-collapse' : 'meta'}>
+                <span
+                    className="collapse"
+                    role="button"
+                    aria-expanded={!collapsed}
+                    aria-label={collapsed ? 'Expand comment' : 'Collapse comment'}
+                    onClick={() => setCollapsed(!collapsed)}
+                >
+                    [{collapsed ? '+' : '-'}]
+                </span>{' '}
+                <Link to={`/user/${comment.user}`}>{comment.user}</Link>
+                <span className="time">{comment.time_ago}</span>
+            </div>
+            <div className="comment-tree">
+                <div hidden={collapsed}>
+                    <p className="comment-text" dangerouslySetInnerHTML={{ __html: comment.content }}></p>
+                    <ul className="subtree">
+                        {comment.comments?.map((subComment) => (
+                            <li key={subComment.id}>
+                                <CommentThread comment={subComment} />
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/react-app/src/features/item-details/ItemDetailsPage.scss
+++ b/react-app/src/features/item-details/ItemDetailsPage.scss
@@ -1,0 +1,151 @@
+@import '../../styles/media';
+@import '../../styles/theme_variables';
+
+.main-content {
+    position: relative;
+    width: 100%;
+    min-height: 100vh;
+    -webkit-transition: opacity 0.2s ease;
+    transition: opacity 0.2s ease;
+    box-sizing: border-box;
+    padding: 8px 0;
+    z-index: 0;
+}
+
+.item {
+    box-sizing: border-box;
+    padding: 10px 40px 0 40px;
+    z-index: 0;
+}
+
+@media #{$tablet-only} {
+    .item {
+        padding: 10px 20px 0 40px;
+    }
+}
+
+@media #{$mobile-only} {
+    .item {
+        box-sizing: border-box;
+        padding: 110px 15px 0 15px;
+    }
+}
+
+.head-margin {
+    margin-bottom: 15px;
+}
+
+p {
+    margin: 2px 0;
+}
+
+.subject {
+    word-wrap: break-word;
+    margin-top: 20px;
+}
+
+a {
+    cursor: pointer;
+    text-decoration: none;
+}
+
+@media #{$mobile-only} {
+    .laptop {
+        display: none;
+    }
+}
+
+@media #{$laptop-only} {
+    .mobile {
+        display: none;
+    }
+}
+
+.title {
+    font-size: 16px;
+    font-family: Verdana, Geneva, sans-serif;
+}
+
+.title-block {
+    text-align: center;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    margin: 0 75px;
+}
+
+@media #{$mobile-only} {
+    .title {
+        font-size: 15px;
+    }
+    .back-button {
+        position: absolute;
+        top: 52%;
+        width: 0.6rem;
+        height: 0.6rem;
+        background: transparent;
+        box-shadow: 0 0 0 lightgray;
+        transition: all 200ms ease;
+        left: 4%;
+        transform: translate3d(0, -50%, 0) rotate(-135deg);
+    }
+}
+
+.subtext {
+    font-size: 12px;
+    font-weight: bold;
+    letter-spacing: 0.5px;
+}
+
+.domain {
+    letter-spacing: 0.5px;
+}
+
+.subtext a {
+    &:hover {
+        text-decoration: underline;
+    }
+}
+
+.item-details {
+    padding: 10px;
+}
+
+.item-header {
+    padding-bottom: 10px;
+}
+
+@media #{$mobile-only} {
+    .item-header {
+        padding: 10px 0 10px 0;
+        position: fixed;
+        width: 100%;
+        left: 0;
+        top: 62px;
+    }
+}
+
+.pollResults {
+    margin-bottom: 1em;
+}
+
+.pollContent {
+    * {
+        padding-bottom: 0;
+        margin-bottom: -1em;
+        margin-top: 1em;
+    }
+    .pollBar {
+        height: 10px;
+        margin-bottom: 1em;
+    }
+}
+
+ul {
+    list-style-type: none;
+    padding: 10px 0;
+}
+
+li {
+    display: list-item;
+}

--- a/react-app/src/features/item-details/ItemDetailsPage.test.tsx
+++ b/react-app/src/features/item-details/ItemDetailsPage.test.tsx
@@ -1,0 +1,166 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Route, Routes } from 'react-router-dom';
+
+import { fetchItemContent } from '../../shared/api/hackernews-api';
+import { makeStory } from '../../test/fixtures';
+import { renderWithProviders } from '../../test/renderWithProviders';
+import ItemDetailsPage from './ItemDetailsPage';
+
+vi.mock('../../shared/api/hackernews-api', () => ({
+    fetchItemContent: vi.fn(),
+}));
+
+const navigate = vi.fn();
+vi.mock('react-router-dom', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('react-router-dom')>();
+    return { ...actual, useNavigate: () => navigate };
+});
+
+const fetchItemContentMock = vi.mocked(fetchItemContent);
+
+function renderItem(route = '/item/8863') {
+    return renderWithProviders(
+        <Routes>
+            <Route path="/item/:id" element={<ItemDetailsPage />} />
+        </Routes>,
+        { route }
+    );
+}
+
+describe('ItemDetailsPage', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        navigate.mockReset();
+        fetchItemContentMock.mockReset();
+        vi.stubGlobal('scrollTo', vi.fn());
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('shows the loader, then the item with its metadata', async () => {
+        fetchItemContentMock.mockResolvedValue(makeStory({ content: '<p>Story text</p>' }));
+
+        renderItem();
+        expect(screen.getByText('Loading...')).toBeInTheDocument();
+
+        expect(await screen.findByText('Story text')).toBeInTheDocument();
+        expect(fetchItemContentMock).toHaveBeenCalledWith(8863);
+        expect(screen.getAllByRole('link', { name: /My YC app/ })[0]).toHaveAttribute(
+            'href',
+            'http://www.getdropbox.com/u/2/screencast.html'
+        );
+        expect(screen.getByText('(getdropbox.com)')).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: '71 comments' })).toHaveAttribute('href', '/item/8863');
+        expect(screen.getByRole('link', { name: 'dhouston' })).toHaveAttribute('href', '/user/dhouston');
+        expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
+    });
+
+    it('links the title internally when the item has no external url', async () => {
+        fetchItemContentMock.mockResolvedValue(makeStory({ url: 'item?id=8863', domain: '' }));
+
+        renderItem();
+
+        const titles = await screen.findAllByRole('link', { name: /My YC app/ });
+        expect(titles[0]).toHaveAttribute('href', '/item/8863');
+        expect(screen.queryByText('(getdropbox.com)')).not.toBeInTheDocument();
+    });
+
+    it('opens the external title link in a new tab when the setting is enabled', async () => {
+        localStorage.setItem('openLinkInNewTab', 'true');
+        fetchItemContentMock.mockResolvedValue(makeStory());
+
+        renderItem();
+
+        const titles = await screen.findAllByRole('link', { name: /My YC app/ });
+        expect(titles[0]).toHaveAttribute('target', '_blank');
+    });
+
+    it('renders poll options with a bar sized by their share of the votes', async () => {
+        fetchItemContentMock.mockResolvedValue(
+            makeStory({
+                type: 'poll',
+                poll: [
+                    { points: 30, content: '<p>Option A</p>' },
+                    { points: 10, content: '<p>Option B</p>' },
+                ],
+                poll_votes_count: 40,
+            })
+        );
+
+        const { container } = renderItem();
+
+        expect(await screen.findByText('Option A')).toBeInTheDocument();
+        expect(screen.getByText('30 points')).toBeInTheDocument();
+        const bars = container.querySelectorAll('.pollBar');
+        expect(bars[0]).toHaveStyle({ width: '75%' });
+        expect(bars[1]).toHaveStyle({ width: '25%' });
+    });
+
+    it('renders the comment threads of the item', async () => {
+        fetchItemContentMock.mockResolvedValue(
+            makeStory({
+                comments: [
+                    {
+                        id: 1,
+                        level: 0,
+                        user: 'pg',
+                        time: 1,
+                        time_ago: '1 hour ago',
+                        content: '<p>First</p>',
+                        deleted: false,
+                        comments: [
+                            {
+                                id: 2,
+                                level: 1,
+                                user: 'jl',
+                                time: 2,
+                                time_ago: '30 minutes ago',
+                                content: '<p>Second</p>',
+                                deleted: false,
+                                comments: [],
+                            },
+                        ],
+                    },
+                ],
+            })
+        );
+
+        renderItem();
+
+        expect(await screen.findByText('First')).toBeInTheDocument();
+        expect(screen.getByText('Second')).toBeInTheDocument();
+    });
+
+    it('hides points, author and comments for jobs', async () => {
+        fetchItemContentMock.mockResolvedValue(makeStory({ type: 'job', comments_count: 0, user: '' }));
+
+        renderItem();
+
+        await screen.findAllByRole('link', { name: /My YC app/ });
+        expect(screen.queryByText(/points by/)).not.toBeInTheDocument();
+    });
+
+    it('navigates back in history from the mobile header', async () => {
+        fetchItemContentMock.mockResolvedValue(makeStory());
+
+        renderItem();
+        await screen.findAllByRole('link', { name: /My YC app/ });
+
+        await userEvent.click(screen.getByRole('button', { name: 'Go back' }));
+
+        expect(navigate).toHaveBeenCalledWith(-1);
+    });
+
+    it('shows an error message when the item cannot be loaded', async () => {
+        fetchItemContentMock.mockRejectedValue(new Error('offline'));
+
+        renderItem();
+
+        expect(await screen.findByText('Could not load item comments.')).toBeInTheDocument();
+        await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument());
+    });
+});

--- a/react-app/src/features/item-details/ItemDetailsPage.tsx
+++ b/react-app/src/features/item-details/ItemDetailsPage.tsx
@@ -1,7 +1,133 @@
-import { useParams } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+
+import { fetchItemContent } from '../../shared/api/hackernews-api';
+import ErrorMessage from '../../shared/components/ErrorMessage';
+import Loader from '../../shared/components/Loader';
+import type { Story } from '../../shared/models/story';
+import { useSettings } from '../../shared/settings/useSettings';
+import { formatCommentCount } from '../../shared/utils/comment-count';
+import CommentThread from './CommentThread';
+import './ItemDetailsPage.scss';
 
 export default function ItemDetailsPage() {
     const { id } = useParams<{ id: string }>();
+    const navigate = useNavigate();
+    const settings = useSettings();
+    const [item, setItem] = useState<Story | null>(null);
+    const [errorMessage, setErrorMessage] = useState('');
 
-    return <div className="main-content" data-testid="item-details-page" data-item-id={id}></div>;
+    useEffect(() => {
+        let cancelled = false;
+        setItem(null);
+        setErrorMessage('');
+        window.scrollTo(0, 0);
+
+        fetchItemContent(Number(id))
+            .then((story) => {
+                if (!cancelled) {
+                    setItem(story);
+                }
+            })
+            .catch(() => {
+                if (!cancelled) {
+                    setErrorMessage('Could not load item comments.');
+                }
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [id]);
+
+    if (!item) {
+        return (
+            <div className="main-content">
+                {!errorMessage && <Loader />}
+                {errorMessage !== '' && <ErrorMessage message={errorMessage} />}
+            </div>
+        );
+    }
+
+    const hasUrl = item.url?.indexOf('http') === 0;
+    const isJob = item.type === 'job';
+    const externalLinkProps = settings.openLinkInNewTab ? { target: '_blank', rel: 'noopener' } : {};
+    const titleLink = hasUrl ? (
+        <a className="title" href={item.url} {...externalLinkProps}>
+            {item.title}
+        </a>
+    ) : (
+        <Link className="title" to={`/item/${item.id}`}>
+            {item.title}
+        </Link>
+    );
+    const laptopClassNames = ['laptop'];
+    if (item.comments_count > 0 || isJob) {
+        laptopClassNames.push('item-header');
+    }
+    if (item.text) {
+        laptopClassNames.push('head-margin');
+    }
+
+    return (
+        <div className="main-content">
+            <div className="item">
+                <div className="mobile item-header">
+                    <p className="title-block">
+                        <span
+                            className="back-button"
+                            role="button"
+                            aria-label="Go back"
+                            onClick={() => navigate(-1)}
+                        ></span>
+                        {titleLink}
+                    </p>
+                </div>
+                <div className={laptopClassNames.join(' ')}>
+                    <p>
+                        {titleLink}
+                        {hasUrl && item.domain && <span className="domain">({item.domain})</span>}
+                    </p>
+                    <div className="subtext">
+                        {!isJob && (
+                            <span>
+                                {item.points} points by <Link to={`/user/${item.user}`}>{item.user}</Link>
+                            </span>
+                        )}
+                        <span className={isJob ? undefined : 'item-details'}>
+                            {item.time_ago}
+                            {!isJob && (
+                                <span>
+                                    {' | '}
+                                    <Link to={`/item/${item.id}`}>{formatCommentCount(item.comments_count)}</Link>
+                                </span>
+                            )}
+                        </span>
+                    </div>
+                </div>
+                {item.type === 'poll' && (
+                    <div className="pollResults">
+                        {item.poll.map((pollResult, index) => (
+                            <div key={index} className="pollContent">
+                                <div dangerouslySetInnerHTML={{ __html: pollResult.content }}></div>
+                                <div className="subtext">{pollResult.points} points</div>
+                                <div
+                                    className="pollBar"
+                                    style={{ width: `${(pollResult.points / item.poll_votes_count) * 100}%` }}
+                                ></div>
+                            </div>
+                        ))}
+                    </div>
+                )}
+                <p className="subject" dangerouslySetInnerHTML={{ __html: item.content ?? '' }}></p>
+                <ul className="comment-list">
+                    {item.comments?.map((comment) => (
+                        <li key={comment.id}>
+                            <CommentThread comment={comment} />
+                        </li>
+                    ))}
+                </ul>
+            </div>
+        </div>
+    );
 }

--- a/react-app/src/router/AppRoutes.test.tsx
+++ b/react-app/src/router/AppRoutes.test.tsx
@@ -1,21 +1,26 @@
 import { screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { fetchFeed } from '../shared/api/hackernews-api';
+import { fetchFeed, fetchItemContent } from '../shared/api/hackernews-api';
+import { makeStory } from '../test/fixtures';
 import { renderWithProviders } from '../test/renderWithProviders';
 import AppRoutes from './AppRoutes';
 
 vi.mock('../shared/api/hackernews-api', () => ({
     fetchFeed: vi.fn(),
+    fetchItemContent: vi.fn(),
 }));
 
 const fetchFeedMock = vi.mocked(fetchFeed);
+const fetchItemContentMock = vi.mocked(fetchItemContent);
 
 describe('AppRoutes', () => {
     beforeEach(() => {
         localStorage.clear();
         fetchFeedMock.mockReset();
         fetchFeedMock.mockResolvedValue([]);
+        fetchItemContentMock.mockReset();
+        fetchItemContentMock.mockResolvedValue(makeStory());
         vi.stubGlobal('scrollTo', vi.fn());
     });
 
@@ -44,7 +49,7 @@ describe('AppRoutes', () => {
     it('renders the item details page with the item id', () => {
         renderWithProviders(<AppRoutes />, { route: '/item/8863' });
 
-        expect(screen.getByTestId('item-details-page')).toHaveAttribute('data-item-id', '8863');
+        expect(fetchItemContentMock).toHaveBeenCalledWith(8863);
     });
 
     it('renders the user page with the user id', () => {


### PR DESCRIPTION
## Summary

Fifth PR of the Angular→React stack (on top of #547): item pages, polls and comment threads.

**`ItemDetailsPage`** — fetches on `[id]` with the same cancel guard as the feed, scrolls to top, and shows `Could not load item comments.` on failure. `goBack()` becomes `navigate(-1)` (`Location.back()` equivalent) behind the mobile back-button span, which gained `role="button"` + `aria-label` since it has no text. `hasUrl` is unchanged (`url.indexOf('http') === 0`, null-safe), and the laptop header keeps its conditional classes:

```ts
laptop + (comments_count > 0 || type === 'job' ? ' item-header' : '') + (item.text ? ' head-margin' : '')
```

Poll rendering is a direct port — each option's `content` is injected as HTML with a bar sized `points / poll_votes_count * 100%` (`poll_votes_count` is already aggregated by the API module from PR #543). Angular's `[innerHTML]` bindings become `dangerouslySetInnerHTML` for poll content, the item text and comment bodies; this is the same trust model as before (the HN API is the only source and Angular sanitized identically-shaped markup).

**`CommentThread`** — the recursive comment component. Each instance owns its `collapsed` state (`useState(false)`), renders `[-]`/`[+]`, toggles the `meta-collapse` class and hides its own subtree only, so collapsing a child leaves its parent expanded. Deleted comments render the `[deleted] | Comment Deleted` placeholder. The Angular `:host >>> a` rule becomes a `.comment-thread a` rule since React has no view encapsulation.

**Tests** — 13 new (74 total): loader→item transition, `fetchItemContent` argument, external vs. internal title link, new-tab setting, domain rendering, poll bars (75% / 25% of 40 votes), nested comment rendering, job variant, back navigation, error state; plus collapse/expand, per-comment collapse isolation and the deleted placeholder.


Link to Devin session: https://app.devin.ai/sessions/d8dbf31831b94e208654e841c16cc384
Requested by: @vibhaseshadri-cognition
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/548?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/548" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->