### PR TITLE
React migration 5/5: user profile, app shell and routing

### DIFF
--- a/react-app/README.md
+++ b/react-app/README.md
@@ -1,0 +1,39 @@
+# React HN
+
+A React port of the Angular app in `src/`. Both apps live side by side in this repository and target the
+same [node-hnapi](https://github.com/cheeaun/node-hnapi) backend.
+
+## Commands
+
+```bash
+npm install
+npm start        # dev server on http://localhost:4200
+npm run build    # typecheck + production build into dist/
+npm test         # vitest unit tests
+npm run lint     # eslint
+```
+
+## Structure
+
+| Angular (`src/app/`)                        | React (`react-app/src/`)                  |
+| ------------------------------------------- | ----------------------------------------- |
+| `app.component.*`                           | `App.tsx`                                 |
+| `app.routes.ts`                             | `<Routes>` in `App.tsx`                   |
+| `core/header/`                              | `components/core/Header.tsx`              |
+| `core/footer/`                              | `components/core/Footer.tsx`              |
+| `core/settings/`                            | `components/core/Settings.tsx`            |
+| `feeds/feed/`                               | `components/feeds/Feed.tsx`               |
+| `feeds/item/`                               | `components/feeds/Item.tsx`               |
+| `item-details/`                             | `components/item-details/ItemDetails.tsx` |
+| `item-details/comment/`                     | `components/item-details/Comment.tsx`     |
+| `user/`                                     | `components/user/UserProfile.tsx`         |
+| `shared/components/loader/`                 | `components/shared/Loader.tsx`            |
+| `shared/components/error-message/`          | `components/shared/ErrorMessage.tsx`      |
+| `shared/services/hackernews-api.service.ts` | `services/hackernewsApi.ts`               |
+| `shared/services/settings.service.ts`       | `context/SettingsContext.tsx`             |
+| `shared/pipes/comment.pipe.ts`              | `utils/comment.ts`                        |
+| `shared/models/`                            | `models/index.ts`                         |
+| `shared/scss/`                              | `scss/`                                   |
+
+Component SCSS is copied from the Angular components unchanged, so the three themes (default, night, AMOLED
+black), fonts, and spacing settings render identically.

--- a/react-app/index.html
+++ b/react-app/index.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>React HN</title>
+
+  <meta name="description" content="A Hacker News client built with React, React Router and Vite"/>
+
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:site" content="@hdjirdeh">
+  <meta name="twitter:title" content="React HN">
+  <meta name="twitter:description" content="A Hacker News client built with React, React Router and Vite">
+  <meta name="twitter:creator" content="@hdjirdeh">
+  <meta name="twitter:image" content="/assets/images/logo-loading.png">
+
+  <meta property="og:title" content="React HN"/>
+  <meta property="og:type" content="website"/>
+  <meta property="og:image" content="/assets/images/logo-loading.png"/>
+  <meta property="og:description" content="A Hacker News client built with React, React Router and Vite"/>
+  <meta property="og:site_name" content="React HN"/>
+
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  <meta name="theme-color" content="#b92b27">
+
+  <meta name="msapplication-TileColor" content="#b92b27">
+  <meta name="msapplication-TileImage" content="/assets/icons/mstile-150x150.png">
+  <meta name="msapplication-config" content="/assets/icons/browserconfig.xml">
+
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black">
+
+  <link rel="manifest" href="/manifest.json">
+  <link rel="mask-icon" href="/assets/icons/safari-pinned-tab.svg" color="#b92b27">
+
+  <link rel="icon" type="image/x-icon" href="/favicon.ico">
+  <link rel="icon" type="image/png" href="/assets/icons/favicon-32x32.png" sizes="32x32">
+  <link rel="icon" type="image/png" href="/assets/icons/favicon-16x16.png" sizes="16x16">
+
+  <link rel="apple-touch-icon" sizes="180x180" href="/assets/icons/apple-touch-icon.png">
+  <link rel="apple-touch-icon" sizes="120x120" href="/assets/icons/apple-touch-icon-120x120.png">
+  <link rel="apple-touch-icon" sizes="152x152" href="/assets/icons/apple-touch-icon-152x152.png">
+  <style>
+    #skip a {  position:absolute;  left:-10000px;  top:auto;  width:1px;  height:1px;  overflow:hidden;  }
+    #skip a:focus {  position:static;  width:auto;  height:auto;  }
+  </style>
+</head>
+<body>
+  <div id="skip"><a href="#content">skip to navigation</a></div>
+  <div id="root"></div>
+
+  <div class="app-loader" id="content">
+    <img class="logo" src="/assets/images/logo.svg" alt="Logo">
+
+    <noscript>
+      <h4 style="font-family: 'HelveticaNeue-Light', 'Helvetica Neue Light', 'Helvetica Neue', Helvetica;">
+        Sorry, JavaScript needs to be enabled in order to run this application.
+      </h4>
+    </noscript>
+  </div>
+
+  <script type="module" src="/src/main.tsx"></script>
+</body>
+</html>

--- a/react-app/index.html
+++ b/react-app/index.html
@@ -11,11 +11,11 @@
   <meta name="twitter:title" content="React HN">
   <meta name="twitter:description" content="A Hacker News client built with React, React Router and Vite">
   <meta name="twitter:creator" content="@hdjirdeh">
-  <meta name="twitter:image" content="/assets/images/logo-loading.png">
+  <meta name="twitter:image" content="/assets/images/logo-header.png">
 
   <meta property="og:title" content="React HN"/>
   <meta property="og:type" content="website"/>
-  <meta property="og:image" content="/assets/images/logo-loading.png"/>
+  <meta property="og:image" content="/assets/images/logo-header.png"/>
   <meta property="og:description" content="A Hacker News client built with React, React Router and Vite"/>
   <meta property="og:site_name" content="React HN"/>
 

--- a/react-app/src/App.scss
+++ b/react-app/src/App.scss
@@ -1,0 +1,24 @@
+@import "./scss/media";
+@import "./scss/theme_variables";
+
+.body-cover {
+  width: 100%;
+  z-index: 0;
+  position: fixed;
+  height: 100%;
+}
+
+.wrapper {
+  position: relative;
+  width: 85%;
+  min-height: 80px;
+  margin: 0 auto;
+  font-family: "HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
+  font-size: 15px;
+  height: 100%;
+  line-height: 1.3;
+
+   @media #{$mobile-only} {
+    width: 100%;
+  }
+}

