### PR TITLE
React migration 2/5: shared UI components and app chrome

### DIFF
--- a/react-app/src/components/core/Footer.scss
+++ b/react-app/src/components/core/Footer.scss
@@ -1,0 +1,23 @@
+@import "../../scss/media";
+@import "../../scss/theme_variables";
+
+#footer {
+  position: relative;
+  padding: 10px;
+  height: 60px;
+  letter-spacing: 0.7px;
+  text-align: center;
+
+  a {
+  	font-weight: bold;
+  	text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  @media #{$mobile-only} {
+    display: none;
+  }
+}

--- a/react-app/src/components/core/Footer.tsx
+++ b/react-app/src/components/core/Footer.tsx
@@ -1,0 +1,14 @@
+import './Footer.scss';
+
+export default function Footer() {
+    return (
+        <div id="footer">
+            <p>
+                Show this project some ❤ on{' '}
+                <a href="https://github.com/hdjirdeh/angular2-hn" target="_blank" rel="noopener noreferrer">
+                    GitHub
+                </a>
+            </p>
+        </div>
+    );
+}

--- a/react-app/src/components/core/Header.scss
+++ b/react-app/src/components/core/Header.scss
@@ -1,0 +1,149 @@
+@import "../../scss/media";
+@import "../../scss/theme_variables";
+
+#header {
+  color: #fff;
+  padding: 6px 0;
+  line-height: 18px;
+  vertical-align: middle;
+  position: relative;
+  z-index: 1;
+  width: 100%;
+
+  @media #{$mobile-only} {
+    height: 50px;
+    position: fixed;
+    top: 0;
+  }
+
+  a {
+    display: inline;
+  }
+}
+
+.home-link {
+  width: 50px;
+  height: 66px;
+}
+
+.logo-inner {
+  width: 32px;
+  position: absolute;
+  left: 17px;
+  top: 18px;
+  z-index: -1;
+  height: 32px;
+  border-radius: 50%;
+
+  @media #{$mobile-only} {
+    left: 16px;
+    top: 12px;
+  }
+}
+
+.logo {
+  width: 50px;
+  padding: 3px 8px 0;
+
+  @media #{$mobile-only} {
+    width: 45px;
+    padding: 0 0 0 10px;
+  }
+}
+
+h1 {
+  font-weight: normal;
+  display: inline-block;
+  vertical-align:middle;
+  margin: 0;
+  font-size: 16px;
+
+  a {
+    color: #fff;
+    text-decoration: none;
+  }
+}
+
+.name {
+  margin-right: 30px;
+  margin-bottom: 2px;
+
+  @media #{$mobile-only} {
+    display: none;
+  }
+}
+
+.header-text {
+  position: absolute;
+  width: inherit;
+  height: 20px;
+  left: 10px;
+  top: 27px;
+  z-index: -1;
+
+  @media #{$mobile-only} {
+    top: 22px;
+  }
+}
+
+.left {
+  position: absolute;
+  left: 60px;
+  font-size: 16px;
+
+  @media #{$mobile-only} {
+    width: 100%;
+    left: 0;
+  }
+}
+
+.header-nav {
+  display: inline-block;
+  margin-left: 20px;
+
+  @media #{$mobile-only} {
+    margin-left: 60px;
+  }
+
+  a {
+    color: hsla(0,0%,100%,.9);
+    text-decoration: none;
+    margin: 0 5px;
+    letter-spacing: 1.8px;
+
+    &:hover {
+      color: #fff;
+    }
+  }
+
+  .active {
+    color: #fff;
+  }
+}
+
+.info {
+  position: absolute;
+  top: 0;
+  right: 20px;
+  height: 100%;
+
+  @media #{$mobile-only} {
+    right: 10px;
+  }
+
+  img {
+    opacity: 0.8;
+    width: 25px;
+    margin-top: 21.5px;
+    display: block;
+
+    &:hover {
+      opacity: 1;
+      cursor: pointer;
+    }
+
+    @media #{$mobile-only} {
+      margin-top: 15px;
+    }
+  }
+}

