### PR TITLE
feature: React port of the Angular feeds view (Phase 2a)

### DIFF
--- a/react-app/e2e/feed.spec.ts
+++ b/react-app/e2e/feed.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test } from '@playwright/test';
+import type { Page } from '@playwright/test';
+
+function story(id: number) {
+    return {
+        id,
+        title: `Stubbed story ${id}`,
+        points: id,
+        user: 'pg',
+        time: 0,
+        time_ago: '1 hour ago',
+        type: 'link',
+        url: `https://example.com/${id}`,
+        domain: 'example.com',
+        comments: [],
+        comments_count: id,
+    };
+}
+
+async function stubFeed(page: Page, count: number) {
+    await page.route('**/node-hnapi.herokuapp.com/**', async (route) => {
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify(Array.from({ length: count }, (_, i) => story(i + 1))),
+        });
+    });
+}
+
+test('renders the news feed with numbered stories', async ({ page }) => {
+    await stubFeed(page, 30);
+    await page.goto('/news/1');
+
+    await expect(page.locator('ol')).toHaveAttribute('start', '1');
+    await expect(page.locator('li.post')).toHaveCount(30);
+    await expect(page.locator('li.post').first().locator('.title')).toHaveText('Stubbed story 1');
+    await expect(page.locator('li.post').first().locator('.domain')).toHaveText('(example.com)');
+    await expect(page.locator('.nav .prev')).toHaveCount(0);
+});
+
+test('navigates to the next page with the More link', async ({ page }) => {
+    await stubFeed(page, 30);
+    await page.goto('/news/1');
+
+    await page.locator('.nav .more').click();
+    await expect(page).toHaveURL(/\/news\/2$/);
+    await expect(page.locator('ol')).toHaveAttribute('start', '31');
+    await expect(page.locator('.nav .prev')).toHaveText('‹ Prev');
+});
+
+test('shows the job header on the jobs feed', async ({ page }) => {
+    await stubFeed(page, 5);
+    await page.goto('/jobs/1');
+
+    await expect(page.locator('.job-header')).toContainText('Y Combinator');
+    await expect(page.locator('ol')).not.toHaveClass(/list-margin/);
+});
+
+test('shows an error message when the feed request fails', async ({ page }) => {
+    await page.route('**/node-hnapi.herokuapp.com/**', (route) => route.fulfill({ status: 500, body: 'nope' }));
+    await page.goto('/news/1');
+
+    await expect(page.locator('.error-section')).toContainText('Could not load news stories.');
+});

--- a/react-app/src/components/Item.test.tsx
+++ b/react-app/src/components/Item.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+import { Item } from './Item';
+import { SettingsProvider } from '../context/SettingsProvider';
+import type { Story } from '../models';
+
+const baseStory: Story = {
+    id: 1,
+    title: 'A linked story',
+    points: 42,
+    user: 'pg',
+    time: 0,
+    time_ago: '2 hours ago',
+    type: 'story',
+    url: 'https://example.com/story',
+    domain: 'example.com',
+    comments: [],
+    comments_count: 3,
+};
+
+function renderItem(item: Story) {
+    return render(
+        <MemoryRouter>
+            <SettingsProvider>
+                <div className="item-block">
+                    <Item item={item} />
+                </div>
+            </SettingsProvider>
+        </MemoryRouter>
+    );
+}
+
+describe('Item', () => {
+    it('links the title externally when the story has a url', () => {
+        const { container } = renderItem(baseStory);
+        const title = screen.getByRole('link', { name: 'A linked story' });
+        expect(title).toHaveAttribute('href', 'https://example.com/story');
+        expect(title).not.toHaveAttribute('target');
+        expect(container.querySelector('.domain')).toHaveTextContent('(example.com)');
+    });
+
+    it('links the title to the item page when there is no url', () => {
+        renderItem({ ...baseStory, url: 'item?id=1', domain: undefined });
+        expect(screen.getByRole('link', { name: 'A linked story' })).toHaveAttribute('href', '/item/1');
+    });
+
+    it('renders points, user and comment count for stories', () => {
+        const { container } = renderItem(baseStory);
+        expect(container.querySelector('.subtext-laptop')).toHaveTextContent('42 points by pg');
+        expect(screen.getAllByRole('link', { name: /3 comments/ }).length).toBe(2);
+        expect(container.querySelector('.subtext-palm .right')).toHaveTextContent('42 ★');
+    });
+
+    it('hides points, user and comments for job items', () => {
+        const { container } = renderItem({ ...baseStory, type: 'job', comments_count: 0 });
+        expect(container.querySelector('.subtext-laptop')).not.toHaveTextContent('points by');
+        expect(screen.queryByRole('link', { name: /discuss|comment/ })).toBeNull();
+        expect(container.querySelector('.subtext-palm')).toHaveTextContent('2 hours ago');
+    });
+});

