### PR TITLE
feature: port the feeds page and story row to React

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,10 @@
 import { lazy, Suspense, useEffect } from 'react';
 import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
 
-import Feed from './components/Feed';
 import Footer from './components/Footer';
 import Header from './components/Header';
 import { useSettings } from './context/SettingsContext';
+import Feed from './features/feeds/Feed';
 
 const ItemDetails = lazy(() => import('./components/ItemDetails'));
 const UserDetails = lazy(() => import('./components/UserDetails'));

--- a/src/components/ErrorMessage.scss
+++ b/src/components/ErrorMessage.scss
@@ -1,0 +1,115 @@
+@import "../app/shared/scss/media";
+@import "../app/shared/scss/theme_variables";
+
+.error-section {
+  height: 300px;
+  margin: 200px;
+
+  @media #{$mobile-only} {
+    height: 0;
+    display: block;
+    position: relative;
+    margin: 30vh 0;
+  }
+
+  p {
+    text-align: center;
+    padding: 0 25px;
+
+    &.strong {
+      margin-top: 25px;
+      font-weight: bold;
+    }
+  }
+
+  .skull {
+    width: $skull-size;
+    height: $skull-size;
+    position: relative;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    margin: auto;
+
+    .head {
+      width: 100%;
+      height: 75%;
+      border-radius: 15% / 20%;
+      position: absolute;
+      top: 0;
+      left: 0;
+      &:before, &:after {
+        content: "";
+        position: absolute;
+        border-radius: 50%;
+        width: 20%;
+        height: 30%;
+        bottom: 10%;
+      }
+      &:before {
+        left: 10%;
+      }
+      &:after {
+        right: 10%;
+      }
+      .crack {
+        width: 10%;
+        height: 10%;
+        position: absolute;
+        top: 0;
+        right: 25%;
+        transform: skew(-15deg);
+
+        &:before {
+          content: "";
+          position: absolute;
+          top: 100%;
+          left: $skull-size / 15;
+          border-right: $skull-size / 20 solid transparent;
+          border-left: $skull-size / 40 solid transparent;
+        }
+      }
+    }
+    .mouth {
+      width: 40%;
+      height: 25%;
+      position: absolute;
+      top: 75%;
+      left: 30%;
+      border-radius: 0 0 $skull-size / 10 $skull-size / 10;
+      &:before {
+        content: "";
+        position: absolute;
+        width: 15%;
+        height: 50%;
+        border-radius: 50% / 30%;
+        left: 42.5%;
+        top: -25%;
+      }
+      .teeth {
+        position: absolute;
+        bottom: 0;
+        left: 45%;
+        width: 10%;
+        height: 50%;
+        margin-bottom: -5%;
+        border-radius: 50% / 20%;
+
+        &:before, &:after {
+          content: "";
+          position: absolute;
+          width: 100%;
+          height: 100%;
+          border-radius: 50% / 20%;
+        }
+        &:before {
+          left: -250%;
+        }
+        &:after {
+          right: -250%;
+        }
+      }
+    }
+  }
+}

--- a/src/components/ErrorMessage.tsx
+++ b/src/components/ErrorMessage.tsx
@@ -1,0 +1,25 @@
+import './ErrorMessage.scss';
+
+interface ErrorMessageProps {
+    message: string;
+}
+
+export default function ErrorMessage({ message }: ErrorMessageProps) {
+    return (
+        <div className="error-section">
+            <div className="skull">
+                <div className="head">
+                    <div className="crack" />
+                </div>
+                <div className="mouth">
+                    <div className="teeth" />
+                </div>
+            </div>
+            <p className="strong">{message}</p>
+            <p>
+                If you are offline viewing, you&apos;ll need to visit this page with a network connection first before
+                it can work offline.
+            </p>
+        </div>
+    );
+}

--- a/src/components/Feed.tsx
+++ b/src/components/Feed.tsx
@@ -1,9 +1,0 @@
-import Placeholder from './Placeholder';
-
-interface FeedProps {
-    feedType: string;
-}
-
-export default function Feed({ feedType }: FeedProps) {
-    return <Placeholder name="Feed" feedType={feedType} />;
-}

