### PR TITLE
feature: React port of item details view and recursive comment tree (Phase 2b)

### DIFF
--- a/react-app/e2e/item-details.spec.ts
+++ b/react-app/e2e/item-details.spec.ts
@@ -1,0 +1,81 @@
+import { expect, test } from '@playwright/test';
+
+const item = {
+    id: 100,
+    title: 'Stubbed item details story',
+    points: 123,
+    user: 'devin',
+    time: 1,
+    time_ago: '3 hours ago',
+    type: 'story',
+    url: 'https://example.com/story',
+    domain: 'example.com',
+    content: '<p>Story body content</p>',
+    comments_count: 2,
+    comments: [
+        {
+            id: 200,
+            level: 0,
+            user: 'alice',
+            time: 1,
+            time_ago: '2 hours ago',
+            content: '<p>Top level comment</p>',
+            comments: [
+                {
+                    id: 201,
+                    level: 1,
+                    user: 'bob',
+                    time: 1,
+                    time_ago: '1 hour ago',
+                    content: '<p>Nested reply</p>',
+                    comments: [],
+                },
+            ],
+        },
+        {
+            id: 202,
+            level: 0,
+            user: 'carol',
+            time: 1,
+            time_ago: '30 minutes ago',
+            content: '',
+            deleted: true,
+            comments: [],
+        },
+    ],
+};
+
+test.beforeEach(async ({ page }) => {
+    await page.route('**/node-hnapi.herokuapp.com/item/100', async (route) => {
+        await route.fulfill({ json: item });
+    });
+});
+
+test('renders the item details view with its comment tree', async ({ page }) => {
+    await page.goto('/item/100');
+
+    await expect(page.locator('.laptop .title')).toHaveText('Stubbed item details story');
+    await expect(page.locator('.laptop .domain')).toHaveText('(example.com)');
+    await expect(page.locator('.subtext').first()).toContainText('123 points by');
+    await expect(page.locator('.subject')).toHaveText('Story body content');
+    await expect(page.locator('.comment-list > li')).toHaveCount(2);
+    await expect(page.locator('.comment-text').first()).toHaveText('Top level comment');
+    await expect(page.locator('.subtree .comment-text')).toHaveText('Nested reply');
+    await expect(page.locator('.deleted-meta')).toContainText('Comment Deleted');
+});
+
+test('collapses and expands a comment', async ({ page }) => {
+    await page.goto('/item/100');
+
+    const firstComment = page.locator('.comment-list > li').first();
+    const body = firstComment.locator('.comment-tree > div').first();
+    await expect(body).toBeVisible();
+
+    await firstComment.locator('.collapse').first().click();
+    await expect(body).toBeHidden();
+    await expect(firstComment.locator('.meta').first()).toHaveClass(/meta-collapse/);
+    await expect(firstComment.locator('.collapse').first()).toHaveText('[+]');
+
+    await firstComment.locator('.collapse').first().click();
+    await expect(body).toBeVisible();
+});

