### PR TITLE
feature: port app chrome, shared UI and SCSS theme engine to React

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,8 +2,9 @@ import { lazy, Suspense, useEffect } from 'react';
 import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
 
 import Feed from './components/Feed';
-import Footer from './components/Footer';
-import Header from './components/Header';
+import Loader from './components/Loader';
+import Footer from './core/Footer';
+import Header from './core/Header';
 import { useSettings } from './context/SettingsContext';
 
 const ItemDetails = lazy(() => import('./components/ItemDetails'));
@@ -34,7 +35,7 @@ export default function App() {
             <div className="body-cover" />
             <div className="wrapper">
                 <Header />
-                <Suspense fallback={<div className="loading">Loading...</div>}>
+                <Suspense fallback={<Loader />}>
                     <Routes>
                         <Route path="/" element={<Navigate to="/news/1" replace />} />
                         <Route path="/news" element={<Navigate to="/news/1" replace />} />

--- a/src/components/ErrorMessage.tsx
+++ b/src/components/ErrorMessage.tsx
@@ -1,0 +1,23 @@
+interface ErrorMessageProps {
+    message: string;
+}
+
+export default function ErrorMessage({ message }: ErrorMessageProps) {
+    return (
+        <div className="error-section">
+            <div className="skull">
+                <div className="head">
+                    <div className="crack" />
+                </div>
+                <div className="mouth">
+                    <div className="teeth" />
+                </div>
+            </div>
+            <p className="strong">{message}</p>
+            <p>
+                If you are offline viewing, you&apos;ll need to visit this page with a network connection first before
+                it can work offline.
+            </p>
+        </div>
+    );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,5 +1,0 @@
-import Placeholder from './Placeholder';
-
-export default function Footer() {
-    return <Placeholder name="Footer" />;
-}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,0 @@
-import Placeholder from './Placeholder';
-
-export default function Header() {
-    return <Placeholder name="Header" />;
-}

--- a/src/components/Loader.tsx
+++ b/src/components/Loader.tsx
@@ -1,0 +1,7 @@
+export default function Loader() {
+    return (
+        <div className="loading-section">
+            <div className="loader">Loading...</div>
+        </div>
+    );
+}

--- a/src/core/Footer.tsx
+++ b/src/core/Footer.tsx
@@ -1,0 +1,12 @@
+export default function Footer() {
+    return (
+        <div id="footer">
+            <p>
+                Show this project some ❤ on{' '}
+                <a href="https://github.com/hdjirdeh/angular2-hn" target="_blank" rel="noopener noreferrer">
+                    GitHub
+                </a>
+            </p>
+        </div>
+    );
+}

--- a/src/core/Header.tsx
+++ b/src/core/Header.tsx
@@ -1,0 +1,56 @@
+import { NavLink } from 'react-router-dom';
+
+import { useSettings } from '../context/SettingsContext';
+import Settings from './Settings';
+
+const NAV_LINKS = [
+    { path: '/newest/1', label: 'new' },
+    { path: '/show/1', label: 'show' },
+    { path: '/ask/1', label: 'ask' },
+    { path: '/jobs/1', label: 'jobs' },
+];
+
+function scrollTop() {
+    window.scrollTo(0, 0);
+}
+
+export default function Header() {
+    const { settings, toggleSettings } = useSettings();
+
+    return (
+        <header>
+            <div id="header">
+                <NavLink
+                    to="/news/1"
+                    className={({ isActive }) => (isActive ? 'home-link active' : 'home-link')}
+                    onClick={scrollTop}
+                >
+                    <div className="logo-inner" />
+                    <img className="logo" src="/assets/images/logo.svg" alt="Logo" />
+                </NavLink>
+                <div className="header-text">
+                    <div className="left">
+                        <span className="header-nav">
+                            {NAV_LINKS.map(({ path, label }, index) => (
+                                <span key={path}>
+                                    {index > 0 && ' | '}
+                                    <NavLink
+                                        to={path}
+                                        className={({ isActive }) => (isActive ? 'active' : '')}
+                                        onClick={scrollTop}
+                                    >
+                                        {label}
+                                    </NavLink>
+                                </span>
+                            ))}
+                        </span>
+                    </div>
+                </div>
+                <div className="info">
+                    <img className="settings" src="/assets/images/cog.svg" alt="Settings" onClick={toggleSettings} />
+                </div>
+            </div>
+            {settings.showSettings && <Settings />}
+        </header>
+    );
+}

--- a/src/core/Settings.test.tsx
+++ b/src/core/Settings.test.tsx
@@ -1,0 +1,46 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { SettingsProvider } from '../context/SettingsContext';
+import Settings from './Settings';
+
+function renderSettings() {
+    return render(
+        <SettingsProvider>
+            <Settings />
+        </SettingsProvider>
+    );
+}
+
+describe('Settings', () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    it('persists the selected theme', () => {
+        renderSettings();
+
+        fireEvent.click(screen.getByLabelText('Black (AMOLED)'));
+
+        expect(screen.getByLabelText<HTMLInputElement>('Black (AMOLED)').checked).toBe(true);
+        expect(localStorage.getItem('theme')).toBe('amoledblack');
+    });
+
+    it('persists font size and list spacing', () => {
+        renderSettings();
+
+        fireEvent.change(screen.getByLabelText(/Font size:/), { target: { value: '20' } });
+        fireEvent.change(screen.getByLabelText(/List spacing:/), { target: { value: '5' } });
+
+        expect(localStorage.getItem('titleFontSize')).toBe('20');
+        expect(localStorage.getItem('listSpacing')).toBe('5');
+    });
+
+    it('persists the open links in a new tab preference', () => {
+        renderSettings();
+
+        fireEvent.click(screen.getByLabelText('Open links in a new tab'));
+
+        expect(localStorage.getItem('openLinkInNewTab')).toBe('true');
+    });
+});

--- a/src/core/Settings.tsx
+++ b/src/core/Settings.tsx
@@ -1,0 +1,80 @@
+import { useSettings } from '../context/SettingsContext';
+
+const THEMES = [
+    { value: 'default', label: 'Default' },
+    { value: 'night', label: 'Night' },
+    { value: 'amoledblack', label: 'Black (AMOLED)' },
+];
+
+export default function Settings() {
+    const { settings, toggleSettings, toggleOpenLinksInNewTab, setTheme, setFont, setSpacing } = useSettings();
+
+    return (
+        <div id="popup1" className="overlay">
+            <div className="popup">
+                <h1>Settings</h1>
+                <hr />
+                <span className="close" onClick={toggleSettings}>
+                    &times;
+                </span>
+                <div className="content">
+                    <div className="control-section">
+                        <h2>Links</h2>
+                        <label>
+                            <input
+                                type="checkbox"
+                                checked={settings.openLinkInNewTab}
+                                onChange={toggleOpenLinksInNewTab}
+                            />
+                            Open links in a new tab
+                        </label>
+                    </div>
+                    <div className="theme-controls">
+                        <div className="control-section">
+                            <h2>Select a theme</h2>
+                            {THEMES.map(({ value, label }) => (
+                                <div key={value}>
+                                    <label>
+                                        <input
+                                            name="theme"
+                                            type="radio"
+                                            value={value}
+                                            checked={settings.theme === value}
+                                            onChange={() => setTheme(value)}
+                                        />
+                                        {label}
+                                    </label>
+                                </div>
+                            ))}
+                        </div>
+                        <div className="control-section">
+                            <h2>Change Font</h2>
+                            <div>
+                                <label>
+                                    Font size:
+                                    <input
+                                        min="1"
+                                        type="number"
+                                        value={settings.titleFontSize}
+                                        onChange={(event) => setFont(event.target.value)}
+                                    />
+                                </label>
+                            </div>
+                            <div>
+                                <label>
+                                    List spacing:
+                                    <input
+                                        min="0"
+                                        type="number"
+                                        value={settings.listSpacing}
+                                        onChange={(event) => setSpacing(event.target.value)}
+                                    />
+                                </label>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,4 +1,4 @@
-@import "./app/shared/scss/themes";
+@use "./styles/index";
 
 html {
   height: 100%;

--- a/src/styles/_error-message.scss
+++ b/src/styles/_error-message.scss
@@ -1,0 +1,116 @@
+@use "sass:math";
+@use "./media" as *;
+@use "./theme_variables" as *;
+
+.error-section {
+  height: 300px;
+  margin: 200px;
+
+  @media #{$mobile-only} {
+    height: 0;
+    display: block;
+    position: relative;
+    margin: 30vh 0;
+  }
+
+  p {
+    text-align: center;
+    padding: 0 25px;
+
+    &.strong {
+      margin-top: 25px;
+      font-weight: bold;
+    }
+  }
+
+  .skull {
+    width: $skull-size;
+    height: $skull-size;
+    position: relative;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    margin: auto;
+
+    .head {
+      width: 100%;
+      height: 75%;
+      border-radius: 15% / 20%;
+      position: absolute;
+      top: 0;
+      left: 0;
+      &:before, &:after {
+        content: "";
+        position: absolute;
+        border-radius: 50%;
+        width: 20%;
+        height: 30%;
+        bottom: 10%;
+      }
+      &:before {
+        left: 10%;
+      }
+      &:after {
+        right: 10%;
+      }
+      .crack {
+        width: 10%;
+        height: 10%;
+        position: absolute;
+        top: 0;
+        right: 25%;
+        transform: skew(-15deg);
+
+        &:before {
+          content: "";
+          position: absolute;
+          top: 100%;
+          left: math.div($skull-size, 15);
+          border-right: math.div($skull-size, 20) solid transparent;
+          border-left: math.div($skull-size, 40) solid transparent;
+        }
+      }
+    }
+    .mouth {
+      width: 40%;
+      height: 25%;
+      position: absolute;
+      top: 75%;
+      left: 30%;
+      border-radius: 0 0 math.div($skull-size, 10) math.div($skull-size, 10);
+      &:before {
+        content: "";
+        position: absolute;
+        width: 15%;
+        height: 50%;
+        border-radius: 50% / 30%;
+        left: 42.5%;
+        top: -25%;
+      }
+      .teeth {
+        position: absolute;
+        bottom: 0;
+        left: 45%;
+        width: 10%;
+        height: 50%;
+        margin-bottom: -5%;
+        border-radius: 50% / 20%;
+
+        &:before, &:after {
+          content: "";
+          position: absolute;
+          width: 100%;
+          height: 100%;
+          border-radius: 50% / 20%;
+        }
+        &:before {
+          left: -250%;
+        }
+        &:after {
+          right: -250%;
+        }
+      }
+    }
+  }
+}

--- a/src/styles/_footer.scss
+++ b/src/styles/_footer.scss
@@ -1,0 +1,23 @@
+@use "./media" as *;
+@use "./theme_variables" as *;
+
+#footer {
+  position: relative;
+  padding: 10px;
+  height: 60px;
+  letter-spacing: 0.7px;
+  text-align: center;
+
+  a {
+  	font-weight: bold;
+  	text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  @media #{$mobile-only} {
+    display: none;
+  }
+}

--- a/src/styles/_header.scss
+++ b/src/styles/_header.scss
@@ -51,25 +51,27 @@
   }
 }
 
