### PR TITLE
feature: React port of the user profile view (phase 2c)

### DIFF
--- a/react-app/e2e/user-profile.spec.ts
+++ b/react-app/e2e/user-profile.spec.ts
@@ -1,0 +1,46 @@
+import { expect, test } from '@playwright/test';
+
+const profile = {
+    id: 'pg',
+    created: '5 years ago',
+    karma: 155000,
+    about: 'Bug fixer &amp; <i>essayist</i>',
+};
+
+test.describe('user profile', () => {
+    test('renders the profile for the routed user', async ({ page }) => {
+        await page.route('**/node-hnapi.herokuapp.com/user/*', (route) =>
+            route.fulfill({ json: profile, headers: { 'access-control-allow-origin': '*' } }),
+        );
+
+        await page.goto('/user/pg');
+
+        await expect(page.locator('.profile .main-details .name')).toHaveText('pg');
+        await expect(page.locator('.profile .main-details .right')).toHaveText('155000 ★');
+        await expect(page.locator('.profile .main-details .age')).toHaveText('Created 5 years ago');
+        await expect(page.locator('.profile .other-details i')).toHaveText('essayist');
+        await expect(page.locator('.profile .item-header .title-block')).toContainText('Profile: pg');
+    });
+
+    test('shows an error message when the user request fails', async ({ page }) => {
+        await page.route('**/node-hnapi.herokuapp.com/user/*', (route) => route.fulfill({ status: 500, body: 'nope' }));
+
+        await page.goto('/user/nobody');
+
+        await expect(page.locator('.error-section')).toContainText('Could not load user nobody.');
+    });
+
+    test('the back button returns to the previous page', async ({ page }) => {
+        await page.route('**/node-hnapi.herokuapp.com/user/*', (route) =>
+            route.fulfill({ json: profile, headers: { 'access-control-allow-origin': '*' } }),
+        );
+        await page.route('**/news?*', (route) => route.fulfill({ json: [] }));
+
+        await page.goto('/news/1');
+        await page.goto('/user/pg');
+        await expect(page.locator('.profile .main-details .name')).toHaveText('pg');
+
+        await page.locator('.profile .back-button').dispatchEvent('click');
+        await expect(page).toHaveURL(/\/news\/1$/);
+    });
+});

