### PR TITLE
React migration 4/5: item details and recursive comments

### DIFF
--- a/react-app/src/components/item-details/Comment.scss
+++ b/react-app/src/components/item-details/Comment.scss
@@ -1,0 +1,85 @@
+@import "../../scss/media";
+@import "../../scss/theme_variables";
+
+:host >>> {
+  a {
+    font-weight: bold;
+    text-decoration: none;
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}
+
+.meta {
+  font-size: 13px;
+  color: #696969;
+  font-weight: bold;
+  letter-spacing: 0.5px;
+  margin-bottom: 8px;
+  a {
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+  .time {
+    padding-left: 5px;
+  }
+}
+
+@media #{$mobile-only} {
+  .meta {
+    font-size: 14px;
+    margin-bottom: 10px;
+    .time {
+      padding: 0;
+      float: right;
+    }
+  }
+}
+
+.meta-collapse {
+  margin-bottom: 20px;
+}
+
+.deleted-meta {
+  font-size: 12px;
+  font-weight: bold;
+  letter-spacing: 0.5px;
+  margin: 30px 0;
+  a {
+    text-decoration: none;
+  }
+}
+
+.collapse {
+  font-size: 13px;
+  letter-spacing: 2px;
+  cursor: pointer;
+}
+
+.comment-tree {
+  margin-left: 24px;
+}
+
+@media #{$tablet-only} {
+  .comment-tree {
+    margin-left: 8px;
+  }
+}
+
+.comment-text {
+  font-size: 15px;
+  margin-top: 0;
+  margin-bottom: 20px;
+  word-wrap: break-word;
+  line-height: 1.5em;
+}
+
+.subtree {
+  margin-left: 0;
+  padding: 0;
+  list-style-type: none;
+}

--- a/react-app/src/components/item-details/Comment.scss
+++ b/react-app/src/components/item-details/Comment.scss
@@ -1,7 +1,7 @@
 @import "../../scss/media";
 @import "../../scss/theme_variables";
 