--- a/react-app/src/components/Item.tsx
+++ b/react-app/src/components/Item.tsx
@@ -1,0 +1,71 @@
+import { Link } from 'react-router-dom';
+import type { Story } from '../models';
+import { useSettings } from '../context/settingsContext';
+import { commentCount } from '../utils/comment';
+import { hasUrl } from '../utils/hasUrl';
+
+export function Item({ item }: { item: Story }) {
+    const { settings } = useSettings();
+    const titleStyle = { fontSize: `${settings.titleFontSize}px` };
+    const isJob = item.type === 'job';
+
+    return (
+        <div style={{ marginBottom: `${settings.listSpacing}px` }}>
+            {hasUrl(item.url) ? (
+                <p>
+                    <a
+                        className="title"
+                        style={titleStyle}
+                        href={item.url}
+                        target={settings.openLinkInNewTab ? '_blank' : undefined}
+                        rel={settings.openLinkInNewTab ? 'noopener' : undefined}
+                    >
+                        {item.title}
+                    </a>
+                    {item.domain && <span className="domain">({item.domain})</span>}
+                </p>
+            ) : (
+                <p>
+                    <Link className="title" style={titleStyle} to={`/item/${item.id}`}>
+                        {item.title}
+                    </Link>
+                </p>
+            )}
+            <div className="subtext-palm">
+                {!isJob && (
+                    <div className="details">
+                        <span className="name">
+                            <Link to={`/user/${item.user}`}>{item.user}</Link>
+                        </span>
+                        <span className="right">{item.points} ★</span>
+                    </div>
+                )}
+                <div className="details">
+                    {item.time_ago}
+                    {!isJob && (
+                        <Link to={`/item/${item.id}`} className="comment-number">
+                            {' '}
+                            • {commentCount(item.comments_count)}
+                        </Link>
+                    )}
+                </div>
+            </div>
+            <div className="subtext-laptop">
+                {!isJob && (
+                    <span>
+                        {item.points} points by <Link to={`/user/${item.user}`}>{item.user}</Link>
+                    </span>
+                )}
+                <span className={isJob ? undefined : 'item-details'}>
+                    {item.time_ago}
+                    {!isJob && (
+                        <span>
+                            {' '}
+                            | <Link to={`/item/${item.id}`}>{commentCount(item.comments_count)}</Link>
+                        </span>
+                    )}
+                </span>
+            </div>
+        </div>
+    );
+}