-h1 {
-  font-weight: normal;
-  display: inline-block;
-  vertical-align:middle;
-  margin: 0;
-  font-size: 16px;
+#header {
+  h1 {
+    font-weight: normal;
+    display: inline-block;
+    vertical-align: middle;
+    margin: 0;
+    font-size: 16px;
 
-  a {
-    color: #fff;
-    text-decoration: none;
+    a {
+      color: #fff;
+      text-decoration: none;
+    }
   }
-}
 
-.name {
-  margin-right: 30px;
-  margin-bottom: 2px;
+  .name {
+    margin-right: 30px;
+    margin-bottom: 2px;
 
-  @media #{$mobile-only} {
-    display: none;
+    @media #{$mobile-only} {
+      display: none;
+    }
   }
 }
 

--- a/src/styles/_header.scss
+++ b/src/styles/_header.scss
@@ -1,0 +1,149 @@
+@use "./media" as *;
+@use "./theme_variables" as *;
+
+#header {
+  color: #fff;
+  padding: 6px 0;
+  line-height: 18px;
+  vertical-align: middle;
+  position: relative;
+  z-index: 1;
+  width: 100%;
+
+  @media #{$mobile-only} {
+    height: 50px;
+    position: fixed;
+    top: 0;
+  }
+
+  a {
+    display: inline;
+  }
+}
+
+.home-link {
+  width: 50px;
+  height: 66px;
+}
+
+.logo-inner {
+  width: 32px;
+  position: absolute;
+  left: 17px;
+  top: 18px;
+  z-index: -1;
+  height: 32px;
+  border-radius: 50%;
+
+  @media #{$mobile-only} {
+    left: 16px;
+    top: 12px;
+  }
+}
+
+.logo {
+  width: 50px;
+  padding: 3px 8px 0;
+
+  @media #{$mobile-only} {
+    width: 45px;
+    padding: 0 0 0 10px;
+  }
+}
+
+h1 {
+  font-weight: normal;
+  display: inline-block;
+  vertical-align:middle;
+  margin: 0;
+  font-size: 16px;
+
+  a {
+    color: #fff;
+    text-decoration: none;
+  }
+}
+
+.name {
+  margin-right: 30px;
+  margin-bottom: 2px;
+
+  @media #{$mobile-only} {
+    display: none;
+  }
+}
+
+.header-text {
+  position: absolute;
+  width: inherit;
+  height: 20px;
+  left: 10px;
+  top: 27px;
+  z-index: -1;
+
+  @media #{$mobile-only} {
+    top: 22px;
+  }
+}
+
+.left {
+  position: absolute;
+  left: 60px;
+  font-size: 16px;
+
+  @media #{$mobile-only} {
+    width: 100%;
+    left: 0;
+  }
+}
+
+.header-nav {
+  display: inline-block;
+  margin-left: 20px;
+
+  @media #{$mobile-only} {
+    margin-left: 60px;
+  }
+
+  a {
+    color: hsla(0,0%,100%,.9);
+    text-decoration: none;
+    margin: 0 5px;
+    letter-spacing: 1.8px;
+
+    &:hover {
+      color: #fff;
+    }
+  }
+
+  .active {
+    color: #fff;
+  }
+}
+
+.info {
+  position: absolute;
+  top: 0;
+  right: 20px;
+  height: 100%;
+
+  @media #{$mobile-only} {
+    right: 10px;
+  }
+
+  img {
+    opacity: 0.8;
+    width: 25px;
+    margin-top: 21.5px;
+    display: block;
+
+    &:hover {
+      opacity: 1;
+      cursor: pointer;
+    }
+
+    @media #{$mobile-only} {
+      margin-top: 15px;
+    }
+  }
+}

