### PR TITLE
feature: migrate Angular FeedComponent to React

### DIFF
--- a/react-app/src/feeds/Feed/Feed.scss
+++ b/react-app/src/feeds/Feed/Feed.scss
@@ -1,0 +1,107 @@
+@use "../../shared/scss/media" as *;
+@use "../../shared/scss/theme_variables" as *;
+
+.main-content {
+  position: relative;
+  width: 100%;
+  min-height: 100vh;
+  -webkit-transition: opacity .2s ease;
+  transition: opacity .2s ease;
+  box-sizing: border-box;
+  padding: 8px 0;
+  z-index: 0;
+
+  a {
+    text-decoration: none;
+    font-weight: bold;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  ol {
+    padding: 0 40px;
+    margin: 0;
+
+    @media #{$mobile-only} {
+      box-sizing: border-box;
+      list-style: none;
+      padding: 0 10px;
+    }
+
+    li {
+      position: relative;
+      -webkit-transition: background-color .2s ease;
+      transition: background-color .2s ease;
+    }
+  }
+
+  .list-margin {
+    @media #{$mobile-only} {
+      margin-top: 55px;
+    }
+  }
+
+  .post {
+    padding: 10px 0 10px 5px;
+    transition: background-color 0.2s ease;
+    border-bottom: 1px solid #CECECB;
+
+    .itemNum {
+      color: #696969;
+      position: absolute;
+      width: 30px;
+      text-align: right;
+      left: 0;
+      top: 4px;
+    }
+  }
+
+  .item-block {
+    display: block;
+  }
+
+  .nav {
+    padding: 10px 40px;
+    margin-top: 10px;
+    font-size: 17px;
+
+    a {
+      @media #{$mobile-only} {
+        text-decoration: none;
+      }
+    }
+
+    @media #{$mobile-only} {
+      margin: 20px 0;
+      text-align: center;
+      padding: 10px 80px;
+      height: 20px;
+    }
+
+    .prev {
+      padding-right: 20px;
+
+      @media #{$mobile-only} {
+        float: left;
+        padding-right: 0;
+      }
+    }
+
+    .more {
+      @media #{$mobile-only} {
+        float: right;
+      }
+    }
+  }
+
+  .job-header {
+    font-size: 15px;
+    padding: 0 40px 10px;
+
+    @media #{$mobile-only} {
+      padding: 60px 15px 25px 15px;
+    }
+  }
+}

--- a/react-app/src/feeds/Feed/Feed.scss
+++ b/react-app/src/feeds/Feed/Feed.scss
@@ -11,15 +11,6 @@
   padding: 8px 0;
   z-index: 0;
 