--- a/react-app/src/pages/Feed.test.tsx
+++ b/react-app/src/pages/Feed.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Feed } from './Feed';
+import { SettingsProvider } from '../context/SettingsProvider';
+import * as api from '../services/hackernewsApi';
+import type { Story } from '../models';
+
+function story(id: number): Story {
+    return {
+        id,
+        title: `Story ${id}`,
+        points: id,
+        user: 'pg',
+        time: 0,
+        time_ago: '1 hour ago',
+        type: 'story',
+        url: `https://example.com/${id}`,
+        domain: 'example.com',
+        comments: [],
+        comments_count: id,
+    };
+}
+
+function renderFeed(feedType: string, path: string) {
+    return render(
+        <MemoryRouter initialEntries={[path]}>
+            <SettingsProvider>
+                <Routes>
+                    <Route path={`/${feedType}/:page`} element={<Feed feedType={feedType} />} />
+                </Routes>
+            </SettingsProvider>
+        </MemoryRouter>
+    );
+}
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe('Feed', () => {
+    it('shows the loader then the stories', async () => {
+        vi.spyOn(api, 'fetchFeed').mockResolvedValue([story(1), story(2)]);
+        const { container } = renderFeed('news', '/news/1');
+
+        expect(container.querySelector('.loader')).toBeInTheDocument();
+        expect(await screen.findByText('Story 1')).toBeInTheDocument();
+        expect(container.querySelector('ol')).toHaveAttribute('start', '1');
+        expect(container.querySelector('ol')).toHaveClass('list-margin');
+    });
+
+    it('shows an error message when the request fails', async () => {
+        vi.spyOn(api, 'fetchFeed').mockRejectedValue(new Error('boom'));
+        renderFeed('news', '/news/1');
+        expect(await screen.findByText('Could not load news stories.')).toBeInTheDocument();
+    });
+
+    it('computes listStart and renders prev/more navigation', async () => {
+        vi.spyOn(api, 'fetchFeed').mockResolvedValue(Array.from({ length: 30 }, (_, i) => story(i + 1)));
+        const { container } = renderFeed('news', '/news/2');
+
+        await screen.findByText('Story 1');
+        expect(container.querySelector('ol')).toHaveAttribute('start', '31');
+        expect(screen.getByRole('link', { name: '‹ Prev' })).toHaveAttribute('href', '/news/1');
+        expect(screen.getByRole('link', { name: 'More ›' })).toHaveAttribute('href', '/news/3');
+    });
+
+    it('hides navigation links on the first page with fewer than 30 items', async () => {
+        vi.spyOn(api, 'fetchFeed').mockResolvedValue([story(1)]);
+        renderFeed('news', '/news/1');
+        await screen.findByText('Story 1');
+        expect(screen.queryByRole('link', { name: '‹ Prev' })).toBeNull();
+        expect(screen.queryByRole('link', { name: 'More ›' })).toBeNull();
+    });
+
+    it('renders the job header without list-margin for the jobs feed', async () => {
+        vi.spyOn(api, 'fetchFeed').mockResolvedValue([{ ...story(1), type: 'job' }]);
+        const { container } = renderFeed('jobs', '/jobs/1');
+
+        await screen.findByText('Story 1');
+        expect(container.querySelector('.job-header')).toBeInTheDocument();
+        expect(container.querySelector('ol')).not.toHaveClass('list-margin');
+    });
+
+    it('aborts the in-flight request on unmount', async () => {
+        const spy = vi.spyOn(api, 'fetchFeed').mockResolvedValue([story(1)]);
+        const { unmount } = renderFeed('news', '/news/1');
+        await waitFor(() => expect(spy).toHaveBeenCalled());
+        const signal = spy.mock.calls[0][2] as AbortSignal;
+        unmount();
+        expect(signal.aborted).toBe(true);
+    });
+});

--- a/react-app/src/pages/Feed.tsx
+++ b/react-app/src/pages/Feed.tsx
@@ -1,12 +1,75 @@
-import { useParams } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import type { Story } from '../models';
+import { fetchFeed } from '../services/hackernewsApi';
+import { Loader } from '../components/Loader';
+import { ErrorMessage } from '../components/ErrorMessage';
+import { Item } from '../components/Item';
 
 export function Feed({ feedType }: { feedType: string }) {
     const { page } = useParams();
+    const pageNum = page ? +page : 1;
+    const [items, setItems] = useState<Story[] | null>(null);
+    const [errorMessage, setErrorMessage] = useState('');
+
+    useEffect(() => {
+        const controller = new AbortController();
+        setItems(null);
+        setErrorMessage('');
+
+        fetchFeed(feedType, pageNum, controller.signal)
+            .then((stories) => {
+                setItems(stories);
+                window.scrollTo(0, 0);
+            })
+            .catch((error: unknown) => {
+                if (error instanceof DOMException && error.name === 'AbortError') {
+                    return;
+                }
+                setErrorMessage(`Could not load ${feedType} stories.`);
+            });
+
+        return () => controller.abort();
+    }, [feedType, pageNum]);
+
+    const listStart = (pageNum - 1) * 30 + 1;
+
     return (
         <div className="main-content">
-            <p>
-                {feedType} feed, page {page ?? '1'}
-            </p>
+            {!items && !errorMessage && <Loader />}
+            {!items && errorMessage !== '' && <ErrorMessage message={errorMessage} />}
+
+            {items && (
+                <div>
+                    {feedType === 'jobs' && (
+                        <p className="job-header">
+                            These are jobs at startups that were funded by Y Combinator. You can also get a job at a YC
+                            startup through <a href="https://triplebyte.com/?ref=yc_jobs">Triplebyte</a>.
+                        </p>
+                    )}
+                    <ol className={feedType !== 'jobs' ? 'list-margin' : undefined} start={listStart}>
+                        {items.map((item) => (
+                            <li key={item.id} className="post">
+                                <div className="item-block">
+                                    <Item item={item} />
+                                </div>
+                            </li>
+                        ))}
+                    </ol>
+                    <div className="nav">
+                        {listStart !== 1 && (
+                            <Link to={`/${feedType}/${pageNum - 1}`} className="prev">
+                                ‹ Prev
+                            </Link>
+                        )}
+                        {items.length === 30 && (
+                            <Link to={`/${feedType}/${pageNum + 1}`} className="more">
+                                More ›
+                            </Link>
+                        )}
+                    </div>
+                </div>
+            )}
         </div>
     );
 }