--- a/react-app/src/components/core/Header.tsx
+++ b/react-app/src/components/core/Header.tsx
@@ -1,0 +1,62 @@
+import { NavLink } from 'react-router-dom';
+
+import { useSettings } from '../../context/SettingsContext';
+import Settings from './Settings';
+import './Header.scss';
+
+const FEEDS = [
+    { path: '/newest/1', label: 'new' },
+    { path: '/show/1', label: 'show' },
+    { path: '/ask/1', label: 'ask' },
+    { path: '/jobs/1', label: 'jobs' },
+];
+
+function scrollTop() {
+    window.scrollTo(0, 0);
+}
+
+export default function Header() {
+    const { settings, toggleSettings } = useSettings();
+
+    return (
+        <header>
+            <div id="header">
+                <NavLink
+                    className={({ isActive }) => (isActive ? 'home-link active' : 'home-link')}
+                    to="/news/1"
+                    onClick={scrollTop}
+                >
+                    <div className="logo-inner"></div>
+                    <img className="logo" src="/assets/images/logo.svg" alt="Logo" />
+                </NavLink>
+                <div className="header-text">
+                    <div className="left">
+                        <span className="header-nav">
+                            {FEEDS.map((feed, index) => (
+                                <span key={feed.path}>
+                                    {index > 0 && ' | '}
+                                    <NavLink
+                                        className={({ isActive }) => (isActive ? 'active' : '')}
+                                        to={feed.path}
+                                        onClick={scrollTop}
+                                    >
+                                        {feed.label}
+                                    </NavLink>
+                                </span>
+                            ))}
+                        </span>
+                    </div>
+                </div>
+                <div className="info">
+                    <img
+                        className="settings"
+                        src="/assets/images/cog.svg"
+                        alt="Settings"
+                        onClick={toggleSettings}
+                    />
+                </div>
+            </div>
+            {settings.showSettings && <Settings />}
+        </header>
+    );
+}

--- a/react-app/src/components/core/Settings.scss
+++ b/react-app/src/components/core/Settings.scss
@@ -1,0 +1,74 @@
+@import "../../scss/media";
+@import "../../scss/theme_variables";
+
+.overlay {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: rgba(0, 0, 0, 0.7);
+  opacity: 1;
+  z-index: 1;
+}
+
+.popup {
+  margin: 70px auto;
+  padding: 30px;
+  border-radius: 5px;
+  width: 30%;
+  position: relative;
+  h1 {
+    margin-top: 0;
+    margin-bottom: 0px;
+    color: #fff;
+    text-align: center;
+    letter-spacing: 1px;
+  }
+  h2 {
+    padding-top: 10px;
+  }
+  hr {
+    width: 40%;
+    margin-bottom: 20px;
+  }
+  .close {
+    position: absolute;
+    top: 12px;
+    right: 20px;
+    font-size: 30px;
+    font-weight: bold;
+    text-decoration: none;
+    color: rgba(255,255,255,0.8);
+    &:hover {
+      color: #fff;
+      cursor: pointer;
+    }
+  }
+  .content {
+    max-height: 30%;
+    color: #fff;
+    letter-spacing: 1px;
+    overflow: auto;
+  }
+  input[type=number] {
+      display: block;
+      width: 80%;
+      height: 20px;
+      margin-bottom: 15px;
+      border-radius: 5px;
+      padding: 2px;
+  }
+}
+
+.control-section {
+    margin-bottom: 15px;
+    padding-bottom: 15px;
+    border-bottom: 1px solid white;
+}
+
+@media screen and (max-width: 700px) {
+  .box, .popup {
+    width: 70%;
+  }
+}