--- a/react-app/src/App.tsx
+++ b/react-app/src/App.tsx
@@ -1,0 +1,54 @@
+import { lazy, Suspense, useEffect } from 'react';
+import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
+
+import Footer from './components/core/Footer';
+import Header from './components/core/Header';
+import Feed from './components/feeds/Feed';
+import Loader from './components/shared/Loader';
+import { useSettings } from './context/SettingsContext';
+import './App.scss';
+
+const ItemDetails = lazy(() => import('./components/item-details/ItemDetails'));
+const UserProfile = lazy(() => import('./components/user/UserProfile'));
+
+const FEED_TYPES = ['news', 'newest', 'show', 'ask', 'jobs'];
+
+declare global {
+    interface Window {
+        ga?: (...args: unknown[]) => void;
+    }
+}
+
+export default function App() {
+    const { settings } = useSettings();
+    const location = useLocation();
+
+    useEffect(() => {
+        if (typeof window.ga === 'function') {
+            window.ga('set', 'page', location.pathname);
+            window.ga('send', 'pageview');
+        }
+    }, [location.pathname]);
+
+    return (
+        <div className={settings.theme}>
+            <div className="body-cover"></div>
+            <div className="wrapper">
+                <Header />
+                <Suspense fallback={<Loader />}>
+                    <Routes>
+                        <Route path="/" element={<Navigate to="/news/1" replace />} />
+                        {FEED_TYPES.map((feedType) => (
+                            <Route key={feedType} path={`/${feedType}`}>
+                                <Route path=":page" element={<Feed feedType={feedType} />} />
+                            </Route>
+                        ))}
+                        <Route path="/item/:id" element={<ItemDetails />} />
+                        <Route path="/user/:id" element={<UserProfile />} />
+                    </Routes>
+                </Suspense>
+                <Footer />
+            </div>
+        </div>
+    );
+}