--- a/react-app/src/styles/_feed.scss
+++ b/react-app/src/styles/_feed.scss
@@ -1,0 +1,108 @@
+@import "./media";
+@import "./theme_variables";
+@import "./item";
+
+.main-content {
+  position: relative;
+  width: 100%;
+  min-height: 100vh;
+  -webkit-transition: opacity .2s ease;
+  transition: opacity .2s ease;
+  box-sizing: border-box;
+  padding: 8px 0;
+  z-index: 0;
+
+  a {
+    text-decoration: none;
+    font-weight: bold;
+
+    &:hover {
+      text-decoration: underline;
+    };
+  }
+
+  ol {
+    padding: 0 40px;
+    margin: 0;
+
+    @media #{$mobile-only} {
+      box-sizing: border-box;
+      list-style: none;
+      padding: 0 10px;
+    }
+
+    li {
+      position: relative;
+      -webkit-transition: background-color .2s ease;
+      transition: background-color .2s ease;
+    }
+  }
+
+  .list-margin {
+    @media #{$mobile-only} {
+      margin-top: 55px;
+    }
+  }
+
+  .post {
+    padding: 10px 0 10px 5px;
+    transition: background-color 0.2s ease;
+    border-bottom: 1px solid #CECECB;
+
+    .itemNum {
+      color: #696969;
+      position: absolute;
+      width: 30px;
+      text-align: right;
+      left: 0;
+      top: 4px;
+    }
+  }
+
+  .item-block {
+    display: block;
+  }
+
+  .nav {
+    padding: 10px 40px;
+    margin-top: 10px;
+    font-size: 17px;
+
+    a {
+      @media #{$mobile-only} {
+        text-decoration: none;
+      }
+    }
+
+    @media #{$mobile-only} {
+      margin: 20px 0;
+      text-align: center;
+      padding: 10px 80px;
+      height: 20px;
+    }
+
+    .prev {
+      padding-right: 20px;
+
+      @media #{$mobile-only} {
+        float: left;
+        padding-right: 0;
+      }
+    }
+
+    .more {
+      @media #{$mobile-only} {
+        float: right;
+      }
+    }
+  }
+
+  .job-header {
+    font-size: 15px;
+    padding: 0 40px 10px;
+
+    @media #{$mobile-only} {
+      padding: 60px 15px 25px 15px;
+    }
+  }
+}

