### PR TITLE
feature: port the feed page and item row to React (Phase 2b)

### DIFF
--- a/web/src/feeds/Item.test.tsx
+++ b/web/src/feeds/Item.test.tsx
@@ -1,0 +1,140 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { Item } from './Item';
+import { SettingsProvider } from '../context/SettingsContext';
+import { Story } from '../models/story';
+import { stubMatchMedia } from '../testUtils/matchMedia';
+
+function makeStory(overrides: Partial<Story> = {}): Story {
+    return {
+        id: 1,
+        title: 'A React story',
+        points: 42,
+        user: 'dan',
+        time: 1600000000,
+        time_ago: '2 hours ago',
+        type: 'story',
+        url: 'https://example.com/story',
+        domain: 'example.com',
+        comments_count: 3,
+        ...overrides,
+    };
+}
+
+function renderItem(story: Story) {
+    stubMatchMedia(false);
+
+    return render(
+        <MemoryRouter>
+            <SettingsProvider>
+                <Item className="item-block" item={story} />
+            </SettingsProvider>
+        </MemoryRouter>
+    );
+}
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+describe('Item', () => {
+    it('renders an external link with its domain for stories that have a url', () => {
+        renderItem(makeStory());
+
+        const title = screen.getByRole('link', { name: 'A React story' });
+        expect(title).toHaveClass('title');
+        expect(title).toHaveAttribute('href', 'https://example.com/story');
+        expect(title).not.toHaveAttribute('target');
+        expect(title).not.toHaveAttribute('rel');
+        expect(screen.getByText('(example.com)')).toHaveClass('domain');
+    });
+
+    it('links to the item details page for stories without an external url', () => {
+        renderItem(makeStory({ id: 7, url: 'item?id=7', domain: undefined }));
+
+        const title = screen.getByRole('link', { name: 'A React story' });
+        expect(title).toHaveClass('title');
+        expect(title).toHaveAttribute('href', '/item/7');
+        expect(screen.queryByText(/\(.*\)/)).toBeNull();
+    });
+
+    it('links to the item details page when the story has no url at all', () => {
+        renderItem(makeStory({ id: 9, url: undefined, domain: undefined }));
+
+        expect(screen.getByRole('link', { name: 'A React story' })).toHaveAttribute('href', '/item/9');
+    });
+
+    it('renders the user, points, time and comment count', () => {
+        const { container } = renderItem(makeStory({ id: 5, user: 'pg', points: 12, comments_count: 1 }));
+
+        const userLinks = screen.getAllByRole('link', { name: 'pg' });
+        expect(userLinks).toHaveLength(2);
+        userLinks.forEach((link) => expect(link).toHaveAttribute('href', '/user/pg'));
+        expect(screen.getByText('12 ★')).toBeInTheDocument();
+
+        const commentLinks = screen.getAllByRole('link', { name: '1 comment' });
+        expect(commentLinks).toHaveLength(1);
+        expect(commentLinks[0]).toHaveAttribute('href', '/item/5');
+        expect(screen.getByRole('link', { name: '• 1 comment' })).toHaveClass('comment-number');
+
+        expect(container.querySelector('.subtext-palm')).toHaveTextContent('2 hours ago • 1 comment');
+        expect(container.querySelector('.subtext-laptop')).toHaveTextContent('12 points by pg2 hours ago | 1 comment');
+    });
+
+    it('renders "discuss" when a story has no comments', () => {
+        const { container } = renderItem(makeStory({ comments_count: 0 }));
+
+        expect(container.querySelector('.subtext-palm')).toHaveTextContent('• discuss');
+        expect(container.querySelector('.subtext-laptop')).toHaveTextContent('| discuss');
+    });
+
+    it('omits the user, points and comments for job items', () => {
+        renderItem(makeStory({ type: 'job', title: 'Work at a startup', comments_count: 0 }));
+
+        expect(screen.queryByRole('link', { name: 'dan' })).toBeNull();
+        expect(screen.queryByText('42 ★')).toBeNull();
+        expect(screen.queryByRole('link', { name: /discuss/ })).toBeNull();
+        expect(screen.getAllByText('2 hours ago')).toHaveLength(2);
+    });
+
+    it('does not add the item-details class on the laptop subtext for job items', () => {
+        const { container } = renderItem(makeStory({ type: 'job' }));
+
+        expect(container.querySelector('.subtext-laptop .item-details')).toBeNull();
+    });
+
+    it('adds the item-details class on the laptop subtext for regular items', () => {
+        const { container } = renderItem(makeStory());
+
+        expect(container.querySelector('.subtext-laptop .item-details')).not.toBeNull();
+    });
+
+    it('opens external links in a new tab when the setting is enabled', () => {
+        localStorage.setItem('openLinkInNewTab', 'true');
+
+        renderItem(makeStory());
+
+        const title = screen.getByRole('link', { name: 'A React story' });
+        expect(title).toHaveAttribute('target', '_blank');
+        expect(title).toHaveAttribute('rel', 'noopener');
+    });
+
+    it('applies the title font size and list spacing settings', () => {
+        localStorage.setItem('titleFontSize', '20');
+        localStorage.setItem('listSpacing', '15');
+
+        const { container } = renderItem(makeStory());
+
+        expect(screen.getByRole('link', { name: 'A React story' })).toHaveStyle({ fontSize: '20px' });
+        expect(container.querySelector('.item-block > div')).toHaveStyle({ marginBottom: '15px' });
+    });
+
+    it('falls back to the default font size and spacing', () => {
+        const { container } = renderItem(makeStory());
+
+        expect(screen.getByRole('link', { name: 'A React story' })).toHaveStyle({ fontSize: '16px' });
+        expect(container.querySelector('.item-block > div')).toHaveStyle({ marginBottom: '0px' });
+    });
+});

