### PR TITLE
[6/7] Migrate the user feature to React

### DIFF
--- a/react-app/src/App.test.tsx
+++ b/react-app/src/App.test.tsx
@@ -2,17 +2,22 @@ import { screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import App from './App';
-import { fetchFeed } from './shared/api/hackernews-api';
+import { fetchFeed, fetchItemContent, fetchUser } from './shared/api/hackernews-api';
+import { makeStory, makeUser } from './test/fixtures';
 import { renderWithProviders } from './test/renderWithProviders';
 
 vi.mock('./shared/api/hackernews-api', () => ({
     fetchFeed: vi.fn(),
+    fetchItemContent: vi.fn(),
+    fetchUser: vi.fn(),
 }));
 
 describe('App', () => {
     beforeEach(() => {
         localStorage.clear();
         vi.mocked(fetchFeed).mockResolvedValue([]);
+        vi.mocked(fetchItemContent).mockResolvedValue(makeStory());
+        vi.mocked(fetchUser).mockResolvedValue(makeUser());
         vi.stubGlobal('scrollTo', vi.fn());
     });
 

--- a/react-app/src/features/user/UserPage.scss
+++ b/react-app/src/features/user/UserPage.scss
@@ -1,0 +1,90 @@
+@import '../../styles/media';
+@import '../../styles/theme_variables';
+
+// `:host >>> pre` in Angular; scoping is global here so the selector is applied to the profile
+.profile pre {
+    white-space: pre-wrap;
+}
+
+.profile {
+    padding: 30px;
+}
+
+@media #{$mobile-only} {
+    .profile {
+        padding: 110px 15px 0 15px;
+    }
+    .title-block {
+        font-size: 15px;
+        text-align: center;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        overflow: hidden;
+        margin: 0 75px;
+    }
+    .back-button {
+        position: absolute;
+        top: 52%;
+        width: 0.6rem;
+        height: 0.6rem;
+        background: transparent;
+        box-shadow: 0 0 0 lightgray;
+        transition: all 200ms ease;
+        left: 4%;
+        transform: translate3d(0, -50%, 0) rotate(-135deg);
+    }
+    .item-header {
+        padding-bottom: 10px;
+        background-color: #fff;
+        padding: 10px 0 10px 0;
+        position: fixed;
+        width: 100%;
+        left: 0;
+        top: 62px;
+        height: 20px;
+    }
+}
+
+@media #{$laptop-only} {
+    .mobile {
+        display: none;
+    }
+}
+
+.main-details {
+    .name {
+        font-weight: bold;
+        font-size: 32px;
+        letter-spacing: 2px;
+    }
+    .age {
+        font-weight: bold;
+        color: #696969;
+        padding-bottom: 0;
+    }
+    .right {
+        float: right;
+        font-weight: bold;
+        font-size: 32px;
+        letter-spacing: 2px;
+    }
+}
+
+@media #{$mobile-only} {
+    .main-details {
+        margin-top: 20px;
+        .name {
+            font-size: 18px;
+        }
+    }
+}
+
+@media #{$mobile-only} {
+    .main-details .right {
+        font-size: 18px;
+    }
+}
+
+.other-details {
+    word-wrap: break-word;
+}

--- a/react-app/src/features/user/UserPage.test.tsx
+++ b/react-app/src/features/user/UserPage.test.tsx
@@ -1,0 +1,80 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Route, Routes } from 'react-router-dom';
+
+import { fetchUser } from '../../shared/api/hackernews-api';
+import { makeUser } from '../../test/fixtures';
+import { renderWithProviders } from '../../test/renderWithProviders';
+import UserPage from './UserPage';
+
+vi.mock('../../shared/api/hackernews-api', () => ({
+    fetchUser: vi.fn(),
+}));
+
+const navigate = vi.fn();
+vi.mock('react-router-dom', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('react-router-dom')>();
+    return { ...actual, useNavigate: () => navigate };
+});
+
+const fetchUserMock = vi.mocked(fetchUser);
+
+function renderUser(route = '/user/pg') {
+    return renderWithProviders(
+        <Routes>
+            <Route path="/user/:id" element={<UserPage />} />
+        </Routes>,
+        { route }
+    );
+}
+
+describe('UserPage', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        navigate.mockReset();
+        fetchUserMock.mockReset();
+    });
+
+    it('shows the loader, then the profile of the requested user', async () => {
+        fetchUserMock.mockResolvedValue(makeUser());
+
+        renderUser();
+        expect(screen.getByText('Loading...')).toBeInTheDocument();
+
+        expect(await screen.findByText('Created October 9, 2006')).toBeInTheDocument();
+        expect(fetchUserMock).toHaveBeenCalledWith('pg');
+        expect(screen.getByText('Profile: pg')).toBeInTheDocument();
+        expect(screen.getByText('155111 ★')).toBeInTheDocument();
+        expect(screen.getByText('Bug fixer.')).toBeInTheDocument();
+    });
+
+    it('omits the about section when the user has none', async () => {
+        fetchUserMock.mockResolvedValue(makeUser({ about: '' }));
+
+        const { container } = renderUser();
+
+        await screen.findByText('Created October 9, 2006');
+        expect(container.querySelector('.other-details')).toBeNull();
+    });
+
+    it('shows an error message naming the user that could not be loaded', async () => {
+        fetchUserMock.mockRejectedValue(new Error('not found'));
+
+        renderUser('/user/nobody');
+
+        expect(await screen.findByText('Could not load user nobody.')).toBeInTheDocument();
+        await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument());
+    });
+
+    it('navigates back in history from the mobile header', async () => {
+        fetchUserMock.mockResolvedValue(makeUser());
+
+        renderUser();
+        await screen.findByText('Created October 9, 2006');
+
+        await userEvent.click(screen.getByRole('button', { name: 'Go back' }));
+
+        expect(navigate).toHaveBeenCalledWith(-1);
+    });
+});