--- a/react-app/src/App.tsx
+++ b/react-app/src/App.tsx
@@ -23,12 +23,14 @@ export default function App() {
     const { settings } = useSettings();
     const location = useLocation();
 
+    const url = `${location.pathname}${location.search}${location.hash}`;
+
     useEffect(() => {
         if (typeof window.ga === 'function') {
-            window.ga('set', 'page', location.pathname);
+            window.ga('set', 'page', url);
             window.ga('send', 'pageview');
         }
-    }, [location.pathname]);
+    }, [url]);
 
     return (
         <div className={settings.theme}>
@@ -40,11 +42,13 @@ export default function App() {
                         <Route path="/" element={<Navigate to="/news/1" replace />} />
                         {FEED_TYPES.map((feedType) => (
                             <Route key={feedType} path={`/${feedType}`}>
+                                <Route index element={<Navigate to={`/${feedType}/1`} replace />} />
                                 <Route path=":page" element={<Feed feedType={feedType} />} />
                             </Route>
                         ))}
                         <Route path="/item/:id" element={<ItemDetails />} />
                         <Route path="/user/:id" element={<UserProfile />} />
+                        <Route path="*" element={<Navigate to="/news/1" replace />} />
                     </Routes>
                 </Suspense>
                 <Footer />

--- a/react-app/src/components/user/UserProfile.scss
+++ b/react-app/src/components/user/UserProfile.scss
@@ -1,0 +1,89 @@
+@import "../../scss/media";
+@import "../../scss/theme_variables";
+
+:host >>> pre {
+  white-space: pre-wrap;
+}
+
+.profile {
+  padding: 30px;
+}
+
+@media #{$mobile-only} {
+  .profile {
+    padding: 110px 15px 0 15px;
+  }
+  .title-block {
+    font-size: 15px;
+    text-align: center;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    margin: 0 75px;
+  }
+  .back-button {
+    position: absolute;
+    top: 52%;
+    width: 0.6rem;
+    height: 0.6rem;
+    background: transparent;
+    box-shadow: 0 0 0 lightgray;
+    transition: all 200ms ease;
+    left: 4%;
+    transform: translate3d(0, -50%, 0) rotate(-135deg);
+  }
+  .item-header {
+    padding-bottom: 10px;
+    background-color: #fff;
+    padding: 10px 0 10px 0;
+    position: fixed;
+    width: 100%;
+    left: 0;
+    top: 62px;
+    height: 20px;
+  }
+}
+
+@media #{$laptop-only} {
+  .mobile {
+    display: none;
+  }
+}
+
+.main-details {
+  .name {
+    font-weight: bold;
+    font-size: 32px;
+    letter-spacing: 2px;
+  }
+  .age {
+    font-weight: bold;
+    color: #696969;
+    padding-bottom: 0;
+  }
+  .right {
+    float: right;
+    font-weight: bold;
+    font-size: 32px;
+    letter-spacing: 2px;
+  }
+}
+
+@media #{$mobile-only} {
+  .main-details {
+    margin-top: 20px;
+    .name {
+      font-size: 18px;
+    }
+  }
+}
+
+@media #{$mobile-only} {
+  .main-details .right {
+    font-size: 18px;
+  }
+}
+
+.other-details {
+  word-wrap: break-word;
+}

--- a/react-app/src/components/user/UserProfile.scss
+++ b/react-app/src/components/user/UserProfile.scss
@@ -1,10 +1,6 @@
 @import "../../scss/media";
 @import "../../scss/theme_variables";
 
-:host >>> pre {
-  white-space: pre-wrap;
-}
-
 .profile {
   padding: 30px;
 }

--- a/react-app/src/components/user/UserProfile.tsx
+++ b/react-app/src/components/user/UserProfile.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 
 import { User } from '../../models';
 import { fetchUser } from '../../services/hackernewsApi';
+import { sanitizeHtml } from '../../utils/sanitize';
 import ErrorMessage from '../shared/ErrorMessage';
 import Loader from '../shared/Loader';
 import './UserProfile.scss';