--- a/web/src/feeds/Item.tsx
+++ b/web/src/feeds/Item.tsx
@@ -1,0 +1,82 @@
+import { NavLink } from 'react-router-dom';
+
+import { useSettings } from '../context/SettingsContext';
+import { Story } from '../models/story';
+import { formatCommentCount } from '../utils/formatCommentCount';
+import './item.scss';
+
+export interface ItemProps {
+    item: Story;
+    className?: string;
+}
+
+export function Item({ item, className }: ItemProps) {
+    const { settings } = useSettings();
+    const hasUrl = item.url !== undefined && item.url.indexOf('http') === 0;
+    const isJob = item.type === 'job';
+    const titleStyle = { fontSize: `${settings.titleFontSize}px` };
+
+    return (
+        <div className={className}>
+            <div style={{ marginBottom: `${settings.listSpacing}px` }}>
+                {hasUrl ? (
+                    <p>
+                        <a
+                            className="title"
+                            style={titleStyle}
+                            href={item.url}
+                            target={settings.openLinkInNewTab ? '_blank' : undefined}
+                            rel={settings.openLinkInNewTab ? 'noopener' : undefined}
+                        >
+                            {item.title}
+                        </a>
+                        {item.domain && <span className="domain">({item.domain})</span>}
+                    </p>
+                ) : (
+                    <p>
+                        <NavLink className="title" style={titleStyle} to={`/item/${item.id}`}>
+                            {item.title}
+                        </NavLink>
+                    </p>
+                )}
+                <div className="subtext-palm">
+                    {!isJob && (
+                        <div className="details">
+                            <span className="name">
+                                <NavLink to={`/user/${item.user}`}>{item.user}</NavLink>
+                            </span>
+                            <span className="right">{item.points} ★</span>
+                        </div>
+                    )}
+                    <div className="details">
+                        {item.time_ago}
+                        {!isJob && (
+                            <NavLink to={`/item/${item.id}`} className="comment-number">
+                                {' '}
+                                • {formatCommentCount(item.comments_count)}
+                            </NavLink>
+                        )}
+                    </div>
+                </div>
+                <div className="subtext-laptop">
+                    {!isJob && (
+                        <span>
+                            {item.points} points by <NavLink to={`/user/${item.user}`}>{item.user}</NavLink>
+                        </span>
+                    )}
+                    <span className={isJob ? undefined : 'item-details'}>
+                        {item.time_ago}
+                        {!isJob && (
+                            <span>
+                                {' '}
+                                | <NavLink to={`/item/${item.id}`}>{formatCommentCount(item.comments_count)}</NavLink>
+                            </span>
+                        )}
+                    </span>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+export default Item;

--- a/web/src/feeds/feed.scss
+++ b/web/src/feeds/feed.scss
@@ -1,0 +1,107 @@
+@import '../styles/media';
+@import '../styles/theme_variables';
+
+a {
+    text-decoration: none;
+    font-weight: bold;
+
+    &:hover {
+        text-decoration: underline;
+    }
+}
+
+ol {
+    padding: 0 40px;
+    margin: 0;
+
+    @media #{$mobile-only} {
+        box-sizing: border-box;
+        list-style: none;
+        padding: 0 10px;
+    }
+
+    li {
+        position: relative;
+        -webkit-transition: background-color 0.2s ease;
+        transition: background-color 0.2s ease;
+    }
+}
+
+.list-margin {
+    @media #{$mobile-only} {
+        margin-top: 55px;
+    }
+}
+
+.main-content {
+    position: relative;
+    width: 100%;
+    min-height: 100vh;
+    -webkit-transition: opacity 0.2s ease;
+    transition: opacity 0.2s ease;
+    box-sizing: border-box;
+    padding: 8px 0;
+    z-index: 0;
+}
+
+.post {
+    padding: 10px 0 10px 5px;
+    transition: background-color 0.2s ease;
+    border-bottom: 1px solid #cececb;
+
+    .itemNum {
+        color: #696969;
+        position: absolute;
+        width: 30px;
+        text-align: right;
+        left: 0;
+        top: 4px;
+    }
+}
+
+.item-block {
+    display: block;
+}
+
+.nav {
+    padding: 10px 40px;
+    margin-top: 10px;
+    font-size: 17px;
+
+    a {
+        @media #{$mobile-only} {
+            text-decoration: none;
+        }
+    }
+
+    @media #{$mobile-only} {
+        margin: 20px 0;
+        text-align: center;
+        padding: 10px 80px;
+        height: 20px;
+    }
+
+    .prev {
+        padding-right: 20px;
+
+        @media #{$mobile-only} {
+            float: left;
+            padding-right: 0;
+        }
+    }
+
+    .more {
+        @media #{$mobile-only} {
+            float: right;
+        }
+    }
+}
+
+.job-header {
+    font-size: 15px;
+    padding: 0 40px 10px;
+
+    @media #{$mobile-only} {
+        padding: 60px 15px 25px 15px;
+    }
+}