--- a/src/styles/_layout.scss
+++ b/src/styles/_layout.scss
@@ -1,0 +1,24 @@
+@use "./media" as *;
+@use "./theme_variables" as *;
+
+.body-cover {
+  width: 100%;
+  z-index: 0;
+  position: fixed;
+  height: 100%;
+}
+
+.wrapper {
+  position: relative;
+  width: 85%;
+  min-height: 80px;
+  margin: 0 auto;
+  font-family: "HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
+  font-size: 15px;
+  height: 100%;
+  line-height: 1.3;
+
+   @media #{$mobile-only} {
+    width: 100%;
+  }
+}

--- a/src/styles/_loader.scss
+++ b/src/styles/_loader.scss
@@ -1,0 +1,109 @@
+@use "./media" as *;
+@use "./theme_variables" as *;
+
+.loader {
+  -webkit-animation: load1 1s infinite ease-in-out;
+  animation: load1 1s infinite ease-in-out;
+  width: 1em;
+  height: 4em;
+  &:before, &:after {
+    -webkit-animation: load1 1s infinite ease-in-out;
+    animation: load1 1s infinite ease-in-out;
+    width: 1em;
+    height: 4em;
+  }
+  &:before, &:after {
+    position: absolute;
+    top: 0;
+    content: '';
+  }
+  &:before {
+    left: -1.5em;
+    -webkit-animation-delay: -0.32s;
+    animation-delay: -0.32s;
+  }
+}
+
+.loading-section {
+    height: 70px;
+    margin: 40px 0 40px 40px;
+
+  @media #{$mobile-only} {
+    display: block;
+    position: relative;
+    margin: 45vh 0;
+  }
+}
+
+.loader {
+  text-indent: -9999em;
+  margin: 20px 20px;
+  position: relative;
+  font-size: 11px;
+  -webkit-transform: translateZ(0);
+  -ms-transform: translateZ(0);
+  transform: translateZ(0);
+  -webkit-animation-delay: -0.16s;
+  animation-delay: -0.16s;
+  &:after {
+    left: 1.5em;
+  }
+
+  @media #{$mobile-only} {
+    margin: 20px auto;
+  }
+}
+
+@-webkit-keyframes load1 {
+  0%,
+    80%,
+    100% {
+    box-shadow: 0 0;
+    height: 2em;
+  }
+  40% {
+    box-shadow: 0 -2em;
+    height: 3em;
+  }
+}
+
+@keyframes load1 {
+  0%,
+    80%,
+    100% {
+    box-shadow: 0 0;
+    height: 2em;
+  }
+  40% {
+    box-shadow: 0 -2em;
+    height: 3em;
+  }
+}
+
+@media #{$mobile-only} {
+  @-webkit-keyframes load1 {
+    0%,
+      80%,
+      100% {
+      box-shadow: 0 0;
+      height: 4em;
+    }
+    40% {
+      box-shadow: 0 -2em;
+      height: 5em;
+    }
+  }
+
+  @keyframes load1 {
+    0%,
+      80%,
+      100% {
+      box-shadow: 0 0;
+      height: 3em;
+    }
+    40% {
+      box-shadow: 0 -2em;
+      height: 4em;
+    }
+  }
+}