-  a {
-    text-decoration: none;
-    font-weight: bold;
-
-    &:hover {
-      text-decoration: underline;
-    }
-  }
-
   ol {
     padding: 0 40px;
     margin: 0;
@@ -68,6 +59,13 @@
     font-size: 17px;
 
     a {
+      text-decoration: none;
+      font-weight: bold;
+
+      &:hover {
+        text-decoration: underline;
+      }
+
       @media #{$mobile-only} {
         text-decoration: none;
       }
@@ -99,6 +97,15 @@
   .job-header {
     font-size: 15px;
     padding: 0 40px 10px;
+
+    a {
+      text-decoration: none;
+      font-weight: bold;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
 
     @media #{$mobile-only} {
       padding: 60px 15px 25px 15px;

--- a/react-app/src/feeds/Feed/Feed.test.tsx
+++ b/react-app/src/feeds/Feed/Feed.test.tsx
@@ -1,0 +1,183 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Story } from '../../shared/models/story';
+import { SettingsProvider } from '../../shared/services/settingsContext';
+import { fetchFeed } from '../../shared/services/hackerNewsApi';
+import Feed from './Feed';
+
+vi.mock('../../shared/services/hackerNewsApi', () => ({
+    fetchFeed: vi.fn(),
+}));
+
+const fetchFeedMock = vi.mocked(fetchFeed);
+
+function makeStory(id: number): Story {
+    return {
+        id,
+        title: `Story ${id}`,
+        points: id,
+        user: `user${id}`,
+        time: 1600000000,
+        time_ago: '1 hour ago',
+        type: 'link',
+        url: `https://example.com/${id}`,
+        domain: 'example.com',
+        comments: [],
+        comments_count: 0,
+        poll: [],
+        poll_votes_count: 0,
+        deleted: false,
+        dead: false,
+    } as unknown as Story;
+}
+
+function makeStories(count: number): Story[] {
+    return Array.from({ length: count }, (_, index) => makeStory(index + 1));
+}
+
+function renderFeed(initialEntry: string) {
+    return render(
+        <SettingsProvider>
+            <MemoryRouter initialEntries={[initialEntry]}>
+                <Routes>
+                    <Route path="/:feedType" element={<Feed />} />
+                    <Route path="/:feedType/:page" element={<Feed />} />
+                </Routes>
+            </MemoryRouter>
+        </SettingsProvider>
+    );
+}
+
+describe('Feed', () => {
+    beforeEach(() => {
+        vi.spyOn(window, 'scrollTo').mockImplementation(() => {});
+        vi.stubGlobal(
+            'matchMedia',
+            vi.fn().mockImplementation((media: string) => ({
+                media,
+                matches: false,
+                addEventListener: () => {},
+                removeEventListener: () => {},
+            }))
+        );
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+        vi.restoreAllMocks();
+        vi.unstubAllGlobals();
+    });
+
+    it('shows the loader while the request is pending', () => {
+        fetchFeedMock.mockReturnValue(new Promise<Story[]>(() => {}));
+
+        renderFeed('/news/1');
+
+        expect(screen.getByText('Loading...')).toBeInTheDocument();
+    });
+
+    it('renders the stories and requests the feed type and page from the URL', async () => {
+        fetchFeedMock.mockResolvedValue(makeStories(3));
+
+        const { container } = renderFeed('/ask/2');
+
+        expect(await screen.findByText('Story 1')).toBeInTheDocument();
+        expect(container.querySelectorAll('li.post')).toHaveLength(3);
+        expect(fetchFeedMock).toHaveBeenCalledWith('ask', 2, expect.any(AbortSignal));
+    });
+
+    it('shows the error message when the request fails', async () => {
+        fetchFeedMock.mockRejectedValue(new Error('boom'));
+
+        renderFeed('/news/1');
+
+        expect(await screen.findByText('Could not load news stories.')).toBeInTheDocument();
+    });
+
+    it('starts the list at 1 on page 1 and scrolls to the top', async () => {
+        fetchFeedMock.mockResolvedValue(makeStories(2));
+
+        const { container } = renderFeed('/news/1');
+
+        await screen.findByText('Story 1');
+        expect(container.querySelector('ol')).toHaveAttribute('start', '1');
+        expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
+    });
+
+    it('starts the list at 61 on page 3', async () => {
+        fetchFeedMock.mockResolvedValue(makeStories(2));
+
+        const { container } = renderFeed('/news/3');
+
+        await screen.findByText('Story 1');
+        expect(container.querySelector('ol')).toHaveAttribute('start', '61');
+    });
+
+    it('adds the list-margin class for news and omits the job header', async () => {
+        fetchFeedMock.mockResolvedValue(makeStories(1));
+
+        const { container } = renderFeed('/news/1');
+
+        await screen.findByText('Story 1');
+        expect(container.querySelector('ol')).toHaveClass('list-margin');
+        expect(container.querySelector('.job-header')).toBeNull();
+    });
+
+    it('omits the list-margin class for jobs and renders the job header', async () => {
+        fetchFeedMock.mockResolvedValue(makeStories(1));
+
+        const { container } = renderFeed('/jobs/1');
+
+        await screen.findByText('Story 1');
+        expect(container.querySelector('ol')).not.toHaveClass('list-margin');
+        expect(container.querySelector('.job-header')).not.toBeNull();
+        expect(screen.getByRole('link', { name: 'Triplebyte' })).toHaveAttribute(
+            'href',
+            'https://triplebyte.com/?ref=yc_jobs'
+        );
+    });
+
+    it('does not render the list for the new feed', async () => {
+        fetchFeedMock.mockResolvedValue(makeStories(1));
+
+        const { container } = renderFeed('/new/1');
+
+        await waitFor(() => expect(container.querySelector('.nav')).not.toBeNull());
+        expect(container.querySelector('ol')).toBeNull();
+    });
+
+    it('hides the Prev link on page 1 and shows More only with 30 items', async () => {
+        fetchFeedMock.mockResolvedValue(makeStories(30));
+
+        renderFeed('/news/1');
+
+        await screen.findByText('Story 1');
+        expect(screen.queryByText('‹ Prev')).toBeNull();
+        expect(screen.getByText('More ›')).toHaveAttribute('href', '/news/2');
+    });
+
+    it('shows the Prev link on page 2 and hides More with fewer than 30 items', async () => {
+        fetchFeedMock.mockResolvedValue(makeStories(29));
+
+        renderFeed('/news/2');
+
+        await screen.findByText('Story 1');
+        expect(screen.getByText('‹ Prev')).toHaveAttribute('href', '/news/1');
+        expect(screen.queryByText('More ›')).toBeNull();
+    });
+
+    it('refetches when the page param changes', async () => {
+        fetchFeedMock.mockResolvedValue(makeStories(30));
+
+        renderFeed('/news/1');
+
+        await screen.findByText('Story 1');
+        expect(fetchFeedMock).toHaveBeenCalledWith('news', 1, expect.any(AbortSignal));
+
+        await userEvent.click(screen.getByText('More ›'));
+
+        await waitFor(() => expect(fetchFeedMock).toHaveBeenCalledWith('news', 2, expect.any(AbortSignal)));
+    });
+});

--- a/react-app/src/feeds/Feed/Feed.tsx
+++ b/react-app/src/feeds/Feed/Feed.tsx
@@ -21,28 +21,22 @@ export default function Feed() {
         setItems(null);
         setErrorMessage('');
 
-        fetchFeed(feedType, pageNum, controller.signal)
-            .then(
-                (feedItems) => {
-                    if (controller.signal.aborted) {
-                        return;
-                    }
-                    setItems(feedItems);
-                },
-                () => {
-                    if (controller.signal.aborted) {
-                        return;
-                    }
-                    setErrorMessage(`Could not load ${feedType} stories.`);
-                }
-            )
-            .then(() => {
+        fetchFeed(feedType, pageNum, controller.signal).then(
+            (feedItems) => {
                 if (controller.signal.aborted) {
                     return;
                 }
+                setItems(feedItems);
                 setListStart(((pageNum - 1) * 30) + 1);
                 window.scrollTo(0, 0);
-            });
+            },
+            () => {
+                if (controller.signal.aborted) {
+                    return;
+                }
+                setErrorMessage(`Could not load ${feedType} stories.`);
+            }
+        );
 
         return () => controller.abort();
     }, [feedType, pageNum]);

--- a/react-app/src/feeds/Feed/Feed.tsx
+++ b/react-app/src/feeds/Feed/Feed.tsx
@@ -1,4 +1,90 @@
-// Placeholder replaced by the FeedComponent migration workstream.
+import { useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import ErrorMessage from '../../shared/components/ErrorMessage/ErrorMessage';
+import Loader from '../../shared/components/Loader/Loader';
+import type { Story } from '../../shared/models/story';
+import { fetchFeed } from '../../shared/services/hackerNewsApi';
+import Item from '../Item/Item';
+import './Feed.scss';
+
 export default function Feed() {
-    return <div className="main-content" />;
+    const { feedType = 'news', page } = useParams();
+    const pageNum = page ? +page : 1;
+
+    const [items, setItems] = useState<Story[] | null>(null);
+    const [errorMessage, setErrorMessage] = useState('');
+    const [listStart, setListStart] = useState(1);
+
+    useEffect(() => {
+        const controller = new AbortController();
+
+        setItems(null);
+        setErrorMessage('');
+
+        fetchFeed(feedType, pageNum, controller.signal)
+            .then(
+                (feedItems) => {
+                    if (controller.signal.aborted) {
+                        return;
+                    }
+                    setItems(feedItems);
+                },
+                () => {
+                    if (controller.signal.aborted) {
+                        return;
+                    }
+                    setErrorMessage(`Could not load ${feedType} stories.`);
+                }
+            )
+            .then(() => {
+                if (controller.signal.aborted) {
+                    return;
+                }
+                setListStart(((pageNum - 1) * 30) + 1);
+                window.scrollTo(0, 0);
+            });
+
+        return () => controller.abort();
+    }, [feedType, pageNum]);
+
+    return (
+        <div className="main-content">
+            {!items && !errorMessage && <Loader />}
+            {!items && errorMessage !== '' && <ErrorMessage message={errorMessage} />}
+
+            {items && (
+                <div>
+                    {feedType === 'jobs' && (
+                        <p className="job-header">
+                            These are jobs at startups that were funded by Y Combinator. You can also get a job at a
+                            YC startup through <a href="https://triplebyte.com/?ref=yc_jobs">Triplebyte</a>.
+                        </p>
+                    )}
+                    {feedType !== 'new' && (
+                        <ol className={feedType !== 'jobs' ? 'list-margin' : undefined} start={listStart}>
+                            {items.map((item) => (
+                                <li key={item.id} className="post">
+                                    <div className="item-block">
+                                        <Item item={item} />
+                                    </div>
+                                </li>
+                            ))}
+                        </ol>
+                    )}
+                    <div className="nav">
+                        {listStart !== 1 && (
+                            <Link to={`/${feedType}/${pageNum - 1}`} className="prev">
+                                ‹ Prev
+                            </Link>
+                        )}
+                        {items.length === 30 && (
+                            <Link to={`/${feedType}/${pageNum + 1}`} className="more">
+                                More ›
+                            </Link>
+                        )}
+                    </div>
+                </div>
+            )}
+        </div>
+    );
 }

--- a/react-app/src/feeds/Feed/Feed.tsx
+++ b/react-app/src/feeds/Feed/Feed.tsx
@@ -64,9 +64,7 @@ export default function Feed() {
                         <ol className={feedType !== 'jobs' ? 'list-margin' : undefined} start={listStart}>
                             {items.map((item) => (
                                 <li key={item.id} className="post">
-                                    <div className="item-block">
-                                        <Item item={item} />
-                                    </div>
+                                    <Item item={item} />
                                 </li>
                             ))}
                         </ol>


### PR DESCRIPTION
## Summary

Ports the Angular `FeedComponent` (story list page) to React at `react-app/src/feeds/Feed/`. Third PR in the stack: base is `devin/react-item-component`, which bases on `devin/1786380497-react-feeds-foundation`. Only `react-app/src/feeds/Feed/{Feed.tsx,Feed.scss,Feed.test.tsx}` is added here.

Two behavioural details worth calling out:

- `feedType` used to come from Angular route `data`; it now comes from the `:feedType` URL segment (`/news/1`, `/ask/2`, ...), with `news` as the default.
- The RxJS `subscribe(next, error, complete)` triple maps to a promise chain, with an `AbortController` so a stale response can never overwrite newer state:

```ts
useEffect(() => {
  const controller = new AbortController();
  setItems(null); setErrorMessage('');
  fetchFeed(feedType, pageNum, controller.signal)
    .then(setItems, () => setErrorMessage(`Could not load ${feedType} stories.`))
    .then(() => { setListStart(((pageNum - 1) * 30) + 1); window.scrollTo(0, 0); }); // guarded on !aborted
  return () => controller.abort();
}, [feedType, pageNum]);
```

DOM, class names, `start={listStart}` maths, the `list-margin`/`jobs` conditionals and the Prev/More link rules are unchanged from the Angular template; `routerLink` becomes `<Link to={`/${feedType}/${pageNum ± 1}`}>`.

`Feed.scss` is a rule-for-rule port of `feed.component.scss` with `@import` → `@use ... as *`. Since Angular view encapsulation no longer scopes them, all rules are nested under `.main-content` so bare `a {}` / `ol {}` do not leak globally.

`Feed.test.tsx` adds 11 Vitest/RTL cases (mocked `hackerNewsApi`, rendered in a `MemoryRouter`): pending loader, resolved list + call args, rejection message, `start` for page 1 vs 3 plus `scrollTo`, `list-margin`/job-header per feed type, no `<ol>` for `new`, Prev/More visibility rules, and refetch on page change.

From `react-app/`: `npm run test` (40 passed), `npm run typecheck`, `npm run build` all pass; `npm run lint` emits only the 3 pre-existing `settingsContext.tsx` warnings.


Link to Devin session: https://app.devin.ai/sessions/3fc934130a864433afb4f08952746144
Requested by: @charityquinn-cognition
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/595?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/595" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/angular2-hn/pull/595" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->