--- a/web/src/feeds/item.scss
+++ b/web/src/feeds/item.scss
@@ -1,0 +1,68 @@
+@import '../styles/media';
+@import '../styles/theme_variables';
+
+p {
+    margin: 2px 0;
+
+    @media #{$mobile-only} {
+        margin-bottom: 5px;
+        margin-top: 0;
+    }
+}
+
+a {
+    cursor: pointer;
+    text-decoration: none;
+}
+
+.title {
+    font-size: 16px;
+    font-family: Verdana, Geneva, sans-serif;
+}
+
+.subtext-laptop {
+    font-size: 12px;
+    font-weight: bold;
+    letter-spacing: 0.5px;
+
+    a {
+        &:hover {
+            text-decoration: underline;
+        }
+    }
+    @media #{$mobile-only} {
+        display: none;
+    }
+}
+
+.subtext-palm {
+    font-size: 13px;
+    font-weight: bold;
+    letter-spacing: 0.5px;
+
+    a {
+        &:hover {
+            text-decoration: underline;
+        }
+    }
+
+    .details {
+        margin-top: 5px;
+
+        .right {
+            float: right;
+        }
+    }
+    @media #{$laptop-only} {
+        display: none;
+    }
+}
+
+.domain {
+    color: #696969;
+    letter-spacing: 0.5px;
+}
+
+.item-details {
+    padding: 10px;
+}