--- a/src/components/Loader.scss
+++ b/src/components/Loader.scss
@@ -1,0 +1,109 @@
+@import "../app/shared/scss/media";
+@import "../app/shared/scss/theme_variables";
+
+.loader {
+  -webkit-animation: load1 1s infinite ease-in-out;
+  animation: load1 1s infinite ease-in-out;
+  width: 1em;
+  height: 4em;
+  &:before, &:after {
+    -webkit-animation: load1 1s infinite ease-in-out;
+    animation: load1 1s infinite ease-in-out;
+    width: 1em;
+    height: 4em;
+  }
+  &:before, &:after {
+    position: absolute;
+    top: 0;
+    content: '';
+  }
+  &:before {
+    left: -1.5em;
+    -webkit-animation-delay: -0.32s;
+    animation-delay: -0.32s;
+  }
+}
+
+.loading-section {
+    height: 70px;
+    margin: 40px 0 40px 40px;
+
+  @media #{$mobile-only} {
+    display: block;
+    position: relative;
+    margin: 45vh 0;
+  }
+}
+
+.loader {
+  text-indent: -9999em;
+  margin: 20px 20px;
+  position: relative;
+  font-size: 11px;
+  -webkit-transform: translateZ(0);
+  -ms-transform: translateZ(0);
+  transform: translateZ(0);
+  -webkit-animation-delay: -0.16s;
+  animation-delay: -0.16s;
+  &:after {
+    left: 1.5em;
+  }
+
+  @media #{$mobile-only} {
+    margin: 20px auto;
+  }
+}
+
+@-webkit-keyframes load1 {
+  0%,
+    80%,
+    100% {
+    box-shadow: 0 0;
+    height: 2em;
+  }
+  40% {
+    box-shadow: 0 -2em;
+    height: 3em;
+  }
+}
+
+@keyframes load1 {
+  0%,
+    80%,
+    100% {
+    box-shadow: 0 0;
+    height: 2em;
+  }
+  40% {
+    box-shadow: 0 -2em;
+    height: 3em;
+  }
+}
+
+@media #{$mobile-only} {
+  @-webkit-keyframes load1 {
+    0%,
+      80%,
+      100% {
+      box-shadow: 0 0;
+      height: 4em;
+    }
+    40% {
+      box-shadow: 0 -2em;
+      height: 5em;
+    }
+  }
+
+  @keyframes load1 {
+    0%,
+      80%,
+      100% {
+      box-shadow: 0 0;
+      height: 3em;
+    }
+    40% {
+      box-shadow: 0 -2em;
+      height: 4em;
+    }
+  }
+}

--- a/src/components/Loader.tsx
+++ b/src/components/Loader.tsx
@@ -1,0 +1,9 @@
+import './Loader.scss';
+
+export default function Loader() {
+    return (
+        <div className="loading-section">
+            <div className="loader">Loading...</div>
+        </div>
+    );
+}