--- a/src/styles/_media.scss
+++ b/src/styles/_media.scss
@@ -1,0 +1,3 @@
+$mobile-only: "only screen and (max-width : 768px)";
+$laptop-only: "only screen and (min-width : 769px)";
+$tablet-only: "only screen and (max-width : 1024px)";

--- a/src/styles/_settings.scss
+++ b/src/styles/_settings.scss
@@ -1,0 +1,74 @@
+@use "./media" as *;
+@use "./theme_variables" as *;
+
+.overlay {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: rgba(0, 0, 0, 0.7);
+  opacity: 1;
+  z-index: 1;
+}
+
+.popup {
+  margin: 70px auto;
+  padding: 30px;
+  border-radius: 5px;
+  width: 30%;
+  position: relative;
+  h1 {
+    margin-top: 0;
+    margin-bottom: 0px;
+    color: #fff;
+    text-align: center;
+    letter-spacing: 1px;
+  }
+  h2 {
+    padding-top: 10px;
+  }
+  hr {
+    width: 40%;
+    margin-bottom: 20px;
+  }
+  .close {
+    position: absolute;
+    top: 12px;
+    right: 20px;
+    font-size: 30px;
+    font-weight: bold;
+    text-decoration: none;
+    color: rgba(255,255,255,0.8);
+    &:hover {
+      color: #fff;
+      cursor: pointer;
+    }
+  }
+  .content {
+    max-height: 30%;
+    color: #fff;
+    letter-spacing: 1px;
+    overflow: auto;
+  }
+  input[type=number] {
+      display: block;
+      width: 80%;
+      height: 20px;
+      margin-bottom: 15px;
+      border-radius: 5px;
+      padding: 2px;
+  }
+}
+
+.control-section {
+    margin-bottom: 15px;
+    padding-bottom: 15px;
+    border-bottom: 1px solid white;
+}
+
+@media screen and (max-width: 700px) {
+  .box, .popup {
+    width: 70%;
+  }
+}