--- a/react-app/src/components/core/Settings.tsx
+++ b/react-app/src/components/core/Settings.tsx
@@ -1,0 +1,81 @@
+import { useSettings } from '../../context/SettingsContext';
+import './Settings.scss';
+
+const THEMES = [
+    { value: 'default', label: 'Default' },
+    { value: 'night', label: 'Night' },
+    { value: 'amoledblack', label: 'Black (AMOLED)' },
+];
+
+export default function Settings() {
+    const { settings, toggleSettings, toggleOpenLinksInNewTab, setTheme, setFont, setSpacing } = useSettings();
+
+    return (
+        <div id="popup1" className="overlay">
+            <div className="popup">
+                <h1>Settings</h1>
+                <hr />
+                <span className="close" onClick={toggleSettings}>
+                    &times;
+                </span>
+                <div className="content">
+                    <div className="control-section">
+                        <h2>Links</h2>
+                        <input
+                            type="checkbox"
+                            checked={settings.openLinkInNewTab}
+                            onChange={toggleOpenLinksInNewTab}
+                        />
+                        Open links in a new tab
+                    </div>
+                    <div className="theme-controls">
+                        <div className="control-section">
+                            <h2>Select a theme</h2>
+                            {THEMES.map((theme) => (
+                                <div key={theme.value}>
+                                    <label>
+                                        <input
+                                            name="theme"
+                                            type="radio"
+                                            value={theme.value}
+                                            checked={settings.theme === theme.value}
+                                            onChange={() => setTheme(theme.value)}
+                                        />
+                                        {theme.label}
+                                    </label>
+                                </div>
+                            ))}
+                        </div>
+                        <div className="control-section">
+                            <h2>Change Font</h2>
+                            <div>
+                                <label>
+                                    Font size:
+                                    <input
+                                        min="1"
+                                        value={settings.titleFontSize}
+                                        name="titleFontSize"
+                                        type="number"
+                                        onChange={(event) => setFont(event.target.value)}
+                                    />
+                                </label>
+                            </div>
+                            <div>
+                                <label>
+                                    List spacing:
+                                    <input
+                                        min="0"
+                                        value={settings.listSpacing}
+                                        name="listSpacing"
+                                        type="number"
+                                        onChange={(event) => setSpacing(event.target.value)}
+                                    />
+                                </label>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/react-app/src/components/shared/ErrorMessage.scss
+++ b/react-app/src/components/shared/ErrorMessage.scss
@@ -1,0 +1,115 @@
+@import "../../scss/media";
+@import "../../scss/theme_variables";
+
+.error-section {
+  height: 300px;
+  margin: 200px;
+
+  @media #{$mobile-only} {
+    height: 0;
+    display: block;
+    position: relative;
+    margin: 30vh 0;
+  }
+
+  p {
+    text-align: center;
+    padding: 0 25px;
+
+    &.strong {
+      margin-top: 25px;
+      font-weight: bold;
+    }
+  }
+
+  .skull {
+    width: $skull-size;
+    height: $skull-size;
+    position: relative;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    margin: auto;
+
+    .head {
+      width: 100%;
+      height: 75%;
+      border-radius: 15% / 20%;
+      position: absolute;
+      top: 0;
+      left: 0;
+      &:before, &:after {
+        content: "";
+        position: absolute;
+        border-radius: 50%;
+        width: 20%;
+        height: 30%;
+        bottom: 10%;
+      }
+      &:before {
+        left: 10%;
+      }
+      &:after {
+        right: 10%;
+      }
+      .crack {
+        width: 10%;
+        height: 10%;
+        position: absolute;
+        top: 0;
+        right: 25%;
+        transform: skew(-15deg);
+
+        &:before {
+          content: "";
+          position: absolute;
+          top: 100%;
+          left: $skull-size / 15;
+          border-right: $skull-size / 20 solid transparent;
+          border-left: $skull-size / 40 solid transparent;
+        }
+      }
+    }
+    .mouth {
+      width: 40%;
+      height: 25%;
+      position: absolute;
+      top: 75%;
+      left: 30%;
+      border-radius: 0 0 $skull-size / 10 $skull-size / 10;
+      &:before {
+        content: "";
+        position: absolute;
+        width: 15%;
+        height: 50%;
+        border-radius: 50% / 30%;
+        left: 42.5%;
+        top: -25%;
+      }
+      .teeth {
+        position: absolute;
+        bottom: 0;
+        left: 45%;
+        width: 10%;
+        height: 50%;
+        margin-bottom: -5%;
+        border-radius: 50% / 20%;
+
+        &:before, &:after {
+          content: "";
+          position: absolute;
+          width: 100%;
+          height: 100%;
+          border-radius: 50% / 20%;
+        }
+        &:before {
+          left: -250%;
+        }
+        &:after {
+          right: -250%;
+        }
+      }
+    }
+  }
+}

--- a/react-app/src/components/shared/ErrorMessage.test.tsx
+++ b/react-app/src/components/shared/ErrorMessage.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import ErrorMessage from './ErrorMessage';
+import Loader from './Loader';
+
+describe('shared components', () => {
+    it('renders the error message it is given', () => {
+        render(<ErrorMessage message="Could not load news stories." />);
+
+        expect(screen.getByText('Could not load news stories.')).toBeInTheDocument();
+    });
+
+    it('renders the loader', () => {
+        render(<Loader />);
+
+        expect(screen.getByText('Loading...')).toBeInTheDocument();
+    });
+});

--- a/react-app/src/components/shared/ErrorMessage.tsx
+++ b/react-app/src/components/shared/ErrorMessage.tsx
@@ -1,0 +1,25 @@
+import './ErrorMessage.scss';
+
+export interface ErrorMessageProps {
+    message: string;
+}
+
+export default function ErrorMessage({ message }: ErrorMessageProps) {
+    return (
+        <div className="error-section">
+            <div className="skull">
+                <div className="head">
+                    <div className="crack"></div>
+                </div>
+                <div className="mouth">
+                    <div className="teeth"></div>
+                </div>
+            </div>
+            <p className="strong">{message}</p>
+            <p>
+                If you are offline viewing, you&apos;ll need to visit this page with a network connection first
+                before it can work offline.
+            </p>
+        </div>
+    );
+}

--- a/react-app/src/components/shared/Loader.scss
+++ b/react-app/src/components/shared/Loader.scss
@@ -1,0 +1,109 @@
+@import "../../scss/media";
+@import "../../scss/theme_variables";
+
+.loader {
+  -webkit-animation: load1 1s infinite ease-in-out;
+  animation: load1 1s infinite ease-in-out;
+  width: 1em;
+  height: 4em;
+  &:before, &:after {
+    -webkit-animation: load1 1s infinite ease-in-out;
+    animation: load1 1s infinite ease-in-out;
+    width: 1em;
+    height: 4em;
+  }
+  &:before, &:after {
+    position: absolute;
+    top: 0;
+    content: '';
+  }
+  &:before {
+    left: -1.5em;
+    -webkit-animation-delay: -0.32s;
+    animation-delay: -0.32s;
+  }
+}
+
+.loading-section {
+    height: 70px;
+    margin: 40px 0 40px 40px;
+
+  @media #{$mobile-only} {
+    display: block;
+    position: relative;
+    margin: 45vh 0;
+  }
+}
+
+.loader {
+  text-indent: -9999em;
+  margin: 20px 20px;
+  position: relative;
+  font-size: 11px;
+  -webkit-transform: translateZ(0);
+  -ms-transform: translateZ(0);
+  transform: translateZ(0);
+  -webkit-animation-delay: -0.16s;
+  animation-delay: -0.16s;
+  &:after {
+    left: 1.5em;
+  }
+
+  @media #{$mobile-only} {
+    margin: 20px auto;
+  }
+}
+
+@-webkit-keyframes load1 {
+  0%,
+    80%,
+    100% {
+    box-shadow: 0 0;
+    height: 2em;
+  }
+  40% {
+    box-shadow: 0 -2em;
+    height: 3em;
+  }
+}
+
+@keyframes load1 {
+  0%,
+    80%,
+    100% {
+    box-shadow: 0 0;
+    height: 2em;
+  }
+  40% {
+    box-shadow: 0 -2em;
+    height: 3em;
+  }
+}
+
+@media #{$mobile-only} {
+  @-webkit-keyframes load1 {
+    0%,
+      80%,
+      100% {
+      box-shadow: 0 0;
+      height: 4em;
+    }
+    40% {
+      box-shadow: 0 -2em;
+      height: 5em;
+    }
+  }
+
+  @keyframes load1 {
+    0%,
+      80%,
+      100% {
+      box-shadow: 0 0;
+      height: 3em;
+    }
+    40% {
+      box-shadow: 0 -2em;
+      height: 4em;
+    }
+  }
+}