--- a/react-app/src/components/Comment.tsx
+++ b/react-app/src/components/Comment.tsx
@@ -1,0 +1,41 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import type { Comment as CommentModel } from '../models';
+
+export function Comment({ comment }: { comment: CommentModel }) {
+    const [collapse, setCollapse] = useState(false);
+
+    if (comment.deleted) {
+        return (
+            <div>
+                <div className="deleted-meta">
+                    <span className="collapse">[deleted]</span> | Comment Deleted
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div>
+            <div className={collapse ? 'meta meta-collapse' : 'meta'}>
+                <span className="collapse" onClick={() => setCollapse(!collapse)}>
+                    [{collapse ? '+' : '-'}]
+                </span>{' '}
+                <Link to={`/user/${comment.user}`}>{comment.user}</Link>
+                <span className="time">{comment.time_ago}</span>
+            </div>
+            <div className="comment-tree">
+                <div hidden={collapse}>
+                    <p className="comment-text" dangerouslySetInnerHTML={{ __html: comment.content }}></p>
+                    <ul className="subtree">
+                        {comment.comments?.map((subComment) => (
+                            <li key={subComment.id}>
+                                <Comment comment={subComment} />
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/react-app/src/pages/ItemDetails.test.tsx
+++ b/react-app/src/pages/ItemDetails.test.tsx
@@ -1,0 +1,138 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Story } from '../models';
+import { SettingsProvider } from '../context/SettingsProvider';
+import { ItemDetails } from './ItemDetails';
+import * as api from '../services/hackernewsApi';
+
+const story: Story = {
+    id: 1,
+    title: 'A React story',
+    points: 42,
+    user: 'devin',
+    time: 1,
+    time_ago: '2 hours ago',
+    type: 'story',
+    url: 'https://example.com/story',
+    domain: 'example.com',
+    content: '<p>Story body</p>',
+    comments_count: 2,
+    comments: [
+        {
+            id: 10,
+            level: 0,
+            user: 'alice',
+            time: 1,
+            time_ago: '1 hour ago',
+            content: '<p>Top level comment</p>',
+            comments: [
+                {
+                    id: 11,
+                    level: 1,
+                    user: 'bob',
+                    time: 1,
+                    time_ago: '30 minutes ago',
+                    content: '<p>Nested reply</p>',
+                    comments: [],
+                },
+            ],
+        },
+        {
+            id: 12,
+            level: 0,
+            user: 'carol',
+            time: 1,
+            time_ago: '10 minutes ago',
+            content: '',
+            deleted: true,
+            comments: [],
+        },
+    ],
+};
+
+function renderItem() {
+    return render(
+        <SettingsProvider>
+            <MemoryRouter initialEntries={['/item/1']}>
+                <Routes>
+                    <Route path="/item/:id" element={<ItemDetails />} />
+                </Routes>
+            </MemoryRouter>
+        </SettingsProvider>,
+    );
+}
+
+describe('ItemDetails', () => {
+    beforeEach(() => {
+        window.scrollTo = vi.fn();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('renders the story header, body and comment tree', async () => {
+        vi.spyOn(api, 'fetchItemContent').mockResolvedValue(story);
+        const { container } = renderItem();
+
+        expect(container.querySelector('.loader')).toBeInTheDocument();
+
+        expect(await screen.findAllByText('A React story')).toHaveLength(2);
+        expect(screen.getByText('(example.com)')).toBeInTheDocument();
+        expect(screen.getByText('2 comments')).toBeInTheDocument();
+        expect(container.querySelector('.subject')?.innerHTML).toBe('<p>Story body</p>');
+        expect(container.querySelectorAll('.comment-list > li')).toHaveLength(2);
+        expect(screen.getByText('Nested reply')).toBeInTheDocument();
+        expect(container.querySelector('.deleted-meta')?.textContent).toContain('[deleted] | Comment Deleted');
+        expect(container.querySelector('.laptop')).toHaveClass('item-header', 'head-margin');
+    });
+
+    it('collapses and expands a comment without unmounting its subtree', async () => {
+        vi.spyOn(api, 'fetchItemContent').mockResolvedValue(story);
+        const { container } = renderItem();
+        await screen.findByText('Top level comment');
+
+        const toggle = screen.getAllByText('[-]')[0];
+        await userEvent.click(toggle);
+
+        const meta = container.querySelector('.meta');
+        expect(meta).toHaveClass('meta-collapse');
+        expect(container.querySelector('.comment-tree > div')).toHaveAttribute('hidden');
+        expect(screen.getByText('Nested reply')).toBeInTheDocument();
+
+        await userEvent.click(screen.getAllByText('[+]')[0]);
+        expect(container.querySelector('.comment-tree > div')).not.toHaveAttribute('hidden');
+    });
+
+    it('renders poll results with proportional bars', async () => {
+        vi.spyOn(api, 'fetchItemContent').mockResolvedValue({
+            ...story,
+            type: 'poll',
+            url: '',
+            poll: [
+                { points: 30, content: 'Option A' },
+                { points: 10, content: 'Option B' },
+            ],
+            poll_votes_count: 40,
+        });
+        const { container } = renderItem();
+        await screen.findByText('Option A');
+
+        const bars = container.querySelectorAll('.pollContent .pollBar');
+        expect(bars).toHaveLength(2);
+        expect((bars[0] as HTMLElement).style.width).toBe('75%');
+        expect((bars[1] as HTMLElement).style.width).toBe('25%');
+        expect(screen.getByText('30 points')).toBeInTheDocument();
+    });
+
+    it('shows an error message when the request fails', async () => {
+        vi.spyOn(api, 'fetchItemContent').mockRejectedValue(new Error('boom'));
+        renderItem();
+
+        await waitFor(() => {
+            expect(screen.getByText('Could not load item comments.')).toBeInTheDocument();
+        });
+    });
+});

--- a/react-app/src/pages/ItemDetails.tsx
+++ b/react-app/src/pages/ItemDetails.tsx
@@ -1,6 +1,131 @@
-import { useParams } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import { Comment } from '../components/Comment';
+import { ErrorMessage } from '../components/ErrorMessage';
+import { Loader } from '../components/Loader';
+import { useSettings } from '../context/settingsContext';
+import type { Story } from '../models';
+import { fetchItemContent } from '../services/hackernewsApi';
+import { commentCount } from '../utils/comment';
+import { hasUrl } from '../utils/hasUrl';
 
 export function ItemDetails() {
     const { id } = useParams();
-    return <div className="main-content">Item {id}</div>;
+    const navigate = useNavigate();
+    const { settings } = useSettings();
+    const [item, setItem] = useState<Story | null>(null);
+    const [errorMessage, setErrorMessage] = useState('');
+
+    useEffect(() => {
+        window.scrollTo(0, 0);
+    }, []);
+
+    useEffect(() => {
+        const controller = new AbortController();
+        setItem(null);
+        setErrorMessage('');
+        fetchItemContent(Number(id), controller.signal)
+            .then((story) => setItem(story))
+            .catch((error: unknown) => {
+                if (error instanceof DOMException && error.name === 'AbortError') {
+                    return;
+                }
+                setErrorMessage('Could not load item comments.');
+            });
+        return () => controller.abort();
+    }, [id]);
+
+    const external = item ? hasUrl(item.url) : false;
+    const target = settings.openLinkInNewTab ? '_blank' : undefined;
+    const rel = settings.openLinkInNewTab ? 'noopener' : undefined;
+
+    const laptopClasses = ['laptop'];
+    if (item && (item.comments_count > 0 || item.type === 'job')) {
+        laptopClasses.push('item-header');
+    }
+    if (item?.content) {
+        laptopClasses.push('head-margin');
+    }
+
+    return (
+        <div className="main-content">
+            {!item && errorMessage === '' && <Loader />}
+            {!item && errorMessage !== '' && <ErrorMessage message={errorMessage} />}
+
+            {item && (
+                <div className="item">
+                    <div className="mobile item-header">
+                        <p className="title-block">
+                            <span className="back-button" onClick={() => navigate(-1)}></span>
+                            {external ? (
+                                <a className="title" href={item.url} target={target} rel={rel}>
+                                    {item.title}
+                                </a>
+                            ) : (
+                                <Link className="title" to={`/item/${item.id}`}>
+                                    {item.title}
+                                </Link>
+                            )}
+                        </p>
+                    </div>
+                    <div className={laptopClasses.join(' ')}>
+                        {external ? (
+                            <p>
+                                <a className="title" href={item.url} target={target} rel={rel}>
+                                    {item.title}
+                                </a>
+                                {item.domain && <span className="domain">({item.domain})</span>}
+                            </p>
+                        ) : (
+                            <p>
+                                <Link className="title" to={`/item/${item.id}`}>
+                                    {item.title}
+                                </Link>
+                            </p>
+                        )}
+                        <div className="subtext">
+                            {item.type !== 'job' && (
+                                <span>
+                                    {item.points} points by <Link to={`/user/${item.user}`}>{item.user}</Link>
+                                </span>
+                            )}
+                            <span className={item.type !== 'job' ? 'item-details' : undefined}>
+                                {item.time_ago}
+                                {item.type !== 'job' && (
+                                    <span>
+                                        {' '}
+                                        | <Link to={`/item/${item.id}`}>{commentCount(item.comments_count)}</Link>
+                                    </span>
+                                )}
+                            </span>
+                        </div>
+                    </div>
+                    {item.type === 'poll' && (
+                        <div className="pollResults">
+                            {item.poll?.map((pollResult, index) => (
+                                <div className="pollContent" key={index}>
+                                    <div dangerouslySetInnerHTML={{ __html: pollResult.content }}></div>
+                                    <div className="subtext">{pollResult.points} points</div>
+                                    <div
+                                        className="pollBar"
+                                        style={{
+                                            width: `${(pollResult.points / (item.poll_votes_count ?? 0)) * 100}%`,
+                                        }}
+                                    ></div>
+                                </div>
+                            ))}
+                        </div>
+                    )}
+                    <p className="subject" dangerouslySetInnerHTML={{ __html: item.content ?? '' }}></p>
+                    <ul className="comment-list">
+                        {item.comments?.map((comment) => (
+                            <li key={comment.id}>
+                                <Comment comment={comment} />
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            )}
+        </div>
+    );
 }

--- a/react-app/src/styles/_item-details.scss
+++ b/react-app/src/styles/_item-details.scss
@@ -1,0 +1,232 @@
+@import "./media";
+@import "./theme_variables";
+
+.main-content {
+  position: relative;
+  width: 100%;
+  min-height: 100vh;
+  -webkit-transition: opacity .2s ease;
+  transition: opacity .2s ease;
+  box-sizing: border-box;
+  padding: 8px 0;
+  z-index: 0;
+
+  .item {
+    box-sizing: border-box;
+    padding: 10px 40px 0 40px;
+    z-index: 0;
+  }
+
+  @media #{$tablet-only} {
+    .item {
+      padding: 10px 20px 0 40px;
+    }
+  }
+
+  @media #{$mobile-only} {
+    .item {
+      box-sizing: border-box;
+      padding: 110px 15px 0 15px;
+    }
+  }
+
+  .head-margin {
+    margin-bottom: 15px;
+  }
+
+  p {
+    margin: 2px 0;
+  }
+
+  .subject {
+    word-wrap: break-word;
+    margin-top: 20px;
+  }
+
+  a {
+    cursor: pointer;
+    text-decoration: none;
+  }
+
+  @media #{$mobile-only} {
+    .laptop {
+      display: none;
+    }
+  }
+
+  @media #{$laptop-only} {
+    .mobile {
+      display: none;
+    }
+  }
+
+  .title {
+    font-size: 16px;
+    font-family: Verdana, Geneva, sans-serif;
+  }
+
+  .title-block {
+    text-align: center;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    margin: 0 75px;
+  }
+
+  @media #{$mobile-only} {
+    .title {
+      font-size: 15px;
+    }
+    .back-button {
+      position: absolute;
+      top: 52%;
+      width: 0.6rem;
+      height: 0.6rem;
+      background: transparent;
+      box-shadow: 0 0 0 lightgray;
+      transition: all 200ms ease;
+      left: 4%;
+      transform: translate3d(0, -50%, 0) rotate(-135deg);
+    }
+  }
+
+  .subtext {
+    font-size: 12px;
+    font-weight: bold;
+    letter-spacing: 0.5px;
+  }
+
+  .domain {
+    letter-spacing: 0.5px;
+  }
+
+  .subtext a {
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  .item-details {
+    padding: 10px;
+  }
+
+  .item-header {
+    padding-bottom: 10px;
+  }
+
+  @media #{$mobile-only} {
+    .item-header {
+      padding: 10px 0 10px 0;
+      position: fixed;
+      width: 100%;
+      left: 0;
+      top: 62px;
+    }
+  }
+
+  .pollResults {
+    margin-bottom: 1em;
+  }
+
+  .pollContent {
+    * {
+      padding-bottom: 0;
+      margin-bottom: -1em;
+      margin-top: 1em;
+    }
+    .pollBar {
+      height: 10px;
+      margin-bottom: 1em;
+    }
+  }
+
+  ul {
+    list-style-type: none;
+    padding: 10px 0;
+  }
+
+  li {
+    display: list-item;
+  }
+
+  .comment-list a {
+    font-weight: bold;
+    text-decoration: none;
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  .meta {
+    font-size: 13px;
+    color: #696969;
+    font-weight: bold;
+    letter-spacing: 0.5px;
+    margin-bottom: 8px;
+    a {
+      text-decoration: none;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+    .time {
+      padding-left: 5px;
+    }
+  }
+
+  @media #{$mobile-only} {
+    .meta {
+      font-size: 14px;
+      margin-bottom: 10px;
+      .time {
+        padding: 0;
+        float: right;
+      }
+    }
+  }
+
+  .meta-collapse {
+    margin-bottom: 20px;
+  }
+
+  .deleted-meta {
+    font-size: 12px;
+    font-weight: bold;
+    letter-spacing: 0.5px;
+    margin: 30px 0;
+    a {
+      text-decoration: none;
+    }
+  }
+
+  .collapse {
+    font-size: 13px;
+    letter-spacing: 2px;
+    cursor: pointer;
+  }
+
+  .comment-tree {
+    margin-left: 24px;
+  }
+
+  @media #{$tablet-only} {
+    .comment-tree {
+      margin-left: 8px;
+    }
+  }
+
+  .comment-text {
+    font-size: 15px;
+    margin-top: 0;
+    margin-bottom: 20px;
+    word-wrap: break-word;
+    line-height: 1.5em;
+  }
+
+  .subtree {
+    margin-left: 0;
+    padding: 0;
+    list-style-type: none;
+  }
+}

--- a/react-app/src/styles/index.scss
+++ b/react-app/src/styles/index.scss
@@ -44,3 +44,5 @@ pre {
 #root:empty + .app-loader .logo {
     width: 20vh;
 }
+
+@import "./item-details";


### PR DESCRIPTION
## Summary
Phase 2b of the Angular → React migration: replaces the `ItemDetails` placeholder with a faithful port of `src/app/item-details/*` and adds a recursive `components/Comment.tsx` ported from the Angular `app-comment` component. Markup, class names and behaviour mirror the Angular templates so the shared theme SCSS keeps matching.

Notable details:
- Collapse is per-comment local state and toggles the `hidden` attribute rather than unmounting, matching Angular's `[hidden]` (subtree state is preserved across collapse/expand).
- `laptop` header composes `item-header` (`comments_count > 0 || type === 'job'`) and `head-margin` (item has content) exactly like the Angular `[class.x]` bindings; the mobile header's `.back-button` calls `useNavigate()(-1)` in place of `Location.back()`.
- Fetch is keyed on `:id` with an `AbortController`; aborts are swallowed so route changes don't surface `Could not load item comments.`
- Poll bars: `width: points / poll_votes_count * 100 + '%'`, option content via `dangerouslySetInnerHTML`.
- Styles: `src/app/item-details/item-details.component.scss` + `comment.component.scss` ported verbatim into a single `styles/_item-details.scss`, wrapped in `.main-content` so bare `p`/`a`/`ul`/`li` selectors don't leak globally (Angular view encapsulation equivalent); one appended `@import` in `styles/index.scss`.

Tests: 4 vitest specs (`src/pages/ItemDetails.test.tsx`) covering render, collapse/expand, poll bars and the error path, plus 2 Playwright specs in `e2e/item-details.spec.ts` with `page.route()`-stubbed fixtures. `npm run build`, `npm test`, `npm run lint`, `npm run e2e` all pass.

![item details](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfNjlJWEpGTHJsang4elNBdyIsInVzZXJfaWQiOm51bGwsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZ182OUlYSkZMcmxqeDh6U0F3LzFmYzlhYTBmLTg0YmItNDU5YS1hNzIxLWI1NzkwNjk0OWZjNCIsImlhdCI6MTc4Njk3OTkxMSwiZXhwIjoxNzg3NTg0NzExLCJmaWxlbmFtZSI6Iml0ZW0tZGV0YWlscy5wbmcifQ.qQnU9i4RScMOeCwZEVcG3FH59lNrbaQVx5eaDbutaOs)


Link to Devin session: https://app.devin.ai/sessions/3803b610e07348efa829e8ddfecbdef2
Requested by: @vibhaseshadri-cognition
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/641?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/641" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->