--- a/src/features/feeds/Feed.scss
+++ b/src/features/feeds/Feed.scss
@@ -1,0 +1,108 @@
+@import "../../app/shared/scss/media";
+@import "../../app/shared/scss/theme_variables";
+
+a {
+  text-decoration: none;
+  font-weight: bold;
+
+  &:hover {
+    text-decoration: underline;
+  };
+}
+
+ol {
+  padding: 0 40px;
+  margin: 0;
+
+  @media #{$mobile-only} {
+    box-sizing: border-box;
+    list-style: none;
+    padding: 0 10px;
+  }
+
+  li {
+    position: relative;
+    -webkit-transition: background-color .2s ease;
+    transition: background-color .2s ease;
+  }
+}
+
+.list-margin {
+  @media #{$mobile-only} {
+    margin-top: 55px;
+  }
+}
+
+.main-content {
+  position: relative;
+  width: 100%;
+  min-height: 100vh;
+  -webkit-transition: opacity .2s ease;
+  transition: opacity .2s ease;
+  box-sizing: border-box;
+  padding: 8px 0;
+  z-index: 0;
+}
+
+.post {
+  padding: 10px 0 10px 5px;
+  transition: background-color 0.2s ease;
+  border-bottom: 1px solid #CECECB;
+
+  .itemNum {
+    color: #696969;
+    position: absolute;
+    width: 30px;
+    text-align: right;
+    left: 0;
+    top: 4px;
+  }
+}
+
+.item-block {
+  display: block;
+}
+
+
+.nav {
+  padding: 10px 40px;
+  margin-top: 10px;
+  font-size: 17px;
+
+  a {
+    @media #{$mobile-only} {
+      text-decoration: none;
+    }
+  }
+
+  @media #{$mobile-only} {
+    margin: 20px 0;
+    text-align: center;
+    padding: 10px 80px;
+    height: 20px;
+  }
+
+  .prev {
+    padding-right: 20px;
+
+    @media #{$mobile-only} {
+      float: left;
+      padding-right: 0;
+    }
+  }
+
+  .more {
+    @media #{$mobile-only} {
+      float: right;
+    }
+  }
+}
+
+.job-header {
+  font-size: 15px;
+  padding: 0 40px 10px;
+
+  @media #{$mobile-only} {
+    padding: 60px 15px 25px 15px;
+  }
+}