@@ -49,7 +50,7 @@ export default function UserProfile() {
                     </div>
                     {user.about && (
                         <div className="other-details">
-                            <p dangerouslySetInnerHTML={{ __html: user.about }}></p>
+                            <p dangerouslySetInnerHTML={{ __html: sanitizeHtml(user.about) }}></p>
                         </div>
                     )}
                 </div>

--- a/react-app/src/components/user/UserProfile.tsx
+++ b/react-app/src/components/user/UserProfile.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+
+import { User } from '../../models';
+import { fetchUser } from '../../services/hackernewsApi';
+import ErrorMessage from '../shared/ErrorMessage';
+import Loader from '../shared/Loader';
+import './UserProfile.scss';
+
+export default function UserProfile() {
+    const { id } = useParams<{ id: string }>();
+    const navigate = useNavigate();
+    const [user, setUser] = useState<User | null>(null);
+    const [errorMessage, setErrorMessage] = useState('');
+
+    useEffect(() => {
+        const controller = new AbortController();
+        setUser(null);
+        setErrorMessage('');
+
+        fetchUser(id ?? '', controller.signal)
+            .then(setUser)
+            .catch((error: Error) => {
+                if (error.name !== 'AbortError') {
+                    setErrorMessage(`Could not load user ${id}.`);
+                }
+            });
+
+        return () => controller.abort();
+    }, [id]);
+
+    return (
+        <>
+            {!user && !errorMessage && <Loader />}
+            {!user && errorMessage !== '' && <ErrorMessage message={errorMessage} />}
+
+            {user && (
+                <div className="profile">
+                    <div className="mobile item-header">
+                        <p className="title-block">
+                            <span className="back-button" onClick={() => navigate(-1)}></span>
+                            Profile: {user.id}
+                        </p>
+                    </div>
+                    <div className="main-details">
+                        <span className="name">{user.id}</span>
+                        <span className="right">{user.karma} ★</span>
+                        <p className="age">Created {user.created}</p>
+                    </div>
+                    {user.about && (
+                        <div className="other-details">
+                            <p dangerouslySetInnerHTML={{ __html: user.about }}></p>
+                        </div>
+                    )}
+                </div>
+            )}
+        </>
+    );
+}

--- a/react-app/src/main.tsx
+++ b/react-app/src/main.tsx
@@ -1,0 +1,17 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+
+import App from './App';
+import { SettingsProvider } from './context/SettingsContext';
+import './styles.scss';
+
+createRoot(document.getElementById('root') as HTMLElement).render(
+    <StrictMode>
+        <BrowserRouter>
+            <SettingsProvider>
+                <App />
+            </SettingsProvider>
+        </BrowserRouter>
+    </StrictMode>
+);


### PR DESCRIPTION
## Summary

Last of five stacked PRs porting the Angular client to React. Adds `UserComponent` → `UserProfile.tsx` and wires everything together: `AppComponent` → `App.tsx`, `main.ts` → `main.tsx`, and a React-Router equivalent of `app.routes.ts`. After this PR `react-app` is a running app (`npm start`, `npm run build`).

Routing notes:

- Angular's per-feed route blocks carrying `data: {feedType}` become generated routes that pass the feed name as a prop, keeping the same `/:feed/:page` URLs. React Router matches a parent route with no `element` by rendering an empty `<Outlet />`, so bare `/news` would render a blank page; an `index` redirect and a `*` catch-all close that gap:

  ```tsx
  {FEED_TYPES.map((feedType) => (
      <Route key={feedType} path={`/${feedType}`}>
          <Route index element={<Navigate to={`/${feedType}/1`} replace />} />
          <Route path=":page" element={<Feed feedType={feedType} />} />
      </Route>
  ))}
  <Route path="*" element={<Navigate to="/news/1" replace />} />
  ```

- `redirectTo: 'news/1'` → `<Navigate to="/news/1" replace />`.
- `loadChildren: () => import(...)` for the item-details and user modules → `React.lazy()` + a `<Suspense fallback={<Loader />}>`, so those two routes stay in separate chunks.
- The `ga` pageview side effect moves from a `Router.events` subscription to a `useEffect` on `pathname + search + hash` (matching Angular's `urlAfterRedirects`), guarded by `typeof window.ga === 'function'` — the Angular version declared `ga` as a global and threw when the analytics snippet was blocked. `index.html` no longer ships the analytics snippet.
- The user bio is rendered with `sanitizeHtml(user.about)` rather than raw `dangerouslySetInnerHTML`, keeping the sanitization Angular's `[innerHTML]` provided.

`index.html` is the Vite entry: `<app-root>` becomes `<div id="root">`, and asset URLs are absolute (`/assets/...`) so they resolve on nested routes such as `/item/123`.


Link to Devin session: https://app.devin.ai/sessions/0444204c74e5470d9b0222b3464d1e81
Requested by: @devanshi-gpta
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/566?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/566" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/angular2-hn/pull/566" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->