--- a/react-app/src/features/user/UserPage.tsx
+++ b/react-app/src/features/user/UserPage.tsx
@@ -1,7 +1,72 @@
-import { useParams } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+
+import { fetchUser } from '../../shared/api/hackernews-api';
+import ErrorMessage from '../../shared/components/ErrorMessage';
+import Loader from '../../shared/components/Loader';
+import type { User } from '../../shared/models/user';
+import './UserPage.scss';
 
 export default function UserPage() {
     const { id } = useParams<{ id: string }>();
+    const navigate = useNavigate();
+    const [user, setUser] = useState<User | null>(null);
+    const [errorMessage, setErrorMessage] = useState('');
 
-    return <div className="profile" data-testid="user-page" data-user-id={id}></div>;
+    useEffect(() => {
+        let cancelled = false;
+        setUser(null);
+        setErrorMessage('');
+
+        fetchUser(id ?? '')
+            .then((data) => {
+                if (!cancelled) {
+                    setUser(data);
+                }
+            })
+            .catch(() => {
+                if (!cancelled) {
+                    setErrorMessage(`Could not load user ${id}.`);
+                }
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [id]);
+
+    if (!user) {
+        return (
+            <>
+                {!errorMessage && <Loader />}
+                {errorMessage !== '' && <ErrorMessage message={errorMessage} />}
+            </>
+        );
+    }
+
+    return (
+        <div className="profile">
+            <div className="mobile item-header">
+                <p className="title-block">
+                    <span
+                        className="back-button"
+                        role="button"
+                        aria-label="Go back"
+                        onClick={() => navigate(-1)}
+                    ></span>
+                    Profile: {user.id}
+                </p>
+            </div>
+            <div className="main-details">
+                <span className="name">{user.id}</span>
+                <span className="right">{user.karma} ★</span>
+                <p className="age">Created {user.created}</p>
+            </div>
+            {user.about && (
+                <div className="other-details">
+                    <p dangerouslySetInnerHTML={{ __html: user.about }}></p>
+                </div>
+            )}
+        </div>
+    );
 }

--- a/react-app/src/router/AppRoutes.test.tsx
+++ b/react-app/src/router/AppRoutes.test.tsx
@@ -1,18 +1,19 @@
-import { screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { fetchFeed, fetchItemContent } from '../shared/api/hackernews-api';
-import { makeStory } from '../test/fixtures';
+import { fetchFeed, fetchItemContent, fetchUser } from '../shared/api/hackernews-api';
+import { makeStory, makeUser } from '../test/fixtures';
 import { renderWithProviders } from '../test/renderWithProviders';
 import AppRoutes from './AppRoutes';
 
 vi.mock('../shared/api/hackernews-api', () => ({
     fetchFeed: vi.fn(),
     fetchItemContent: vi.fn(),
+    fetchUser: vi.fn(),
 }));
 
 const fetchFeedMock = vi.mocked(fetchFeed);
 const fetchItemContentMock = vi.mocked(fetchItemContent);
+const fetchUserMock = vi.mocked(fetchUser);
 
 describe('AppRoutes', () => {
     beforeEach(() => {
@@ -21,6 +22,8 @@ describe('AppRoutes', () => {
         fetchFeedMock.mockResolvedValue([]);
         fetchItemContentMock.mockReset();
         fetchItemContentMock.mockResolvedValue(makeStory());
+        fetchUserMock.mockReset();
+        fetchUserMock.mockResolvedValue(makeUser());
         vi.stubGlobal('scrollTo', vi.fn());
     });
 
@@ -55,6 +58,6 @@ describe('AppRoutes', () => {
     it('renders the user page with the user id', () => {
         renderWithProviders(<AppRoutes />, { route: '/user/pg' });
 
-        expect(screen.getByTestId('user-page')).toHaveAttribute('data-user-id', 'pg');
+        expect(fetchUserMock).toHaveBeenCalledWith('pg');
     });
 });


### PR DESCRIPTION
## Summary

Sixth PR of the Angular→React stack (on top of #548). With this the React app reaches feature parity with the Angular app; PR 7 handles PWA, e2e and Angular removal.

`UserPage` ports `user.component`: fetch by route id with the same cancel guard as the other pages, `Could not load user <id>.` on failure, karma/created/about rendering (`about` still injected as HTML, section omitted when empty), and `goBack()` → `navigate(-1)` on the mobile back button (given `role="button"` + `aria-label`, it has no text). Angular's `:host >>> pre` rule becomes `.profile pre` since React has no view encapsulation.

**Tests** — 4 new (78 total): loader→profile with `fetchUser('pg')`, absent about section, error copy naming the requested user, back navigation. The routing and shell tests now assert the user route via the mocked `fetchUser` instead of the removed placeholder.


Link to Devin session: https://app.devin.ai/sessions/d8dbf31831b94e208654e841c16cc384
Requested by: @vibhaseshadri-cognition
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/549?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/549" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->