--- a/react-app/src/pages/UserProfile.test.tsx
+++ b/react-app/src/pages/UserProfile.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { UserProfile } from './UserProfile';
+import * as api from '../services/hackernewsApi';
+import type { User } from '../models';
+
+const user: User = {
+    id: 'pg',
+    created: '5 years ago',
+    karma: 155000,
+    about: 'Bug fixer &amp; <i>essayist</i>',
+};
+
+const navigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+    const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+    return { ...actual, useNavigate: () => navigate };
+});
+
+function renderProfile(id = 'pg') {
+    return render(
+        <MemoryRouter initialEntries={[`/user/${id}`]}>
+            <Routes>
+                <Route path="/user/:id" element={<UserProfile />} />
+            </Routes>
+        </MemoryRouter>,
+    );
+}
+
+describe('UserProfile', () => {
+    beforeEach(() => {
+        navigate.mockClear();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('shows the loader while the user is being fetched', () => {
+        vi.spyOn(api, 'fetchUser').mockReturnValue(new Promise(() => {}));
+        const { container } = renderProfile();
+        expect(container.querySelector('.loading-section .loader')).toBeInTheDocument();
+    });
+
+    it('renders the user profile once loaded', async () => {
+        const fetchUser = vi.spyOn(api, 'fetchUser').mockResolvedValue(user);
+        const { container } = renderProfile();
+
+        expect(await screen.findByText('Profile: pg')).toBeInTheDocument();
+        expect(fetchUser).toHaveBeenCalledWith('pg', expect.any(AbortSignal));
+        expect(container.querySelector('.profile .main-details .name')).toHaveTextContent('pg');
+        expect(container.querySelector('.main-details .right')).toHaveTextContent('155000 ★');
+        expect(container.querySelector('.main-details .age')).toHaveTextContent('Created 5 years ago');
+        expect(container.querySelector('.other-details p')?.innerHTML).toBe(
+            'Bug fixer &amp; <i>essayist</i>',
+        );
+    });
+
+    it('omits the other-details block when the user has no about text', async () => {
+        vi.spyOn(api, 'fetchUser').mockResolvedValue({ ...user, about: undefined });
+        const { container } = renderProfile();
+
+        await screen.findByText('Profile: pg');
+        expect(container.querySelector('.other-details')).toBeNull();
+    });
+
+    it('navigates back when the back button is clicked', async () => {
+        vi.spyOn(api, 'fetchUser').mockResolvedValue(user);
+        const { container } = renderProfile();
+
+        await screen.findByText('Profile: pg');
+        await userEvent.click(container.querySelector('.back-button') as HTMLElement);
+        expect(navigate).toHaveBeenCalledWith(-1);
+    });
+
+    it('shows an error message when the request fails', async () => {
+        vi.spyOn(api, 'fetchUser').mockRejectedValue(new Error('boom'));
+        renderProfile('missing');
+
+        expect(await screen.findByText('Could not load user missing.')).toBeInTheDocument();
+    });
+
+    it('aborts the in-flight request on unmount', async () => {
+        let capturedSignal: AbortSignal | undefined;
+        vi.spyOn(api, 'fetchUser').mockImplementation((_id, signal) => {
+            capturedSignal = signal;
+            return new Promise(() => {});
+        });
+        const { unmount } = renderProfile();
+        unmount();
+
+        await waitFor(() => expect(capturedSignal?.aborted).toBe(true));
+    });
+});

--- a/react-app/src/pages/UserProfile.tsx
+++ b/react-app/src/pages/UserProfile.tsx
@@ -1,6 +1,56 @@
-import { useParams } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { ErrorMessage } from '../components/ErrorMessage';
+import { Loader } from '../components/Loader';
+import type { User } from '../models';
+import { fetchUser } from '../services/hackernewsApi';
 
 export function UserProfile() {
     const { id } = useParams();
-    return <div className="main-content">User {id}</div>;
+    const navigate = useNavigate();
+    const [user, setUser] = useState<User | null>(null);
+    const [errorMessage, setErrorMessage] = useState('');
+
+    useEffect(() => {
+        if (!id) {
+            return;
+        }
+        const controller = new AbortController();
+        setUser(null);
+        setErrorMessage('');
+        fetchUser(id, controller.signal)
+            .then((data) => setUser(data))
+            .catch((error: unknown) => {
+                if (error instanceof DOMException && error.name === 'AbortError') {
+                    return;
+                }
+                setErrorMessage(`Could not load user ${id}.`);
+            });
+        return () => controller.abort();
+    }, [id]);
+
+    if (!user) {
+        return errorMessage === '' ? <Loader /> : <ErrorMessage message={errorMessage} />;
+    }
+
+    return (
+        <div className="profile">
+            <div className="mobile item-header">
+                <p className="title-block">
+                    <span className="back-button" onClick={() => navigate(-1)} />
+                    Profile: {user.id}
+                </p>
+            </div>
+            <div className="main-details">
+                <span className="name">{user.id}</span>
+                <span className="right">{user.karma} ★</span>
+                <p className="age">Created {user.created}</p>
+            </div>
+            {user.about && (
+                <div className="other-details">
+                    <p dangerouslySetInnerHTML={{ __html: user.about }} />
+                </div>
+            )}
+        </div>
+    );
 }

--- a/react-app/src/styles/_user.scss
+++ b/react-app/src/styles/_user.scss
@@ -1,0 +1,86 @@
+@import "./media";
+@import "./theme_variables";
+
+.profile {
+  padding: 30px;
+
+  pre {
+    white-space: pre-wrap;
+  }
+
+  .main-details {
+    .name {
+      font-weight: bold;
+      font-size: 32px;
+      letter-spacing: 2px;
+    }
+    .age {
+      font-weight: bold;
+      color: #696969;
+      padding-bottom: 0;
+    }
+    .right {
+      float: right;
+      font-weight: bold;
+      font-size: 32px;
+      letter-spacing: 2px;
+    }
+  }
+
+  .other-details {
+    word-wrap: break-word;
+  }
+}
+
+@media #{$mobile-only} {
+  .profile {
+    padding: 110px 15px 0 15px;
+
+    .title-block {
+      font-size: 15px;
+      text-align: center;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      overflow: hidden;
+      margin: 0 75px;
+    }
+    .back-button {
+      position: absolute;
+      top: 52%;
+      width: 0.6rem;
+      height: 0.6rem;
+      background: transparent;
+      box-shadow: 0 0 0 lightgray;
+      transition: all 200ms ease;
+      left: 4%;
+      transform: translate3d(0, -50%, 0) rotate(-135deg);
+    }
+    .item-header {
+      padding-bottom: 10px;
+      background-color: #fff;
+      padding: 10px 0 10px 0;
+      position: fixed;
+      width: 100%;
+      left: 0;
+      top: 62px;
+      height: 20px;
+    }
+    .main-details {
+      margin-top: 20px;
+      .name {
+        font-size: 18px;
+      }
+      .right {
+        font-size: 18px;
+      }
+    }
+  }
+}
+
+@media #{$laptop-only} {
+  .profile {
+    .mobile {
+      display: none;
+    }
+  }
+}