--- a/src/styles/_theme_variables.scss
+++ b/src/styles/_theme_variables.scss
@@ -1,0 +1,37 @@
+$skull-size: 200px;
+
+// -------------------------------------------------------------------------------------------
+// Theme Engine
+// -------------------------------------------------------------------------------------------
+
+// Day theme colors
+$theme-day-body-background-color: #fff;
+$theme-day-wrapper-background-color: #f5f5f5;
+$theme-day-wrapper-mobile-background-color: #fff;
+$theme-day-text-color: #000;
+$theme-day-subtext-color: #696969;
+$theme-day-secondary-color: #b92b27;
+$theme-day-header-background-color: $theme-day-secondary-color;
+$theme-day-logo-inner: #fff;
+
+// Day theme extras
+$theme-day-border: 2px solid #b92b27;
+
+// Night theme colors
+$theme-night-body-background-color: #37474F;
+$theme-night-wrapper-background-color: #263238;
+$theme-night-wrapper-mobile-background-color: $theme-night-wrapper-background-color;
+$theme-night-text-color: rgba(255, 255, 255, 0.7);
+$theme-night-subtext-color: #999;
+$theme-night-secondary-color: #00c0ff;
+$theme-night-header-background-color: #263238;
+$theme-night-logo-inner: $theme-night-header-background-color;
+
+// Night theme extras
+$theme-night-border: 2px solid #00c0ff;
+
+// Black theme colors
+$theme-amoledblack-body-background-color: #000;
+$theme-amoledblack-text-color: rgba(255, 255, 255, 0.75);
+$theme-amoledblack-subtext-color: rgba(255, 255, 255, 0.5);
+$theme-amoledblack-secondary-color: rgba(255, 255, 255, 0.6);