--- a/react-app/src/styles/_item.scss
+++ b/react-app/src/styles/_item.scss
@@ -1,0 +1,70 @@
+@import "./media";
+@import "./theme_variables";
+
+.item-block {
+  p {
+    margin: 2px 0;
+
+    @media #{$mobile-only} {
+      margin-bottom: 5px;
+      margin-top: 0;
+    }
+  }
+
+  a {
+    cursor: pointer;
+    text-decoration: none;
+  }
+
+  .title {
+    font-size: 16px;
+    font-family: Verdana, Geneva, sans-serif;
+  }
+
+  .subtext-laptop {
+    font-size: 12px;
+    font-weight: bold;
+    letter-spacing: 0.5px;
+
+    a {
+      &:hover {
+        text-decoration: underline;
+      };
+    }
+    @media #{$mobile-only} {
+      display: none;
+    }
+  }
+
+  .subtext-palm {
+    font-size: 13px;
+    font-weight: bold;
+    letter-spacing: 0.5px;
+
+    a {
+      &:hover {
+        text-decoration: underline;
+      };
+    }
+
+    .details {
+      margin-top: 5px;
+
+      .right {
+        float: right;
+      }
+    }
+    @media #{$laptop-only} {
+      display: none;
+    }
+  }
+
+  .domain {
+    color: #696969;
+    letter-spacing: 0.5px;
+  }
+
+  .item-details {
+    padding: 10px;
+  }
+}

--- a/react-app/src/styles/index.scss
+++ b/react-app/src/styles/index.scss
@@ -44,3 +44,5 @@ pre {
 #root:empty + .app-loader .logo {
     width: 20vh;
 }
+
+@import "./feed";


### PR DESCRIPTION
## Summary

Phase 2a of the Angular -> React migration: replaces the placeholder `react-app/src/pages/Feed.tsx` with a real port of the Angular `FeedComponent`, plus a new `components/Item.tsx` ported from `ItemComponent`. Angular sources under `src/` are untouched.

`Feed` takes `feedType` as a prop (from `routes.tsx`) and `:page` from the route params, refetching on either change and aborting the in-flight request on unmount/param change:

```tsx
useEffect(() => {
  const controller = new AbortController();
  setItems(null); setErrorMessage('');
  fetchFeed(feedType, pageNum, controller.signal)
    .then(s => { setItems(s); window.scrollTo(0, 0); })
    .catch(e => { if (!isAbort(e)) setErrorMessage(`Could not load ${feedType} stories.`); });
  return () => controller.abort();
}, [feedType, pageNum]);
```

Behaviour kept identical to Angular: `listStart = ((pageNum - 1) * 30) + 1` as the `<ol start>`, `list-margin` only when `feedType !== 'jobs'`, the jobs feed's `.job-header` paragraph, "‹ Prev" only when `listStart !== 1`, "More ›" only when exactly 30 items came back. `Item` keeps the dual `.subtext-palm` / `.subtext-laptop` blocks, the external-vs-internal title link via `hasUrl`, `target`/`rel` gated on `settings.openLinkInNewTab`, inline title font-size and wrapper margin from settings, and hides points/user/comments for `type === 'job'`.

Styles are the Angular component SCSS copied verbatim into `styles/_feed.scss` and `styles/_item.scss`, wrapped in `.main-content` / `.item-block` respectively so bare `a`/`p`/`ol` selectors don't leak globally now that encapsulation is gone. `index.scss` gains a single appended `@import "./feed";` (which pulls in `_item`) to keep parallel-session conflicts trivial.

Tests: vitest coverage for both components (loading/error/pagination/jobs/abort) and a deterministic Playwright spec in `e2e/feed.spec.ts` that stubs the HN API with `page.route()`. `npm run build`, `npm test`, `npm run lint`, `npm run e2e` all pass. Verified in the browser against the live API.

![news feed](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfNjlJWEpGTHJsang4elNBdyIsInVzZXJfaWQiOm51bGwsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZ182OUlYSkZMcmxqeDh6U0F3LzAwYWI2ZGM3LWNlZjAtNDIxNC1iZTQ2LTdmOTVhOTQyY2MzMCIsImlhdCI6MTc4Njk3OTk4MCwiZXhwIjoxNzg3NTg0NzgwLCJmaWxlbmFtZSI6InNzXzExZDgyZjgzLnBuZyJ9.UMkJo-7JTWflLjpt5gMRP5T5YBvroMGsF6gef1rxuuo)


Link to Devin session: https://app.devin.ai/sessions/63c78b36fd6a4989b64f17fc47f33328
Requested by: @vibhaseshadri-cognition
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/640?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/640" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->