--- a/react-app/src/styles/index.scss
+++ b/react-app/src/styles/index.scss
@@ -44,3 +44,5 @@ pre {
 #root:empty + .app-loader .logo {
     width: 20vh;
 }
+
+@import "./user";


### PR DESCRIPTION
## Summary

Replaces the `UserProfile` placeholder with a real port of `src/app/user/user.component.{ts,html,scss}`. Markup, class names and behaviour match the Angular component so the existing theme CSS keeps applying.

- `fetchUser(id, signal)` runs on mount and on every `:id` change; the previous request is aborted in the effect cleanup and `AbortError` is swallowed so a cancelled fetch does not flash the error view.
- Renders `<Loader />` while `!user && !errorMessage`, `<ErrorMessage message={`Could not load user ${id}.`} />` on failure, otherwise the `.profile` block (`.mobile.item-header` > `.title-block` with the `.back-button` calling `navigate(-1)`, `.main-details` with `.name` / `.right` / `.age`, and `.other-details` only when `about` is set, injected via `dangerouslySetInnerHTML`).
- `styles/_user.scss` is the component SCSS ported verbatim, but nested under `.profile` (the Angular styles were view-encapsulated) and with `:host >>> pre` rewritten as a plain nested `pre`. One `@import "./user";` line appended to `styles/index.scss`.

Tests: unit specs for loading / loaded / missing `about` / back navigation / error / abort-on-unmount, plus `e2e/user-profile.spec.ts`. The e2e route stub is scoped to `**/node-hnapi.herokuapp.com/user/*` rather than `**/user/*` — the broader pattern also intercepts the `page.goto('/user/pg')` document request and serves JSON instead of the app.

`npm run build`, `npm test` (20 passed), `npm run lint` and `npm run e2e` (5 passed) all pass from `react-app/`.

![user profile view](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfNjlJWEpGTHJsang4elNBdyIsInVzZXJfaWQiOm51bGwsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZ182OUlYSkZMcmxqeDh6U0F3L2MzNzhhODQ5LWE4NGItNDljNC1iNjQ5LWUxZjMwMTg4ZmE0NSIsImlhdCI6MTc4Njk3OTk2NywiZXhwIjoxNzg3NTg0NzY3LCJmaWxlbmFtZSI6InNzX2U1NDBlMjg2LnBuZyJ9.tMjaHOouLi8i_kwbfRnT2q42KfPYlwsbXI2op9XjPa0)

Manual verification used a local stub API: the public `node-hnapi.herokuapp.com/user/:id` endpoint currently returns 404 for every user.


Link to Devin session: https://app.devin.ai/sessions/4cfeb59cdd294cb4a50d60d0abc834ff
Requested by: @vibhaseshadri-cognition
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/642?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/642" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->