--- a/react-app/src/components/shared/Loader.tsx
+++ b/react-app/src/components/shared/Loader.tsx
@@ -1,0 +1,9 @@
+import './Loader.scss';
+
+export default function Loader() {
+    return (
+        <div className="loading-section">
+            <div className="loader">Loading...</div>
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary

Second of five stacked PRs porting the Angular client to React. Ports the presentational pieces that surround every page: `Loader`, `ErrorMessage`, `Header`, `Footer`, and the `Settings` popup. Each component's SCSS is copied from its Angular counterpart unchanged, so the theme engine in `scss/_themes.scss` keeps matching on the same class names.

Notable translations:

- `routerLink` + `routerLinkActive="active"` → `NavLink` with `className={({ isActive }) => ...}`. The feed links are generated from a `FEEDS` array instead of being hand-written four times, with the `|` separators inserted between entries.
- `*ngIf="settings.showSettings"` in the header template → `{settings.showSettings && <Settings />}`.
- The settings popup's Angular template read live values off template reference variables (`#default`, `#titleFont`, …); in React the inputs are controlled from the `useSettings()` context, and the three theme radios come from a `THEMES` array. `(keyup)` on the font/spacing number inputs becomes `onChange`, which also fires for spinner clicks and paste.

Tests cover `Loader` and `ErrorMessage` rendering.


Link to Devin session: https://app.devin.ai/sessions/0444204c74e5470d9b0222b3464d1e81
Requested by: @devanshi-gpta
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/563?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/563" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->