--- a/web/src/pages/FeedPage.test.tsx
+++ b/web/src/pages/FeedPage.test.tsx
@@ -1,0 +1,174 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { FeedPage } from './FeedPage';
+import { fetchFeed } from '../api/hackerNews';
+import { SettingsProvider } from '../context/SettingsContext';
+import { Story } from '../models/story';
+import { stubMatchMedia } from '../testUtils/matchMedia';
+
+vi.mock('../api/hackerNews');
+
+const fetchFeedMock = vi.mocked(fetchFeed);
+
+function makeStories(count: number, startId = 1): Story[] {
+    return Array.from({ length: count }, (_, index) => ({
+        id: startId + index,
+        title: `Story ${startId + index}`,
+        points: 10 + index,
+        user: `user${startId + index}`,
+        time: 1600000000,
+        time_ago: '1 hour ago',
+        type: 'story' as const,
+        url: `https://example.com/${startId + index}`,
+        domain: 'example.com',
+        comments_count: index,
+    }));
+}
+
+function renderFeed(feedType = 'news', path = `/${feedType}/1`) {
+    return render(
+        <MemoryRouter initialEntries={[path]}>
+            <SettingsProvider>
+                <Routes>
+                    <Route path={`/${feedType}/:page`} element={<FeedPage feedType={feedType} />} />
+                    <Route path={`/${feedType}`} element={<FeedPage feedType={feedType} />} />
+                </Routes>
+            </SettingsProvider>
+        </MemoryRouter>
+    );
+}
+
+beforeEach(() => {
+    stubMatchMedia(false);
+    vi.stubGlobal('scrollTo', vi.fn());
+});
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+});
+
+describe('FeedPage', () => {
+    it('shows the loader while the feed is loading', () => {
+        fetchFeedMock.mockReturnValue(new Promise(() => {}));
+
+        renderFeed();
+
+        expect(screen.getByText('Loading...')).toBeInTheDocument();
+        expect(fetchFeedMock).toHaveBeenCalledWith('news', 1);
+    });
+
+    it('renders the loaded stories and scrolls back to the top', async () => {
+        fetchFeedMock.mockResolvedValue(makeStories(3));
+
+        const { container } = renderFeed();
+
+        expect(await screen.findByText('Story 1')).toBeInTheDocument();
+        expect(screen.queryByText('Loading...')).toBeNull();
+        expect(container.querySelectorAll('li.post')).toHaveLength(3);
+        expect(container.querySelector('ol')).toHaveAttribute('start', '1');
+        expect(container.querySelector('ol')).toHaveClass('list-margin');
+        expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
+    });
+
+    it('continues the rank numbering on later pages', async () => {
+        fetchFeedMock.mockResolvedValue(makeStories(30, 31));
+
+        const { container } = renderFeed('news', '/news/2');
+
+        await screen.findByText('Story 31');
+        expect(fetchFeedMock).toHaveBeenCalledWith('news', 2);
+        expect(container.querySelector('ol')).toHaveAttribute('start', '31');
+    });
+
+    it('defaults to page one when the route has no page parameter', async () => {
+        fetchFeedMock.mockResolvedValue(makeStories(1));
+
+        const { container } = renderFeed('news', '/news');
+
+        await screen.findByText('Story 1');
+        expect(fetchFeedMock).toHaveBeenCalledWith('news', 1);
+        expect(container.querySelector('ol')).toHaveAttribute('start', '1');
+    });
+
+    it('shows an error message when the feed cannot be loaded', async () => {
+        fetchFeedMock.mockRejectedValue(new Error('boom'));
+
+        renderFeed('ask', '/ask/1');
+
+        expect(await screen.findByText('Could not load ask stories.')).toBeInTheDocument();
+        expect(screen.queryByText('Loading...')).toBeNull();
+        expect(window.scrollTo).not.toHaveBeenCalled();
+    });
+
+    it('hides the previous link on the first page and shows More for a full page', async () => {
+        fetchFeedMock.mockResolvedValue(makeStories(30));
+
+        renderFeed();
+
+        const more = await screen.findByRole('link', { name: 'More ›' });
+        expect(more).toHaveAttribute('href', '/news/2');
+        expect(more).toHaveClass('more');
+        expect(screen.queryByRole('link', { name: '‹ Prev' })).toBeNull();
+    });
+
+    it('shows both pagination links on a full later page', async () => {
+        fetchFeedMock.mockResolvedValue(makeStories(30, 61));
+
+        renderFeed('news', '/news/3');
+
+        const prev = await screen.findByRole('link', { name: '‹ Prev' });
+        expect(prev).toHaveAttribute('href', '/news/2');
+        expect(prev).toHaveClass('prev');
+        expect(screen.getByRole('link', { name: 'More ›' })).toHaveAttribute('href', '/news/4');
+    });
+
+    it('hides the More link when the page is not full', async () => {
+        fetchFeedMock.mockResolvedValue(makeStories(29, 31));
+
+        renderFeed('news', '/news/2');
+
+        await screen.findByRole('link', { name: '‹ Prev' });
+        expect(screen.queryByRole('link', { name: 'More ›' })).toBeNull();
+    });
+
+    it('renders the jobs blurb and omits the list margin for the jobs feed', async () => {
+        fetchFeedMock.mockResolvedValue(makeStories(2));
+
+        const { container } = renderFeed('jobs', '/jobs/1');
+
+        await screen.findByText(/These are jobs at startups/);
+        expect(screen.getByRole('link', { name: 'Triplebyte' })).toHaveAttribute(
+            'href',
+            'https://triplebyte.com/?ref=yc_jobs'
+        );
+        expect(container.querySelector('.job-header')).toBeInTheDocument();
+        expect(container.querySelector('ol')).not.toHaveClass('list-margin');
+    });
+
+    it('does not render the jobs blurb for other feeds', async () => {
+        fetchFeedMock.mockResolvedValue(makeStories(2));
+
+        const { container } = renderFeed('show', '/show/1');
+
+        await screen.findByText('Story 1');
+        expect(container.querySelector('.job-header')).toBeNull();
+    });
+
+    it('refetches the feed when navigating to the next page', async () => {
+        fetchFeedMock.mockResolvedValueOnce(makeStories(30)).mockResolvedValueOnce(makeStories(30, 31));
+
+        renderFeed();
+
+        await screen.findByText('Story 1');
+        await userEvent.click(screen.getByRole('link', { name: 'More ›' }));
+
+        expect(await screen.findByText('Story 31')).toBeInTheDocument();
+        await waitFor(() => expect(fetchFeedMock).toHaveBeenCalledTimes(2));
+        expect(fetchFeedMock).toHaveBeenLastCalledWith('news', 2);
+        expect(screen.queryByText('Story 1')).toBeNull();
+    });
+});