--- a/src/features/feeds/Feed.tsx
+++ b/src/features/feeds/Feed.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+
+import { fetchFeed } from '../../api/hackerNewsApi';
+import ErrorMessage from '../../components/ErrorMessage';
+import Loader from '../../components/Loader';
+import { Story } from '../../models/story';
+import Item from './Item';
+
+import './Feed.scss';
+
+interface FeedProps {
+    feedType: string;
+}
+
+export default function Feed({ feedType }: FeedProps) {
+    const { page } = useParams<{ page?: string }>();
+    const pageNum = page ? +page : 1;
+    const [items, setItems] = useState<Story[] | null>(null);
+    const [listStart, setListStart] = useState(1);
+    const [errorMessage, setErrorMessage] = useState('');
+
+    useEffect(() => {
+        const controller = new AbortController();
+        setItems(null);
+        setErrorMessage('');
+
+        fetchFeed(feedType, pageNum, controller.signal)
+            .then((stories) => {
+                setItems(stories);
+                setListStart((pageNum - 1) * 30 + 1);
+                window.scrollTo(0, 0);
+            })
+            .catch((error: unknown) => {
+                if (error instanceof DOMException && error.name === 'AbortError') {
+                    return;
+                }
+                setErrorMessage(`Could not load ${feedType} stories.`);
+            });
+
+        return () => controller.abort();
+    }, [feedType, pageNum]);
+
+    return (
+        <div className="main-content">
+            {!items && !errorMessage && <Loader />}
+            {!items && errorMessage !== '' && <ErrorMessage message={errorMessage} />}
+
+            {items && (
+                <div>
+                    {feedType === 'jobs' && (
+                        <p className="job-header">
+                            These are jobs at startups that were funded by Y Combinator. You can also get a job at a YC
+                            startup through <a href="https://triplebyte.com/?ref=yc_jobs">Triplebyte</a>.
+                        </p>
+                    )}
+                    {feedType !== 'new' && (
+                        <ol className={feedType !== 'jobs' ? 'list-margin' : undefined} start={listStart}>
+                            {items.map((item) => (
+                                <li key={item.id} className="post">
+                                    <Item item={item} />
+                                </li>
+                            ))}
+                        </ol>
+                    )}
+                    <div className="nav">
+                        {listStart !== 1 && (
+                            <Link to={`/${feedType}/${pageNum - 1}`} className="prev">
+                                ‹ Prev
+                            </Link>
+                        )}
+                        {items.length === 30 && (
+                            <Link to={`/${feedType}/${pageNum + 1}`} className="more">
+                                More ›
+                            </Link>
+                        )}
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/features/feeds/Item.scss
+++ b/src/features/feeds/Item.scss
@@ -1,0 +1,68 @@
+@import "../../app/shared/scss/media";
+@import "../../app/shared/scss/theme_variables";
+
+p {
+    margin: 2px 0;
+
+    @media #{$mobile-only} {
+      margin-bottom: 5px;
+      margin-top: 0;
+   }
+  }
+
+  a {
+    cursor: pointer;
+    text-decoration: none;
+  }
+
+  .title {
+    font-size: 16px;
+    font-family: Verdana, Geneva, sans-serif;
+  }
+
+  .subtext-laptop {
+    font-size: 12px;
+    font-weight: bold;
+    letter-spacing: 0.5px;
+
+    a {
+      &:hover {
+        text-decoration: underline;
+      };
+    }
+    @media #{$mobile-only} {
+      display: none;
+    }
+  }
+
+  .subtext-palm {
+    font-size: 13px;
+    font-weight: bold;
+    letter-spacing: 0.5px;
+
+    a {
+      &:hover {
+        text-decoration: underline;
+      };
+    }
+
+    .details {
+      margin-top: 5px;
+
+      .right {
+        float: right;
+      }
+    }
+    @media #{$laptop-only} {
+      display: none;
+    }
+  }
+
+  .domain {
+    color: #696969;
+    letter-spacing: 0.5px;
+  }
+
+  .item-details {
+    padding: 10px;
+  }

--- a/src/features/feeds/Item.tsx
+++ b/src/features/feeds/Item.tsx
@@ -1,0 +1,77 @@
+import { Link } from 'react-router-dom';
+
+import { useSettings } from '../../context/SettingsContext';
+import { Story } from '../../models/story';
+import { commentCount } from './commentCount';
+
+import './Item.scss';
+
+interface ItemProps {
+    item: Story;
+}
+
+export default function Item({ item }: ItemProps) {
+    const { settings } = useSettings();
+    const hasUrl = item.url?.indexOf('http') === 0;
+    const titleStyle = { fontSize: `${settings.titleFontSize}px` };
+
+    return (
+        <div className="item-block" style={{ marginBottom: `${settings.listSpacing}px` }}>
+            {hasUrl ? (
+                <p>
+                    <a
+                        className="title"
+                        style={titleStyle}
+                        href={item.url}
+                        target={settings.openLinkInNewTab ? '_blank' : undefined}
+                        rel={settings.openLinkInNewTab ? 'noopener' : undefined}
+                    >
+                        {item.title}
+                    </a>
+                    {item.domain && <span className="domain">({item.domain})</span>}
+                </p>
+            ) : (
+                <p>
+                    <Link className="title" style={titleStyle} to={`/item/${item.id}`}>
+                        {item.title}
+                    </Link>
+                </p>
+            )}
+            <div className="subtext-palm">
+                {item.type !== 'job' && (
+                    <div className="details">
+                        <span className="name">
+                            <Link to={`/user/${item.user}`}>{item.user}</Link>
+                        </span>
+                        <span className="right">{item.points} ★</span>
+                    </div>
+                )}
+                <div className="details">
+                    {item.time_ago}
+                    {item.type !== 'job' && (
+                        <Link to={`/item/${item.id}`} className="comment-number">
+                            {' '}
+                            • {commentCount(item.comments_count)}
+                        </Link>
+                    )}
+                </div>
+            </div>
+            <div className="subtext-laptop">
+                {item.type !== 'job' && (
+                    <span>
+                        {item.points} points by <Link to={`/user/${item.user}`}>{item.user}</Link>
+                    </span>
+                )}
+                <span className={item.type !== 'job' ? 'item-details' : undefined}>
+                    {item.time_ago}
+                    {item.type !== 'job' && (
+                        <span>
+                            {' '}
+                            | <Link to={`/item/${item.id}`}>{commentCount(item.comments_count)}</Link>
+                        </span>
+                    )}
+                </span>
+            </div>
+        </div>
+    );
+}

--- a/src/features/feeds/commentCount.ts
+++ b/src/features/feeds/commentCount.ts
@@ -1,0 +1,6 @@
+export function commentCount(count: number): string {
+    if (count > 0) {
+        return `${count} ${count === 1 ? 'comment' : 'comments'}`;
+    }
+    return 'discuss';
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,14 @@
         "noFallthroughCasesInSwitch": true,
         "types": ["vite/client", "vite-plugin-pwa/client", "vitest/globals"]
     },
-    "include": ["src/api", "src/components", "src/context", "src/models", "src/App.tsx", "src/main.tsx", "vite.config.ts"]
+    "include": [
+        "src/api",
+        "src/components",
+        "src/context",
+        "src/features",
+        "src/models",
+        "src/App.tsx",
+        "src/main.tsx",
+        "vite.config.ts"
+    ]
 }