--- a/src/styles/_themes.scss
+++ b/src/styles/_themes.scss
@@ -1,0 +1,247 @@
+@use "sass:color";
+@use "sass:math";
+@use "./media" as *;
+@use "./theme_variables" as *;
+
+/* ----------------------------------
+
+  Want a new theme? Add your new theme variables here!
+
+---------------------------------- */
+
+@mixin theme(
+  $name,
+  $body-background-color,
+  $wrapper-background-color,
+  $wrapper-mobile-background-color,
+  $wrapper-color,
+  $item-a-color,
+  $item-a-visited-color,
+  $header-background-color,
+  $subtext-color,
+  $secondary-link-color,
+  $logo-inner-color,
+  $border
+) {
+  .#{$name} {
+    .body-cover {
+      background: $body-background-color;
+
+      @media #{$mobile-only} {
+       background: $wrapper-mobile-background-color;
+      }
+    }
+
+    .wrapper {
+      background: $wrapper-background-color;
+      color: $wrapper-color;
+
+      @media #{$mobile-only} {
+       background: $wrapper-mobile-background-color;
+      }
+
+      a {
+        color: $item-a-color;
+
+        &:visited {
+            color: $item-a-visited-color;
+        }
+      }
+
+      #header {
+        background: $header-background-color;
+        border-bottom: $border;
+      }
+
+      .logo-inner {
+        background: $logo-inner-color;
+      }
+
+      .nav {
+        a {
+          color: $secondary-link-color;
+
+          @media #{$mobile-only} {
+            color: $secondary-link-color;
+          }
+        }
+      }
+
+      #footer {
+        border-top: $border;
+
+        a {
+          color: $secondary-link-color;
+        }
+      }
+
+      .subtext, .subtext-palm, .subtext-laptop, .domain, .meta, .deleted-meta{
+        color: $subtext-color;
+
+        a {
+          color: $secondary-link-color;
+        }
+      }
+
+      .popup {
+        background: $header-background-color;
+      }
+
+      .item-header {
+        border-bottom: $border;
+
+        @media #{$mobile-only} {
+          background: $wrapper-mobile-background-color;
+        }
+      }
+
+      .pollContent {
+        .pollBar {
+          background: $secondary-link-color;
+        }
+      }
+
+      .loader {
+        color: $secondary-link-color;
+        background: $secondary-link-color;
+
+        &:before, &:after {
+          background: $secondary-link-color;
+        }
+      }
+
+      .job-header {
+        @media #{$mobile-only} {
+          border-bottom: $border;
+        }
+      }
+
+      .back-button {
+        @media #{$mobile-only} {
+          border-top: .3rem solid $secondary-link-color;
+          border-right: .3rem solid $secondary-link-color;
+        }
+      }
+
+      .error-section {
+        .skull {
+          .head {
+            background-color: $secondary-link-color;
+
+            &:before, &:after {
+              background-color: $wrapper-background-color;
+
+              @media #{$mobile-only} {
+                background-color: $wrapper-mobile-background-color;
+              }
+            }
+
+            .crack {
+              background-color: $wrapper-background-color;
+
+              @media #{$mobile-only} {
+                background-color: $wrapper-mobile-background-color;
+              }
+
+              &:before {
+                border-top: math.div($skull-size, 8) solid $wrapper-background-color;
+
+                @media #{$mobile-only} {
+                  border-top: math.div($skull-size, 8) solid $wrapper-mobile-background-color;
+                }
+              }
+            }
+          }
+
+          .mouth {
+            background-color: $secondary-link-color;
+
+            &:before {
+              background-color: $wrapper-background-color;
+
+              @media #{$mobile-only} {
+                background-color: $wrapper-mobile-background-color;
+              }
+            }
+          }
+
+          .teeth {
+            background-color: $wrapper-background-color;
+
+            @media #{$mobile-only} {
+              background-color: $wrapper-mobile-background-color;
+            }
+
+            &:before, &:after {
+              background-color: $wrapper-background-color;
+
+              @media #{$mobile-only} {
+                background-color: $wrapper-mobile-background-color;
+              }
+            }
+          }
+        }
+      }
+
+      .main-details {
+        .name {
+          color: $secondary-link-color;
+        }
+        .right {
+          color: $secondary-link-color;
+        }
+      }
+    }
+  }
+}
+
+@include theme(
+  default,
+  $theme-day-body-background-color,
+  $theme-day-wrapper-background-color,
+  $theme-day-wrapper-mobile-background-color,
+  $theme-day-text-color,
+  $theme-day-text-color,
+  $theme-day-subtext-color,
+  $theme-day-header-background-color,
+  $theme-day-subtext-color,
+  $theme-day-secondary-color,
+  $theme-day-logo-inner,
+  $theme-day-border
+);
+
+@include theme(
+  night,
+  $theme-night-body-background-color,
+  $theme-night-wrapper-background-color,
+  $theme-night-wrapper-mobile-background-color,
+  $theme-night-text-color,
+  $theme-night-text-color,
+  $theme-night-subtext-color,
+  $theme-night-header-background-color,
+  $theme-night-subtext-color,
+  $theme-night-secondary-color,
+  $theme-night-logo-inner,
+  $theme-night-border
+);
+
+@include theme(
+  amoledblack,
+  $theme-amoledblack-body-background-color,
+  $theme-amoledblack-body-background-color,
+  $theme-amoledblack-body-background-color,
+  $theme-amoledblack-text-color,
+  $theme-amoledblack-text-color,
+  color.adjust($theme-amoledblack-text-color, $lightness: -33%),
+  $theme-amoledblack-body-background-color,
+  $theme-amoledblack-subtext-color,
+  $theme-amoledblack-secondary-color,
+  $theme-amoledblack-body-background-color,
+  $theme-amoledblack-secondary-color
+);
+
+/* ----------------------------------
+
+  Include your new theme here as well as the settings component
+
+---------------------------------- */

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -1,0 +1,7 @@
+@use "./themes";
+@use "./layout";
+@use "./header";
+@use "./footer";
+@use "./settings";
+@use "./error-message";
+@use "./loader";

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,0 +1,13 @@
+if (!window.matchMedia) {
+    window.matchMedia = (media: string): MediaQueryList =>
+        ({
+            media,
+            matches: false,
+            onchange: null,
+            addEventListener: () => undefined,
+            removeEventListener: () => undefined,
+            addListener: () => undefined,
+            removeListener: () => undefined,
+            dispatchEvent: () => false,
+        }) as MediaQueryList;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,15 @@
         "noFallthroughCasesInSwitch": true,
         "types": ["vite/client", "vite-plugin-pwa/client", "vitest/globals"]
     },
