### PR TITLE
feature: offline saved posts with star toggle and saved tab

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -7,6 +7,7 @@ import { AppComponent } from './app.component';
 import { CoreModule } from './core/core.module';
 import { FeedComponent } from './feeds/feed/feed.component';
 import { ItemComponent } from './feeds/item/item.component';
+import { SavedComponent } from './feeds/saved/saved.component';
 import { SharedComponentsModule } from './shared/components/shared-components.module';
 import { PipesModule } from './shared/pipes/pipes.module';
 import { ServiceWorkerModule } from '@angular/service-worker';
@@ -15,7 +16,7 @@ import { HackerNewsAPIService } from './shared/services/hackernews-api.service';
 import { SettingsService } from './shared/services/settings.service';
 
 @NgModule({
-    declarations: [AppComponent, FeedComponent, ItemComponent],
+    declarations: [AppComponent, FeedComponent, ItemComponent, SavedComponent],
     imports: [
         BrowserModule,
         routing,

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,6 +1,7 @@
 import { Routes, RouterModule } from '@angular/router';
 
 import { FeedComponent } from './feeds/feed/feed.component';
+import { SavedComponent } from './feeds/saved/saved.component';
 
 const feedRoutes = [{
   path: ':page',
@@ -34,6 +35,7 @@ const routes: Routes = [
     children: feedRoutes,
     data: {feedType: 'jobs'}
   },
+  {path: 'saved', component: SavedComponent},
   {path: 'item', loadChildren: () => import('./item-details/item-details.module').then(m => m.ItemDetailsModule)},
   {path: 'user', loadChildren: () => import('./user/user.module').then(m => m.UserModule)}
 ];

--- a/src/app/core/header/header.component.html
+++ b/src/app/core/header/header.component.html
@@ -14,6 +14,8 @@
             <a routerLink="/ask/1" routerLinkActive="active" (click)="scrollTop()">ask</a>
               |
             <a routerLink="/jobs/1" routerLinkActive="active" (click)="scrollTop()">jobs</a>
+              |
+            <a routerLink="/saved" routerLinkActive="active" (click)="scrollTop()">saved</a>
           </span>
         </div>
       </div>

--- a/src/app/core/header/header.component.scss
+++ b/src/app/core/header/header.component.scss
@@ -102,7 +102,12 @@ h1 {
   margin-left: 20px;
 
   @media #{$mobile-only} {
-    margin-left: 60px;
+    box-sizing: border-box;
+    display: block;
+    font-size: 13px;
+    margin-left: 55px;
+    padding-right: 40px;
+    white-space: nowrap;
   }
 
   a {
@@ -113,6 +118,11 @@ h1 {
 
     &:hover {
       color: #fff;
+    }
+
+    @media #{$mobile-only} {
+      margin: 0 1px;
+      letter-spacing: 0.5px;
     }
   }
 

--- a/src/app/feeds/item/item.component.html
+++ b/src/app/feeds/item/item.component.html
@@ -20,6 +20,7 @@
     <a [routerLink]="['/item', item.id]" routerLinkActive="active" class="comment-number" *ngIf="item.type !== 'job'"> •
       {{item.comments_count | comment }}
     </a>
+    <span class="save-toggle right" (click)="toggleSave()" [title]="isSaved ? 'Remove from saved' : 'Save post'">{{ isSaved ? '★' : '☆' }}</span>
     </div>
   </div>
   <div class="subtext-laptop">
@@ -35,5 +36,6 @@
         </a>
       </span>
     </span>
+    <span class="save-toggle" (click)="toggleSave()" [title]="isSaved ? 'Remove from saved' : 'Save post'"> | {{ isSaved ? '★' : '☆' }}</span>
   </div>
 </div>

--- a/src/app/feeds/item/item.component.scss
+++ b/src/app/feeds/item/item.component.scss
@@ -58,6 +58,16 @@ p {
     }
   }
 
+  .save-toggle {
+    cursor: pointer;
+    color: #696969;
+    letter-spacing: 0.5px;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
   .domain {
     color: #696969;
     letter-spacing: 0.5px;

--- a/src/app/feeds/item/item.component.ts
+++ b/src/app/feeds/item/item.component.ts
@@ -2,6 +2,7 @@ import { Component, Input, OnInit } from '@angular/core';
 import { Story } from '../../shared/models/story';
 
 import { SettingsService } from '../../shared/services/settings.service';
+import { SavedPostsService } from '../../shared/services/saved-posts.service';
 import { Settings } from '../../shared/models/settings';
 
 @Component({
@@ -13,7 +14,10 @@ export class ItemComponent implements OnInit {
   @Input() item: Story;
   settings: Settings;
 
-  constructor(private _settingsService: SettingsService) {
+  constructor(
+    private _settingsService: SettingsService,
+    private saveService: SavedPostsService
+  ) {
     this.settings = this._settingsService.settings;
   }
 
@@ -21,6 +25,14 @@ export class ItemComponent implements OnInit {
 
   get hasUrl(): boolean {
     return this.item.url.indexOf('http') === 0;
+  }
+
+  get isSaved(): boolean {
+    return this.saveService.isSaved(this.item.id);
+  }
+
+  toggleSave() {
+    this.saveService.toggleSaved(this.item);
   }
 
 }

--- a/src/app/feeds/saved/saved.component.html
+++ b/src/app/feeds/saved/saved.component.html
@@ -1,0 +1,10 @@
+<div class="main-content">
+  <p class="job-header" *ngIf="items.length === 0">
+    You haven't saved any posts yet. Tap the ☆ on a post to save it for later.
+  </p>
+  <ol class="list-margin" *ngIf="items.length > 0">
+    <li *ngFor="let item of items" class="post">
+      <item class="item-block" [item]="item"></item>
+    </li>
+  </ol>
+</div>

--- a/src/app/feeds/saved/saved.component.scss
+++ b/src/app/feeds/saved/saved.component.scss
@@ -1,0 +1,55 @@
+@import "../../shared/scss/media";
+@import "../../shared/scss/theme_variables";
+
+ol {
+  padding: 0 40px;
+  margin: 0;
+
+  @media #{$mobile-only} {
+    box-sizing: border-box;
+    list-style: none;
+    padding: 0 10px;
+  }
+
+  li {
+    position: relative;
+    -webkit-transition: background-color .2s ease;
+    transition: background-color .2s ease;
+  }
+}
+
+.list-margin {
+  @media #{$mobile-only} {
+    margin-top: 55px;
+  }
+}
+
+.main-content {
+  position: relative;
+  width: 100%;
+  min-height: 100vh;
+  -webkit-transition: opacity .2s ease;
+  transition: opacity .2s ease;
+  box-sizing: border-box;
+  padding: 8px 0;
+  z-index: 0;
+}
+
+.post {
+  padding: 10px 0 10px 5px;
+  transition: background-color 0.2s ease;
+  border-bottom: 1px solid #CECECB;
+}
+
+.item-block {
+  display: block;
+}
+
+.job-header {
+  font-size: 15px;
+  padding: 0 40px 10px;
+
+  @media #{$mobile-only} {
+    padding: 60px 15px 25px 15px;
+  }
+}

--- a/src/app/feeds/saved/saved.component.ts
+++ b/src/app/feeds/saved/saved.component.ts
@@ -1,0 +1,17 @@
+import { Component } from '@angular/core';
+
+import { Story } from '../../shared/models/story';
+import { SavedPostsService } from '../../shared/services/saved-posts.service';
+
+@Component({
+  selector: 'app-saved',
+  templateUrl: './saved.component.html',
+  styleUrls: ['./saved.component.scss']
+})
+export class SavedComponent {
+  constructor(private savedPostsService: SavedPostsService) { }
+
+  get items(): Story[] {
+    return this.savedPostsService.getSavedPosts();
+  }
+}

--- a/src/app/shared/services/saved-posts.service.ts
+++ b/src/app/shared/services/saved-posts.service.ts
@@ -13,7 +13,7 @@ export class SavedPostsService {
   private static read(): Story[] {
     try {
       const stored = JSON.parse(localStorage.getItem(STORAGE_KEY));
-      return Array.isArray(stored) ? stored : [];
+      return Array.isArray(stored) ? stored.filter(post => post && typeof post.id === 'number') : [];
     } catch {
       return [];
     }

--- a/src/app/shared/services/saved-posts.service.ts
+++ b/src/app/shared/services/saved-posts.service.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@angular/core';
+
+import { Story } from '../models/story';
+
+const STORAGE_KEY = 'savedPosts';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SavedPostsService {
+  savedPosts: Story[] = localStorage.getItem(STORAGE_KEY) ? JSON.parse(localStorage.getItem(STORAGE_KEY)) : [];
+
+  getSavedPosts(): Story[] {
+    return this.savedPosts;
+  }
+
+  isSaved(id: number): boolean {
+    return this.savedPosts.some(post => post.id === id);
+  }
+
+  toggleSaved(story: Story) {
+    if (this.isSaved(story.id)) {
+      this.removeSaved(story.id);
+    } else {
+      this.savedPosts = [story, ...this.savedPosts];
+      this.persist();
+    }
+  }
+
+  removeSaved(id: number) {
+    this.savedPosts = this.savedPosts.filter(post => post.id !== id);
+    this.persist();
+  }
+
+  private persist() {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(this.savedPosts));
+  }
+}

--- a/src/app/shared/services/saved-posts.service.ts
+++ b/src/app/shared/services/saved-posts.service.ts
@@ -8,7 +8,16 @@ const STORAGE_KEY = 'savedPosts';
   providedIn: 'root'
 })
 export class SavedPostsService {
-  savedPosts: Story[] = localStorage.getItem(STORAGE_KEY) ? JSON.parse(localStorage.getItem(STORAGE_KEY)) : [];
+  savedPosts: Story[] = SavedPostsService.read();
+
+  private static read(): Story[] {
+    try {
+      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY));
+      return Array.isArray(stored) ? stored : [];
+    } catch {
+      return [];
+    }
+  }
 
   getSavedPosts(): Story[] {
     return this.savedPosts;


### PR DESCRIPTION
## Summary

Adds a client-only "saved posts" feature: a `☆`/`★` toggle on every feed item, a `saved` tab (rightmost in the header nav), and a `/saved` route listing saved stories. Works offline because the whole `Story` object is persisted to `localStorage` — nothing is re-fetched to render the saved list.

`SavedPostsService` (root-provided, mirrors `SettingsService`'s localStorage pattern) keeps an in-memory array as the source of truth for the UI and writes through on every mutation:

```ts
savedPosts: Story[] = SavedPostsService.read();  // try/catch + isArray + drop members without a numeric id
toggleSaved(story)  // removeSaved(story.id) if present, else prepend + persist
```

`SavedComponent` exposes `items` as a getter delegating to the service, so unsaving from the saved list removes the row immediately without extra change-detection wiring. Markup/styles are copied from `feed.component` so the list is visually identical; the empty state reuses the `.job-header` style.

The star renders in both the `subtext-palm` and `subtext-laptop` blocks so it appears on mobile and desktop.

### Header nav on mobile

Adding a 5th tab overflowed the header: the nav had no space reserved for the absolutely-positioned settings cog, so on phones `saved` slid underneath it and taps opened the Settings modal. `.header-nav` is now a nowrap block on mobile with `padding-right` for the cog and tighter font/letter-spacing, which keeps all five tabs on one line down to 320px. Desktop is unchanged.

## Verification

`ng build` passes (needs `NODE_OPTIONS=--openssl-legacy-provider` on Node 20 — this is Angular 9, not 19 as the environment notes claim). `ng lint` fails on master already; no new lint errors from these files.

End-to-end tested against a production build with the service worker active, including genuinely offline (server killed + API host blackholed, since DevTools "Offline" gives false passes for SW-issued fetches) — see the [test results comment](https://github.com/COG-GTM/angular2-hn/pull/576#issuecomment-5206358668).

Toggling stars on the feed:

![feed with star toggles](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfNjlJWEpGTHJsang4elNBdyIsInVzZXJfaWQiOm51bGwsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZ182OUlYSkZMcmxqeDh6U0F3L2EzYTY1MWQ0LTYxMGUtNDdhNy04YmMwLWU0ZTEzNTE3Y2RlZCIsImlhdCI6MTc4NjAyNzg2MiwiZXhwIjoxNzg2NjMyNjYyLCJmaWxlbmFtZSI6ImZlZWQtc3RhcnMucG5nIn0.GW0eafbokK3xQZYRhyYCDBg0Ekh1Q9MCS2mb0XbUJzo)

The saved tab, after a page reload (state survives from localStorage):

![saved tab](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfNjlJWEpGTHJsang4elNBdyIsInVzZXJfaWQiOm51bGwsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZ182OUlYSkZMcmxqeDh6U0F3L2VmNmYwYzAwLWMwNDItNDgzMS1iYTA5LWVjZmI4YzNiN2ZkOCIsImlhdCI6MTc4NjAyNzg2MiwiZXhwIjoxNzg2NjMyNjYyLCJmaWxlbmFtZSI6InNhdmVkLXRhYi5wbmcifQ.Zh0MEkh7iDp7WtzCw4Bi5Whzzl2TivEIeZg0VTbFNrY)


Link to Devin session: https://app.devin.ai/sessions/6b0c3c84d212433f96c0e10a25989139
Requested by: @vibhaseshadri-cognition
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/576?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/576" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->