-:host >>> {
+.comment-text {
   a {
     font-weight: bold;
     text-decoration: none;

--- a/react-app/src/components/item-details/Comment.test.tsx
+++ b/react-app/src/components/item-details/Comment.test.tsx
@@ -1,0 +1,51 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+
+import { Comment as CommentModel } from '../../models';
+import { renderWithProviders } from '../../test-utils';
+import Comment from './Comment';
+
+function buildComment(overrides: Partial<CommentModel> = {}): CommentModel {
+    return {
+        id: 1,
+        level: 0,
+        user: 'pg',
+        time: 0,
+        time_ago: '2 hours ago',
+        content: '<p>top level</p>',
+        deleted: false,
+        comments: [],
+        ...overrides,
+    };
+}
+
+describe('Comment', () => {
+    it('renders nested comments recursively', () => {
+        const comment = buildComment({
+            comments: [buildComment({ id: 2, user: 'dang', content: '<p>reply</p>' })],
+        });
+
+        renderWithProviders(<Comment comment={comment} />);
+
+        expect(screen.getByText('top level')).toBeInTheDocument();
+        expect(screen.getByText('reply')).toBeInTheDocument();
+    });
+
+    it('collapses and expands the comment tree', async () => {
+        const user = userEvent.setup();
+        renderWithProviders(<Comment comment={buildComment()} />);
+
+        const toggle = screen.getByText('[-]');
+        await user.click(toggle);
+
+        expect(screen.getByText('[+]')).toBeInTheDocument();
+        expect(screen.getByText('top level').closest('div[hidden]')).not.toBeNull();
+    });
+
+    it('renders a placeholder for deleted comments', () => {
+        renderWithProviders(<Comment comment={buildComment({ deleted: true })} />);
+
+        expect(screen.getByText('[deleted]')).toBeInTheDocument();
+    });
+});

--- a/react-app/src/components/item-details/Comment.test.tsx
+++ b/react-app/src/components/item-details/Comment.test.tsx
@@ -43,6 +43,15 @@ describe('Comment', () => {
         expect(screen.getByText('top level').closest('div[hidden]')).not.toBeNull();
     });
 
+    it('strips scripts from the comment HTML returned by the API', () => {
+        const comment = buildComment({ content: '<p>safe</p><img src="x" onerror="alert(1)">' });
+
+        const { container } = renderWithProviders(<Comment comment={comment} />);
+
+        expect(screen.getByText('safe')).toBeInTheDocument();
+        expect(container.querySelector('img')?.getAttribute('onerror')).toBeNull();
+    });
+
     it('renders a placeholder for deleted comments', () => {
         renderWithProviders(<Comment comment={buildComment({ deleted: true })} />);
 

--- a/react-app/src/components/item-details/Comment.tsx
+++ b/react-app/src/components/item-details/Comment.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import { Comment as CommentModel } from '../../models';
+import { sanitizeHtml } from '../../utils/sanitize';
 import './Comment.scss';
 
 export interface CommentProps {
@@ -32,7 +33,10 @@ export default function Comment({ comment }: CommentProps) {
             </div>
             <div className="comment-tree">
                 <div hidden={collapse}>
-                    <p className="comment-text" dangerouslySetInnerHTML={{ __html: comment.content }}></p>
+                    <p
+                        className="comment-text"
+                        dangerouslySetInnerHTML={{ __html: sanitizeHtml(comment.content) }}
+                    ></p>
                     <ul className="subtree">
                         {comment.comments?.map((subComment) => (
                             <li key={subComment.id}>

--- a/react-app/src/components/item-details/Comment.tsx
+++ b/react-app/src/components/item-details/Comment.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+
+import { Comment as CommentModel } from '../../models';
+import './Comment.scss';
+
+export interface CommentProps {
+    comment: CommentModel;
+}
+
+export default function Comment({ comment }: CommentProps) {
+    const [collapse, setCollapse] = useState(false);
+
+    if (comment.deleted) {
+        return (
+            <div>
+                <div className="deleted-meta">
+                    <span className="collapse">[deleted]</span> | Comment Deleted
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div>
+            <div className={collapse ? 'meta meta-collapse' : 'meta'}>
+                <span className="collapse" onClick={() => setCollapse(!collapse)}>
+                    [{collapse ? '+' : '-'}]
+                </span>{' '}
+                <Link to={`/user/${comment.user}`}>{comment.user}</Link>
+                <span className="time">{comment.time_ago}</span>
+            </div>
+            <div className="comment-tree">
+                <div hidden={collapse}>
+                    <p className="comment-text" dangerouslySetInnerHTML={{ __html: comment.content }}></p>
+                    <ul className="subtree">
+                        {comment.comments?.map((subComment) => (
+                            <li key={subComment.id}>
+                                <Comment comment={subComment} />
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/react-app/src/components/item-details/ItemDetails.scss
+++ b/react-app/src/components/item-details/ItemDetails.scss
@@ -1,0 +1,151 @@
+@import "../../scss/media";
+@import "../../scss/theme_variables";
+
+.main-content {
+  position: relative;
+  width: 100%;
+  min-height: 100vh;
+  -webkit-transition: opacity .2s ease;
+  transition: opacity .2s ease;
+  box-sizing: border-box;
+  padding: 8px 0;
+  z-index: 0;
+}
+
+.item {
+  box-sizing: border-box;
+  padding: 10px 40px 0 40px;
+  z-index: 0;
+}
+
+@media #{$tablet-only} {
+  .item {
+    padding: 10px 20px 0 40px;
+  }
+}
+
+@media #{$mobile-only} {
+  .item {
+    box-sizing: border-box;
+    padding: 110px 15px 0 15px;
+  }
+}
+
+.head-margin {
+  margin-bottom: 15px;
+}
+
+p {
+  margin: 2px 0;
+}
+
+.subject {
+  word-wrap: break-word;
+  margin-top: 20px;
+}
+
+a {
+  cursor: pointer;
+  text-decoration: none;
+}
+
+@media #{$mobile-only} {
+  .laptop {
+    display: none;
+  }
+}
+
+@media #{$laptop-only} {
+  .mobile {
+    display: none;
+  }
+}
+
+.title {
+  font-size: 16px;
+  font-family: Verdana, Geneva, sans-serif;
+}
+
+.title-block {
+  text-align: center;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  margin: 0 75px;
+}
+
+@media #{$mobile-only} {
+  .title {
+    font-size: 15px;
+  }
+  .back-button {
+    position: absolute;
+    top: 52%;
+    width: 0.6rem;
+    height: 0.6rem;
+    background: transparent;
+    box-shadow: 0 0 0 lightgray;
+    transition: all 200ms ease;
+    left: 4%;
+    transform: translate3d(0, -50%, 0) rotate(-135deg);
+  }
+}
+
+.subtext {
+  font-size: 12px;
+  font-weight: bold;
+  letter-spacing: 0.5px;
+}
+
+.domain {
+  letter-spacing: 0.5px;
+}
+
+.subtext a {
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.item-details {
+  padding: 10px;
+}
+
+.item-header {
+  padding-bottom: 10px;
+}
+
+@media #{$mobile-only} {
+  .item-header {
+    padding: 10px 0 10px 0;
+    position: fixed;
+    width: 100%;
+    left: 0;
+    top: 62px;
+  }
+}
+
+.pollResults {
+  margin-bottom: 1em;
+}
+
+.pollContent {
+  * {
+    padding-bottom: 0;
+    margin-bottom: -1em;
+    margin-top: 1em;
+  }
+  .pollBar {
+    height: 10px;
+    margin-bottom: 1em;
+  }
+}
+
+ul {
+  list-style-type: none;
+  padding: 10px 0;
+}
+
+li {
+  display: list-item;
+}

--- a/react-app/src/components/item-details/ItemDetails.tsx
+++ b/react-app/src/components/item-details/ItemDetails.tsx
@@ -1,0 +1,129 @@
+import { useEffect, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+
+import { useSettings } from '../../context/SettingsContext';
+import { Story } from '../../models';
+import { fetchItemContent } from '../../services/hackernewsApi';
+import { commentCount } from '../../utils/comment';
+import ErrorMessage from '../shared/ErrorMessage';
+import Loader from '../shared/Loader';
+import Comment from './Comment';
+import './ItemDetails.scss';
+
+export default function ItemDetails() {
+    const { id } = useParams<{ id: string }>();
+    const navigate = useNavigate();
+    const { settings } = useSettings();
+    const [item, setItem] = useState<Story | null>(null);
+    const [errorMessage, setErrorMessage] = useState('');
+
+    useEffect(() => {
+        const controller = new AbortController();
+        setItem(null);
+        setErrorMessage('');
+        window.scrollTo(0, 0);
+
+        fetchItemContent(Number(id), controller.signal)
+            .then(setItem)
+            .catch((error: Error) => {
+                if (error.name !== 'AbortError') {
+                    setErrorMessage('Could not load item comments.');
+                }
+            });
+
+        return () => controller.abort();
+    }, [id]);
+
+    if (!item) {
+        return (
+            <div className="main-content">
+                {!errorMessage && <Loader />}
+                {errorMessage !== '' && <ErrorMessage message={errorMessage} />}
+            </div>
+        );
+    }
+
+    const hasUrl = item.url ? item.url.indexOf('http') === 0 : false;
+    const isJob = item.type === 'job';
+    const laptopClasses = ['laptop'];
+    if (item.comments_count > 0 || isJob) {
+        laptopClasses.push('item-header');
+    }
+    if (item.content) {
+        laptopClasses.push('head-margin');
+    }
+
+    const titleLink = hasUrl ? (
+        <a
+            className="title"
+            href={item.url}
+            target={settings.openLinkInNewTab ? '_blank' : undefined}
+            rel={settings.openLinkInNewTab ? 'noopener noreferrer' : undefined}
+        >
+            {item.title}
+        </a>
+    ) : (
+        <Link className="title" to={`/item/${item.id}`}>
+            {item.title}
+        </Link>
+    );
+
+    return (
+        <div className="main-content">
+            <div className="item">
+                <div className="mobile item-header">
+                    <p className="title-block">
+                        <span className="back-button" onClick={() => navigate(-1)}></span>
+                        {titleLink}
+                    </p>
+                </div>
+                <div className={laptopClasses.join(' ')}>
+                    <p>
+                        {titleLink}
+                        {hasUrl && item.domain && <span className="domain">({item.domain})</span>}
+                    </p>
+                    <div className="subtext">
+                        {!isJob && (
+                            <span>
+                                {item.points} points by <Link to={`/user/${item.user}`}>{item.user}</Link>
+                            </span>
+                        )}
+                        <span className={!isJob ? 'item-details' : undefined}>
+                            {item.time_ago}
+                            {!isJob && (
+                                <span>
+                                    {' '}
+                                    | <Link to={`/item/${item.id}`}>{commentCount(item.comments_count)}</Link>
+                                </span>
+                            )}
+                        </span>
+                    </div>
+                </div>
+                {item.type === 'poll' && (
+                    <div className="pollResults">
+                        {item.poll?.map((pollResult, index) => (
+                            <div className="pollContent" key={index}>
+                                <div dangerouslySetInnerHTML={{ __html: pollResult.content }}></div>
+                                <div className="subtext">{pollResult.points} points</div>
+                                <div
+                                    className="pollBar"
+                                    style={{
+                                        width: `${(pollResult.points / item.poll_votes_count) * 100}%`,
+                                    }}
+                                ></div>
+                            </div>
+                        ))}
+                    </div>
+                )}
+                <p className="subject" dangerouslySetInnerHTML={{ __html: item.content ?? '' }}></p>
+                <ul className="comment-list">
+                    {item.comments?.map((comment) => (
+                        <li key={comment.id}>
+                            <Comment comment={comment} />
+                        </li>
+                    ))}
+                </ul>
+            </div>
+        </div>
+    );
+}

--- a/react-app/src/components/item-details/ItemDetails.tsx
+++ b/react-app/src/components/item-details/ItemDetails.tsx
@@ -5,6 +5,7 @@ import { useSettings } from '../../context/SettingsContext';
 import { Story } from '../../models';
 import { fetchItemContent } from '../../services/hackernewsApi';
 import { commentCount } from '../../utils/comment';
+import { sanitizeHtml } from '../../utils/sanitize';
 import ErrorMessage from '../shared/ErrorMessage';
 import Loader from '../shared/Loader';
 import Comment from './Comment';
@@ -103,7 +104,7 @@ export default function ItemDetails() {
                     <div className="pollResults">
                         {item.poll?.map((pollResult, index) => (
                             <div className="pollContent" key={index}>
-                                <div dangerouslySetInnerHTML={{ __html: pollResult.content }}></div>
+                                <div dangerouslySetInnerHTML={{ __html: sanitizeHtml(pollResult.content) }}></div>
                                 <div className="subtext">{pollResult.points} points</div>
                                 <div
                                     className="pollBar"
@@ -115,7 +116,7 @@ export default function ItemDetails() {
                         ))}
                     </div>
                 )}
-                <p className="subject" dangerouslySetInnerHTML={{ __html: item.content ?? '' }}></p>
+                <p className="subject" dangerouslySetInnerHTML={{ __html: sanitizeHtml(item.content ?? '') }}></p>
                 <ul className="comment-list">
                     {item.comments?.map((comment) => (
                         <li key={comment.id}>


### PR DESCRIPTION
## Summary

Fourth of five stacked PRs porting the Angular client to React. Ports the lazily-loaded item-details feature: `ItemDetailsComponent` → `ItemDetails.tsx` and the self-recursive `CommentComponent` → `Comment.tsx`.

Notable translations:

- `Comment` recurses by rendering itself, the same as the Angular template; the collapse flag is local `useState` per node rather than a component field, so each subtree still collapses independently. `[hidden]="collapse"` maps to the `hidden` prop, keeping collapsed subtrees mounted.
- `[innerHTML]="comment.content"` → `dangerouslySetInnerHTML={{ __html: sanitizeHtml(...) }}` for comment bodies, poll options and story text. The API returns pre-rendered HTML; `sanitizeHtml` (from 1/5) replaces the sanitization Angular applied implicitly on `[innerHTML]`.
- `Location.back()` → `useNavigate()(-1)`.
- `ItemDetails` returns early while `item` is null, which removes the `*ngIf="item"` nesting and lets the derived values (`hasUrl`, `isJob`, the `laptop`/`item-header`/`head-margin` class list) be plain locals.
- The Angular template gated `head-margin` on `item.text`, a field that does not exist on the model or in the API response, so the class never applied; it now keys off `item.content`, which is what the API actually returns and what the template renders below.
- The title anchor is built once as `titleLink` and reused by the mobile and laptop headers instead of being duplicated with `*ngIf` pairs.
- `Comment.scss`'s Angular-only `:host >>> a` rule is rescoped to `.comment-text a`, which is what it targeted under ViewEncapsulation and is a no-op selector outside Angular.

`Comment.test.tsx` covers nested rendering, collapse/expand, script stripping in comment HTML, and the deleted-comment placeholder.


Link to Devin session: https://app.devin.ai/sessions/0444204c74e5470d9b0222b3464d1e81
Requested by: @devanshi-gpta
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/565?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/565" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->