### PR DESCRIPTION
## Summary
Replaces the `Feed` placeholder from the foundation branch with a real React port of `FeedComponent`/`ItemComponent` under `src/features/feeds/`. Based on the Session 0 foundation branch (`devin/1786643787-react-foundation`), so the diff should be read against that base.

`Feed` takes `feedType` as a prop (routes in `App.tsx` already pass it) and reads `page` from `useParams`, replacing the Angular `route.data` + `route.params` subscriptions:

```tsx
const pageNum = page ? +page : 1;
useEffect(() => {
    fetchFeed(feedType, pageNum, signal)
        .then(stories => { setItems(stories); setListStart((pageNum - 1) * 30 + 1); window.scrollTo(0, 0); })
        .catch(() => setErrorMessage(`Could not load ${feedType} stories.`));
}, [feedType, pageNum]);
```

Behavior kept from Angular: the `listStart` rank offset feeding `<ol start>`, the scroll-to-top after load, the `errorMessage` string, the jobs-feed blurb, the `feedType !== 'new'` list guard, and Prev/More links gated on `listStart !== 1` / `items.length === 30`. The effect aborts its in-flight request on unmount/param change (no Angular equivalent — replaces subscription teardown).

`Item` renders the story row, reading `openLinkInNewTab`, `titleFontSize`, and `listSpacing` from `useSettings()`; the Angular `comment` pipe becomes `commentCount()` in `src/features/feeds/commentCount.ts`.

Two shared bits the feed depends on were also ported since nothing provides them yet: `src/components/Loader.tsx` and `src/components/ErrorMessage.tsx` (plus their SCSS). If a parallel session ports these too, keep one copy. Component SCSS files are copied verbatim from the Angular ones with the `@import` paths adjusted to `src/app/shared/scss`.

`tsconfig.json` now includes `src/features`.

## Screenshots
`/news/2` — ranks continue at 31 via `listStart`, Prev/More present:

![news page 2](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfNjlJWEpGTHJsang4elNBdyIsInVzZXJfaWQiOm51bGwsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZ182OUlYSkZMcmxqeDh6U0F3LzE4ZDFhYTFmLTQ1MTMtNGJiZi1hNGQ5LTY4OTg2NTQzYjY5NSIsImlhdCI6MTc4NjY0NDQwMywiZXhwIjoxNzg3MjQ5MjAzLCJmaWxlbmFtZSI6InNzX2MxNjAwNGRjLnBuZyJ9.4Fvzs0efFd8q_xzmTLm25AdzbCYku_VmtXU53om9ZkQ)

`/jobs/1` — jobs blurb, no points/comments row:

![jobs](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfNjlJWEpGTHJsang4elNBdyIsInVzZXJfaWQiOm51bGwsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZ182OUlYSkZMcmxqeDh6U0F3L2I0MDcxMjBhLWU5M2EtNGNjNi05ZTY4LWRkYjg5NzdmMjgzNiIsImlhdCI6MTc4NjY0NDQwNCwiZXhwIjoxNzg3MjQ5MjA0LCJmaWxlbmFtZSI6InNzXzQ2NWI3YTI5LnBuZyJ9.gVAeVaiB_UnyceHVJfrm8j7pTtmm5Cg8xb6iWuJi8ls)


Link to Devin session: https://app.devin.ai/sessions/ec6599a61f0c4575b37adab724485f87
Requested by: @charityquinn-cognition
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/634?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/634" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/angular2-hn/pull/634" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->