### PR TITLE
feature: migrate Angular ItemComponent to React

### DIFF
--- a/react-app/src/feeds/Item/Item.scss
+++ b/react-app/src/feeds/Item/Item.scss
@@ -1,0 +1,72 @@
+@use "../../shared/scss/media" as *;
+@use "../../shared/scss/theme_variables" as *;
+
+.item-block {
+  p {
+    margin: 2px 0;
+
+    @media #{$mobile-only} {
+      margin-bottom: 5px;
+      margin-top: 0;
+    }
+  }
+
+  a {
+    cursor: pointer;
+    text-decoration: none;
+  }
+
+  .title {
+    font-size: 16px;
+    font-family: Verdana, Geneva, sans-serif;
+  }
+
+  .subtext-laptop {
+    font-size: 12px;
+    font-weight: bold;
+    letter-spacing: 0.5px;
+
+    a {
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+
+    @media #{$mobile-only} {
+      display: none;
+    }
+  }
+
+  .subtext-palm {
+    font-size: 13px;
+    font-weight: bold;
+    letter-spacing: 0.5px;
+
+    a {
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+
+    .details {
+      margin-top: 5px;
+
+      .right {
+        float: right;
+      }
+    }
+
+    @media #{$laptop-only} {
+      display: none;
+    }
+  }
+
+  .domain {
+    color: #696969;
+    letter-spacing: 0.5px;
+  }
+
+  .item-details {
+    padding: 10px;
+  }
+}