-    "include": ["src/api", "src/components", "src/context", "src/models", "src/App.tsx", "src/main.tsx", "vite.config.ts"]
+    "include": [
+        "src/api",
+        "src/components",
+        "src/context",
+        "src/core",
+        "src/models",
+        "src/App.tsx",
+        "src/main.tsx",
+        "src/test-setup.ts",
+        "vite.config.ts"
+    ]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -36,5 +36,6 @@ export default defineConfig({
     test: {
         environment: 'jsdom',
         globals: true,
+        setupFiles: ['./src/test-setup.ts'],
     },
 });


### PR DESCRIPTION
## Summary

Ports the Angular `CoreModule` chrome (`HeaderComponent`, `FooterComponent`, `SettingsComponent`), the two shared presentational components, and the SCSS theme engine onto Session 0's React/Vite foundation. Based on `devin/1786643787-react-foundation`, replacing its `Header`/`Footer` placeholders.

- `src/core/{Header,Footer,Settings}.tsx` — `routerLink` + `routerLinkActive` become `NavLink` with a callback `className`; the nav's `|` separators come from the item index instead of literal template text. Settings is fully controlled off Session 0's `useSettings()` (`toggleSettings`, `toggleOpenLinksInNewTab`, `setTheme`, `setFont`, `setSpacing`) — Angular's template refs (`#default`, `#titleFont`) and `(keyup)` handlers become `checked`/`value` + `onChange`. Theme radios are rendered from a `THEMES` array rather than three duplicated blocks.
- `src/components/{ErrorMessage,Loader}.tsx` — direct JSX ports; `@Input() message` becomes a prop. `Loader` now backs `App`'s `Suspense` fallback in place of the plain "Loading..." div.
- `src/styles/` — the theme engine (`_themes.scss` with the `theme` mixin for Default/Night/AMOLED Black, `_theme_variables`, `_media`) plus the per-component stylesheets, all imported globally through `src/styles.scss`. Kept global rather than CSS Modules because the engine styles descendants by class name (`.night .wrapper .subtext { … }`), which module-scoped hashing would break. Theme switching still works by `App` rendering `<div className={settings.theme}>` around the tree.
  - Modernized while moving: `@import` → `@use`, `$skull-size / 8` → `math.div(...)`, `darken($c, 33%)` → `color.adjust($c, $lightness: -33%)`, so the build is deprecation-warning free.
  - Angular's per-component style encapsulation is gone, so the header's leftover bare `h1 { display: inline-block; font-size: 16px }` rule leaked into the settings popup title (the popup renders inside `<header>`); it is now nested under `#header`.