--- a/web/src/pages/FeedPage.tsx
+++ b/web/src/pages/FeedPage.tsx
@@ -1,12 +1,89 @@
+import { useEffect, useState } from 'react';
+import { NavLink, useParams } from 'react-router-dom';
+
+import { fetchFeed } from '../api/hackerNews';
+import { ErrorMessage } from '../components/ErrorMessage';
+import { Loader } from '../components/Loader';
+import { Item } from '../feeds/Item';
+import { Story } from '../models/story';
+import '../feeds/feed.scss';
+
 export interface FeedPageProps {
     feedType: string;
 }
 
-/**
- * Placeholder for the ported `FeedComponent`, implemented in Phase 2b.
- */
-export function FeedPage(_props: FeedPageProps) {
-    return null;
+export function FeedPage({ feedType }: FeedPageProps) {
+    const { page } = useParams();
+    const pageNum = page ? Number(page) : 1;
+    const [items, setItems] = useState<Story[] | null>(null);
+    const [errorMessage, setErrorMessage] = useState('');
+
+    useEffect(() => {
+        let cancelled = false;
+
+        setItems(null);
+        setErrorMessage('');
+
+        fetchFeed(feedType, pageNum).then(
+            (feedItems) => {
+                if (cancelled) {
+                    return;
+                }
+                setItems(feedItems);
+                window.scrollTo(0, 0);
+            },
+            () => {
+                if (!cancelled) {
+                    setErrorMessage(`Could not load ${feedType} stories.`);
+                }
+            }
+        );
+
+        return () => {
+            cancelled = true;
+        };
+    }, [feedType, pageNum]);
+
+    const listStart = (pageNum - 1) * 30 + 1;
+
+    return (
+        <div className="main-content">
+            {!items && errorMessage === '' && <Loader />}
+            {!items && errorMessage !== '' && <ErrorMessage message={errorMessage} />}
+
+            {items && (
+                <div>
+                    {feedType === 'jobs' && (
+                        <p className="job-header">
+                            These are jobs at startups that were funded by Y Combinator. You can also get a job at a YC
+                            startup through <a href="https://triplebyte.com/?ref=yc_jobs">Triplebyte</a>.
+                        </p>
+                    )}
+                    {feedType !== 'new' && (
+                        <ol className={feedType !== 'jobs' ? 'list-margin' : undefined} start={listStart}>
+                            {items.map((item) => (
+                                <li key={item.id} className="post">
+                                    <Item className="item-block" item={item} />
+                                </li>
+                            ))}
+                        </ol>
+                    )}
+                    <div className="nav">
+                        {listStart !== 1 && (
+                            <NavLink to={`/${feedType}/${pageNum - 1}`} className="prev">
+                                ‹ Prev
+                            </NavLink>
+                        )}
+                        {items.length === 30 && (
+                            <NavLink to={`/${feedType}/${pageNum + 1}`} className="more">
+                                More ›
+                            </NavLink>
+                        )}
+                    </div>
+                </div>
+            )}
+        </div>
+    );
 }
 
 export default FeedPage;


### PR DESCRIPTION
## Summary

Phase 2b of the Angular → React migration: ports `feeds/feed` and `feeds/item` from `src/app/` into `web/`, replacing the `FeedPage` placeholder and adding `web/src/feeds/Item.tsx`. DOM structure, class names, copy and SCSS are kept identical to the Angular templates so both apps render the same markup.

Behavioural notes worth calling out (all mirror the Angular components rather than "fixing" them):

- `FeedPage` re-fetches on `feedType`/`:page` change and follows the RxJS semantics of the original: `window.scrollTo(0, 0)` runs only on the success path (the Angular `complete` callback never fires after an error), and the error path only sets `Could not load ${feedType} stories.`
- The loading/error/loaded rendering keeps the original three-way condition — `!items && errorMessage === ''` → `<Loader />`, `!items && errorMessage !== ''` → `<ErrorMessage />` — so a failed page shows the error, not an infinite loader.
- The `*ngIf="feedType !== 'new'"` guard around the `<ol>` is preserved verbatim even though no route uses a `new` feed type (routes use `newest`).
- `listStart = (pageNum - 1) * 30 + 1` drives both the `<ol start>` rank numbering and the prev-link visibility (`listStart !== 1`); `More ›` shows only for a full 30-item response.
- `Item` maps `hasUrl = item.url?.indexOf('http') === 0` to an external `<a href>` (plus `(domain)`), otherwise an internal `/item/:id` link. Angular's `routerLinkActive="active"` is reproduced with `NavLink`, which appends `active` for the current route. Job items drop user/points/comment links in both the palm and laptop subtexts.
- Settings are read through `useSettings()`: `titleFontSize` → title `font-size`, `listSpacing` → wrapper `margin-bottom`, `openLinkInNewTab` → `target="_blank"`/`rel="noopener"` (attributes omitted entirely when off, as `[attr.x]="null"` does).

`feed.component.scss` and `item.component.scss` are copied verbatim with only the `@import` paths rewritten to `../styles/*`.

## Tests

`web/src/pages/FeedPage.test.tsx` (11) and `web/src/feeds/Item.test.tsx` (11) cover loading, loaded list + rank numbering across pages, default page when `:page` is absent, error copy, pagination boundaries (page 1 hides prev, 30 items shows `More ›`, 29 hides it), navigating to page 2 refetching, jobs blurb + missing `list-margin`, url vs non-url vs missing-url items, job items, `discuss` vs `n comments`, and the new-tab/font-size/spacing settings. `npm run lint`, `npm test` (49 passing) and `npm run build` all pass in `web/`.


Link to Devin session: https://app.devin.ai/sessions/2725efbf76454adaa9c4123226acf5b3
Requested by: @vibhaseshadri-cognition
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/572?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/572" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->