--- a/react-app/src/feeds/Item/Item.test.tsx
+++ b/react-app/src/feeds/Item/Item.test.tsx
@@ -1,0 +1,149 @@
+import { render, screen, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import type { Settings } from '../../shared/models/settings';
+import type { Story } from '../../shared/models/story';
+import { SettingsContext } from '../../shared/services/settingsContext';
+import type { SettingsContextValue } from '../../shared/services/settingsContext';
+import Item from './Item';
+
+const baseStory: Story = {
+    id: 123,
+    title: 'A very interesting story',
+    points: 42,
+    user: 'pg',
+    time: 1_500_000_000,
+    time_ago: '3 hours ago',
+    type: 'news',
+    url: 'https://example.com/story',
+    domain: 'example.com',
+    comments: [],
+    comments_count: 7,
+    poll: [],
+    poll_votes_count: 0,
+    deleted: false,
+    dead: false,
+};
+
+function makeStory(overrides: Partial<Story> = {}): Story {
+    return { ...baseStory, ...overrides };
+}
+
+const defaultSettings: Settings = {
+    showSettings: false,
+    openLinkInNewTab: false,
+    theme: 'default',
+    titleFontSize: '16',
+    listSpacing: '0',
+};
+
+function renderItem(item: Story, settingsOverrides: Partial<Settings> = {}) {
+    const value: SettingsContextValue = {
+        settings: { ...defaultSettings, ...settingsOverrides },
+        toggleSettings: vi.fn(),
+        toggleOpenLinksInNewTab: vi.fn(),
+        setTheme: vi.fn(),
+        setFont: vi.fn(),
+        setSpacing: vi.fn(),
+    };
+
+    return render(
+        <MemoryRouter>
+            <SettingsContext.Provider value={value}>
+                <Item item={item} />
+            </SettingsContext.Provider>
+        </MemoryRouter>
+    );
+}
+
+describe('Item', () => {
+    it('renders an external story title as an anchor with the domain', () => {
+        const { container } = renderItem(makeStory());
+
+        const title = screen.getByRole('link', { name: 'A very interesting story' });
+        expect(title).toHaveAttribute('href', 'https://example.com/story');
+        expect(title).toHaveClass('title');
+        expect(container.querySelector('.domain')).toHaveTextContent('(example.com)');
+    });
+
+    it('renders a self post title as a router link to the item page', () => {
+        const { container } = renderItem(makeStory({ url: 'item?id=123', domain: '' }));
+
+        const title = screen.getByRole('link', { name: 'A very interesting story' });
+        expect(title).toHaveAttribute('href', '/item/123');
+        expect(container.querySelector('.domain')).toBeNull();
+    });
+
+    it('treats a missing url as a self post', () => {
+        renderItem(makeStory({ url: undefined as unknown as string, domain: '' }));
+
+        expect(screen.getByRole('link', { name: 'A very interesting story' })).toHaveAttribute('href', '/item/123');
+    });
+
+    it.each([
+        [0, 'discuss'],
+        [1, '1 comment'],
+        [7, '7 comments'],
+    ])('renders %i comments as "%s" linking to the item page', (count, expected) => {
+        const { container } = renderItem(makeStory({ comments_count: count }));
+
+        const commentLinks = screen.getAllByRole('link', { name: new RegExp(expected) });
+        expect(commentLinks.length).toBe(2);
+        for (const link of commentLinks) {
+            expect(link).toHaveAttribute('href', '/item/123');
+        }
+        expect(container.querySelector('.comment-number')).toHaveTextContent(`• ${expected}`);
+    });
+
+    it('renders the user link and the points in both layouts', () => {
+        const { container } = renderItem(makeStory());
+
+        const userLinks = screen.getAllByRole('link', { name: 'pg' });
+        expect(userLinks.length).toBe(2);
+        for (const link of userLinks) {
+            expect(link).toHaveAttribute('href', '/user/pg');
+        }
+
+        const palm = container.querySelector('.subtext-palm') as HTMLElement;
+        expect(within(palm).getByText('42 ★')).toHaveClass('right');
+        expect(palm).toHaveTextContent('3 hours ago');
+
+        const laptop = container.querySelector('.subtext-laptop') as HTMLElement;
+        expect(laptop).toHaveTextContent('42 points by pg');
+        expect(laptop.querySelector('.item-details')).toHaveTextContent('3 hours ago');
+    });
+
+    it('hides user, points and comments for job postings', () => {
+        const { container } = renderItem(makeStory({ type: 'job', comments_count: 0 }));
+
+        expect(screen.queryByRole('link', { name: 'pg' })).toBeNull();
+        expect(screen.queryByText(/points by/)).toBeNull();
+        expect(screen.queryByText(/discuss/)).toBeNull();
+        expect(container.querySelector('.comment-number')).toBeNull();
+        expect(container.querySelector('.item-details')).toBeNull();
+        expect(container.querySelector('.subtext-palm')).toHaveTextContent('3 hours ago');
+    });
+
+    it('applies the title font size and list spacing settings', () => {
+        const { container } = renderItem(makeStory(), { titleFontSize: '20', listSpacing: '12' });
+
+        expect(container.querySelector('.item-block')).toHaveStyle({ marginBottom: '12px' });
+        expect(screen.getByRole('link', { name: 'A very interesting story' })).toHaveStyle({ fontSize: '20px' });
+    });
+
+    it('omits target and rel on the external link when openLinkInNewTab is false', () => {
+        renderItem(makeStory(), { openLinkInNewTab: false });
+
+        const title = screen.getByRole('link', { name: 'A very interesting story' });
+        expect(title).not.toHaveAttribute('target');
+        expect(title).not.toHaveAttribute('rel');
+    });
+
+    it('sets target and rel on the external link when openLinkInNewTab is true', () => {
+        renderItem(makeStory(), { openLinkInNewTab: true });
+
+        const title = screen.getByRole('link', { name: 'A very interesting story' });
+        expect(title).toHaveAttribute('target', '_blank');
+        expect(title).toHaveAttribute('rel', 'noopener');
+    });
+});

--- a/react-app/src/feeds/Item/Item.tsx
+++ b/react-app/src/feeds/Item/Item.tsx
@@ -1,6 +1,73 @@
+import { Link } from 'react-router-dom';
 import type { Story } from '../../shared/models/story';
+import { formatCommentCount } from '../../shared/pipes/comment';
+import { useSettings } from '../../shared/services/settingsContext';
+import './Item.scss';
 
-// Placeholder replaced by the ItemComponent migration workstream.
 export default function Item({ item }: { item: Story }) {
-    return <div>{item.title}</div>;
+    const { settings } = useSettings();
+
+    const hasUrl = (item.url ?? '').indexOf('http') === 0;
+    const isJob = item.type === 'job';
+    const titleStyle = { fontSize: `${settings.titleFontSize}px` };
+
+    return (
+        <div className="item-block" style={{ marginBottom: `${settings.listSpacing}px` }}>
+            {hasUrl ? (
+                <p>
+                    <a
+                        className="title"
+                        style={titleStyle}
+                        href={item.url}
+                        target={settings.openLinkInNewTab ? '_blank' : undefined}
+                        rel={settings.openLinkInNewTab ? 'noopener' : undefined}
+                    >
+                        {item.title}
+                    </a>
+                    {item.domain && <span className="domain">({item.domain})</span>}
+                </p>
+            ) : (
+                <p>
+                    <Link className="title" style={titleStyle} to={`/item/${item.id}`}>
+                        {item.title}
+                    </Link>
+                </p>
+            )}
+            <div className="subtext-palm">
+                {!isJob && (
+                    <div className="details">
+                        <span className="name">
+                            <Link to={`/user/${item.user}`}>{item.user}</Link>
+                        </span>
+                        <span className="right">{item.points} ★</span>
+                    </div>
+                )}
+                <div className="details">
+                    {item.time_ago}
+                    {!isJob && (
+                        <Link to={`/item/${item.id}`} className="comment-number">
+                            {' • '}
+                            {formatCommentCount(item.comments_count)}
+                        </Link>
+                    )}
+                </div>
+            </div>
+            <div className="subtext-laptop">
+                {!isJob && (
+                    <span>
+                        {item.points} points by <Link to={`/user/${item.user}`}>{item.user}</Link>
+                    </span>
+                )}
+                <span className={isJob ? undefined : 'item-details'}>
+                    {item.time_ago}
+                    {!isJob && (
+                        <span>
+                            {' | '}
+                            <Link to={`/item/${item.id}`}>{formatCommentCount(item.comments_count)}</Link>
+                        </span>
+                    )}
+                </span>
+            </div>
+        </div>
+    );
 }

--- a/react-app/src/feeds/Item/Item.tsx
+++ b/react-app/src/feeds/Item/Item.tsx
@@ -24,7 +24,7 @@ export default function Item({ item }: { item: Story }) {
                     >
                         {item.title}
                     </a>
-                    {item.domain && <span className="domain">({item.domain})</span>}
+                    {item.domain && <span className="domain"> ({item.domain})</span>}
                 </p>
             ) : (
                 <p>

--- a/react-app/src/feeds/Item/Item.tsx
+++ b/react-app/src/feeds/Item/Item.tsx
@@ -24,7 +24,7 @@ export default function Item({ item }: { item: Story }) {
                     >
                         {item.title}
                     </a>
-                    {item.domain && <span className="domain"> ({item.domain})</span>}
+                    {item.domain && <> <span className="domain">({item.domain})</span></>}
                 </p>
             ) : (
                 <p>

--- a/react-app/src/feeds/Item/Item.tsx
+++ b/react-app/src/feeds/Item/Item.tsx
@@ -43,7 +43,7 @@ export default function Item({ item }: { item: Story }) {
                     </div>
                 )}
                 <div className="details">
-                    {item.time_ago}
+                    {item.time_ago}{' '}
                     {!isJob && (
                         <Link to={`/item/${item.id}`} className="comment-number">
                             {' • '}
@@ -57,9 +57,9 @@ export default function Item({ item }: { item: Story }) {
                     <span>
                         {item.points} points by <Link to={`/user/${item.user}`}>{item.user}</Link>
                     </span>
-                )}
+                )}{' '}
                 <span className={isJob ? undefined : 'item-details'}>
-                    {item.time_ago}
+                    {item.time_ago}{' '}
                     {!isJob && (
                         <span>
                             {' | '}


### PR DESCRIPTION
## Summary

Ports the Angular `ItemComponent` (one Hacker News story row) to React at `react-app/src/feeds/Item/`, replacing the placeholder stub. Second PR in the React migration stack (base: the foundation branch; the Feed component PR stacks on top of this one).

Mapping from Angular to React:

- `@Input() item: Story` → `Item({ item }: { item: Story })` (unchanged public API, as the Feed component depends on it)
- `SettingsService` injection → `useSettings()`; `settings.listSpacing` → root `marginBottom`, `settings.titleFontSize` → title `fontSize`
- `[attr.target]` / `[attr.rel]` → `target={settings.openLinkInNewTab ? '_blank' : undefined}` / same for `rel`, so both attributes are absent (not empty) when the setting is off
- `get hasUrl()` → `(item.url ?? '').indexOf('http') === 0` — defensive about a missing `url`, which the Angular getter would have thrown on
- `[routerLink]="['/item', item.id]"` → `<Link to={\`/item/${item.id}\`}>`; same for `/user/:user`
- `{{ comments_count | comment }}` → `formatCommentCount(item.comments_count)`

`item.component.scss` → `Item.scss` with `@import` → `@use "..." as *;` and rules otherwise identical. Angular's view encapsulation is replaced by nesting everything under a `.item-block` root class (added to the root `div`) so the bare `p {}` / `a {}` rules do not leak globally.

`Item.test.tsx` covers external vs. self/Ask posts, missing `url`, comment-count pluralization (`discuss` / `1 comment` / `n comments`) and its link target, user link + points in both the `.subtext-palm` and `.subtext-laptop` blocks, the `type === 'job'` suppression, and the three settings effects. Settings are supplied via `SettingsContext.Provider` rather than `SettingsProvider` to keep the tests independent of `localStorage` and `matchMedia`.

From `react-app/`: `npm run test` (29 passed), `npm run typecheck`, `npm run build`, `npm run lint` (only the pre-existing `settingsContext.tsx` fast-refresh warnings) all pass.


Link to Devin session: https://app.devin.ai/sessions/02c8916c925b4e77961ca2e51e7ebc68
Requested by: @charityquinn-cognition
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/594?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/594" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/angular2-hn/pull/594" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->