- `src/core/Settings.test.tsx` covers theme/font/spacing/new-tab persistence to `localStorage`; `src/test-setup.ts` stubs `window.matchMedia`, which jsdom lacks and `SettingsProvider` calls on mount.

The Angular sources under `src/app/` are left untouched — the remaining components still import `src/app/shared/scss/*`, so removal belongs to the cleanup session.

Verified with `npm run lint`, `npm run build`, `npm test`, and in the browser (theme switch persists, nav active state, popup open/close).

| Default | Night | AMOLED Black |
| --- | --- | --- |
| ![default](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfNjlJWEpGTHJsang4elNBdyIsInVzZXJfaWQiOm51bGwsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZ182OUlYSkZMcmxqeDh6U0F3LzUwNWViN2YzLTdkYTctNGM1Ni1iOTQ3LTc4OWMyYTU2MTViZiIsImlhdCI6MTc4NjY0NDU1OCwiZXhwIjoxNzg3MjQ5MzU4LCJmaWxlbmFtZSI6InRoZW1lLWRlZmF1bHQucG5nIn0.zGp_7Uey6nwGaU_nKM1P-uLRV4EQyRpP2Jb-P0Zk3Qc) | ![night](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfNjlJWEpGTHJsang4elNBdyIsInVzZXJfaWQiOm51bGwsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZ182OUlYSkZMcmxqeDh6U0F3Lzk0YzA0Y2I0LTNjZjEtNGUzOS1hNzQ2LWI3MThkYTg2NGQ5OCIsImlhdCI6MTc4NjY0NDU1OCwiZXhwIjoxNzg3MjQ5MzU4LCJmaWxlbmFtZSI6InRoZW1lLW5pZ2h0LnBuZyJ9.grQjJWGY9_1fAY4OU7VIhC0jjLJSgpX5drq6FcY5hqg) | ![amoled](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfNjlJWEpGTHJsang4elNBdyIsInVzZXJfaWQiOm51bGwsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZ182OUlYSkZMcmxqeDh6U0F3L2VkMmIxMGYzLTVlYWQtNGQ0Mi1hYTgyLTExMTBmNGI0NDI0MiIsImlhdCI6MTc4NjY0NDU1OSwiZXhwIjoxNzg3MjQ5MzU5LCJmaWxlbmFtZSI6InRoZW1lLWFtb2xlZGJsYWNrLnBuZyJ9.NNNlj5HBjdtEDwQpjGTYNecaEYh2iYzHDLp1rE3pFU0) |

Settings popup and the ported shared components (`ErrorMessage` skull, `Loader`):

![settings](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfNjlJWEpGTHJsang4elNBdyIsInVzZXJfaWQiOm51bGwsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZ182OUlYSkZMcmxqeDh6U0F3L2U3ZjE2NjA4LTVmYzAtNGM1NC05NmE0LTIzZDc4YmY1MjExZiIsImlhdCI6MTc4NjY0NDU1OSwiZXhwIjoxNzg3MjQ5MzU5LCJmaWxlbmFtZSI6InNldHRpbmdzLXBvcHVwLnBuZyJ9.4ovr1v9nu6q4bX9Q-7BgwRPG84cI_kRLAxJX6RpVvhM)
![shared](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfNjlJWEpGTHJsang4elNBdyIsInVzZXJfaWQiOm51bGwsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZ182OUlYSkZMcmxqeDh6U0F3LzVjM2I2MWRjLTE3NjctNDVjYS05MmQxLTU0MmM4MDE2N2QxMyIsImlhdCI6MTc4NjY0NDU1OSwiZXhwIjoxNzg3MjQ5MzU5LCJmaWxlbmFtZSI6InNoYXJlZC1jb21wb25lbnRzLnBuZyJ9.DGKjCUa8jiNiuDRAFs0dY0AaLbcASF48SfQjgR9nWlY)


Link to Devin session: https://app.devin.ai/sessions/9530cfe09dd741dab5fb6ae1f49438a6
Requested by: @charityquinn-cognition
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/637?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/637" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/angular2-hn/pull/637" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->