### PR TITLE
feature: React port of header, footer and settings panel (Phase 2d)

### DIFF
--- a/react-app/e2e/settings.spec.ts
+++ b/react-app/e2e/settings.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from '@playwright/test';
+
+const stories = [
+    {
+        id: 1,
+        title: 'A deterministic story',
+        points: 42,
+        user: 'tester',
+        time_ago: '1 hour ago',
+        comments_count: 3,
+        type: 'link',
+        url: 'https://example.com/story',
+        domain: 'example.com',
+    },
+];
+
+test.beforeEach(async ({ page }) => {
+    await page.route('**/node-hnapi.herokuapp.com/**', (route) =>
+        route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(stories) })
+    );
+});
+
+test('opens the settings panel and applies the Night theme across reloads', async ({ page }) => {
+    await page.goto('/news/1');
+
+    const root = page.locator('#root > div').first();
+
+    await page.locator('#header .info img').click();
+    await expect(page.locator('#popup1 .popup h1')).toHaveText('Settings');
+
+    await page.getByLabel('Night').check();
+    await expect(root).toHaveClass('night');
+
+    await page.locator('#popup1 .close').click();
+    await expect(page.locator('#popup1')).toHaveCount(0);
+
+    await page.reload();
+    await expect(page.locator('#root > div').first()).toHaveClass('night');
+});
+
+test('header nav links navigate between feeds', async ({ page }) => {
+    await page.goto('/news/1');
+
+    await page.locator('#header').getByRole('link', { name: 'show' }).click();
+    await expect(page).toHaveURL(/\/show\/1$/);
+    await expect(page.locator('#header').getByRole('link', { name: 'show' })).toHaveClass(/active/);
+});

--- a/react-app/src/core/Header.tsx
+++ b/react-app/src/core/Header.tsx
@@ -1,14 +1,68 @@
-import { Link } from 'react-router-dom';
+import { Link, NavLink } from 'react-router-dom';
+import { useSettings } from '../context/settingsContext';
+import { Settings } from './Settings';
+
+function scrollTop() {
+    window.scrollTo(0, 0);
+}
 
 export function Header() {
+    const { settings, toggleSettings } = useSettings();
+
     return (
         <header>
             <div id="header">
-                <Link className="home-link" to="/news/1">
+                <Link className="home-link" to="/news/1" onClick={scrollTop}>
                     <div className="logo-inner"></div>
                     <img className="logo" src="/assets/images/logo.svg" alt="Logo" />
                 </Link>
+                <div className="header-text">
+                    <div className="left">
+                        <span className="header-nav">
+                            <NavLink
+                                to="/newest/1"
+                                className={({ isActive }) => (isActive ? 'active' : '')}
+                                onClick={scrollTop}
+                            >
+                                new
+                            </NavLink>
+                            {' | '}
+                            <NavLink
+                                to="/show/1"
+                                className={({ isActive }) => (isActive ? 'active' : '')}
+                                onClick={scrollTop}
+                            >
+                                show
+                            </NavLink>
+                            {' | '}
+                            <NavLink
+                                to="/ask/1"
+                                className={({ isActive }) => (isActive ? 'active' : '')}
+                                onClick={scrollTop}
+                            >
+                                ask
+                            </NavLink>
+                            {' | '}
+                            <NavLink
+                                to="/jobs/1"
+                                className={({ isActive }) => (isActive ? 'active' : '')}
+                                onClick={scrollTop}
+                            >
+                                jobs
+                            </NavLink>
+                        </span>
+                    </div>
+                </div>
+                <div className="info">
+                    <img
+                        className="settings"
+                        src="/assets/images/cog.svg"
+                        alt="Settings"
+                        onClick={toggleSettings}
+                    />
+                </div>
             </div>
+            {settings.showSettings && <Settings />}
         </header>
     );
 }

--- a/react-app/src/core/Settings.tsx
+++ b/react-app/src/core/Settings.tsx
@@ -1,0 +1,97 @@
+import { useSettings } from '../context/settingsContext';
+
+export function Settings() {
+    const { settings, toggleSettings, toggleOpenLinksInNewTab, setTheme, setFont, setSpacing } =
+        useSettings();
+
+    return (
+        <div id="popup1" className="overlay">
+            <div className="popup">
+                <h1>Settings</h1>
+                <hr />
+                <span className="close" onClick={toggleSettings}>
+                    &times;
+                </span>
+                <div className="content">
+                    <div className="control-section">
+                        <h2>Links</h2>
+                        <input
+                            type="checkbox"
+                            checked={settings.openLinkInNewTab}
+                            onChange={toggleOpenLinksInNewTab}
+                        />
+                        Open links in a new tab
+                    </div>
+                    <div className="theme-controls">
+                        <div className="control-section">
+                            <h2>Select a theme</h2>
+                            <div>
+                                <label>
+                                    <input
+                                        name="theme"
+                                        type="radio"
+                                        value="default"
+                                        checked={settings.theme === 'default'}
+                                        onChange={() => setTheme('default')}
+                                    />
+                                    Default
+                                </label>
+                            </div>
+                            <div>
+                                <label>
+                                    <input
+                                        name="theme"
+                                        type="radio"
+                                        value="night"
+                                        checked={settings.theme === 'night'}
+                                        onChange={() => setTheme('night')}
+                                    />
+                                    Night
+                                </label>
+                            </div>
+                            <div>
+                                <label>
+                                    <input
+                                        name="theme"
+                                        type="radio"
+                                        value="amoledblack"
+                                        checked={settings.theme === 'amoledblack'}
+                                        onChange={() => setTheme('amoledblack')}
+                                    />
+                                    Black (AMOLED)
+                                </label>
+                            </div>
+                        </div>
+                        <div className="control-section">
+                            <h2>Change Font</h2>
+                            <div>
+                                <label>
+                                    Font size:
+                                    <input
+                                        min="1"
+                                        value={settings.titleFontSize}
+                                        name="titleFontSize"
+                                        type="number"
+                                        onChange={(event) => setFont(event.target.value)}
+                                    />
+                                </label>
+                            </div>
+                            <div>
+                                <label>
+                                    List spacing:
+                                    <input
+                                        min="0"
+                                        value={settings.listSpacing}
+                                        name="listSpacing"
+                                        type="number"
+                                        onChange={(event) => setSpacing(event.target.value)}
+                                    />
+                                </label>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/react-app/src/core/core.test.tsx
+++ b/react-app/src/core/core.test.tsx
@@ -1,0 +1,133 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SettingsProvider } from '../context/SettingsProvider';
+import { useSettings } from '../context/settingsContext';
+import { Header } from './Header';
+import { Footer } from './Footer';
+import { Settings } from './Settings';
+
+function ThemeWrapper({ children }: { children: React.ReactNode }) {
+    const { settings } = useSettings();
+    return (
+        <div className={settings.theme} data-testid="theme-root">
+            {children}
+        </div>
+    );
+}
+
+function renderWithProviders(ui: React.ReactNode, route = '/news/1') {
+    return render(
+        <MemoryRouter initialEntries={[route]}>
+            <SettingsProvider>
+                <ThemeWrapper>{ui}</ThemeWrapper>
+            </SettingsProvider>
+        </MemoryRouter>
+    );
+}
+
+beforeEach(() => {
+    localStorage.clear();
+});
+
+describe('Header', () => {
+    it('renders the logo link and the feed nav links', () => {
+        renderWithProviders(<Header />);
+
+        const logo = screen.getByAltText('Logo');
+        expect(logo).toHaveAttribute('src', '/assets/images/logo.svg');
+        expect(logo.closest('a')).toHaveAttribute('href', '/news/1');
+
+        expect(screen.getByRole('link', { name: 'new' })).toHaveAttribute('href', '/newest/1');
+        expect(screen.getByRole('link', { name: 'show' })).toHaveAttribute('href', '/show/1');
+        expect(screen.getByRole('link', { name: 'ask' })).toHaveAttribute('href', '/ask/1');
+        expect(screen.getByRole('link', { name: 'jobs' })).toHaveAttribute('href', '/jobs/1');
+    });
+
+    it('marks the current feed link as active', () => {
+        renderWithProviders(<Header />, '/show/1');
+        expect(screen.getByRole('link', { name: 'show' })).toHaveClass('active');
+        expect(screen.getByRole('link', { name: 'ask' })).not.toHaveClass('active');
+    });
+
+    it('scrolls to the top when a nav link is clicked', async () => {
+        const scrollTo = vi.fn();
+        vi.stubGlobal('scrollTo', scrollTo);
+        renderWithProviders(<Header />);
+
+        await userEvent.click(screen.getByRole('link', { name: 'ask' }));
+        expect(scrollTo).toHaveBeenCalledWith(0, 0);
+        vi.unstubAllGlobals();
+    });
+
+    it('toggles the settings panel with the cog', async () => {
+        renderWithProviders(<Header />);
+        expect(screen.queryByRole('heading', { name: 'Settings' })).not.toBeInTheDocument();
+
+        await userEvent.click(screen.getByAltText('Settings'));
+        expect(screen.getByRole('heading', { name: 'Settings' })).toBeInTheDocument();
+
+        await userEvent.click(screen.getByAltText('Settings'));
+        expect(screen.queryByRole('heading', { name: 'Settings' })).not.toBeInTheDocument();
+    });
+});
+
+describe('Settings', () => {
+    it('switches the theme and persists it', async () => {
+        renderWithProviders(<Settings />);
+
+        await userEvent.click(screen.getByLabelText('Night'));
+
+        expect(screen.getByTestId('theme-root')).toHaveClass('night');
+        expect(localStorage.getItem('theme')).toBe('night');
+
+        await userEvent.click(screen.getByLabelText('Black (AMOLED)'));
+        expect(screen.getByTestId('theme-root')).toHaveClass('amoledblack');
+        expect(localStorage.getItem('theme')).toBe('amoledblack');
+    });
+
+    it('toggles opening links in a new tab', async () => {
+        renderWithProviders(<Settings />);
+        const checkbox = screen.getByRole('checkbox');
+        expect(checkbox).not.toBeChecked();
+
+        await userEvent.click(checkbox);
+
+        expect(checkbox).toBeChecked();
+        expect(localStorage.getItem('openLinkInNewTab')).toBe('true');
+    });
+
+    it('updates the title font size and list spacing', async () => {
+        renderWithProviders(<Settings />);
+
+        const fontSize = screen.getByLabelText(/Font size:/);
+        await userEvent.clear(fontSize);
+        await userEvent.type(fontSize, '22');
+        expect(localStorage.getItem('titleFontSize')).toBe('22');
+
+        const spacing = screen.getByLabelText(/List spacing:/);
+        await userEvent.clear(spacing);
+        await userEvent.type(spacing, '5');
+        expect(localStorage.getItem('listSpacing')).toBe('5');
+    });
+
+    it('closes the panel with the close button', async () => {
+        renderWithProviders(<Header />);
+        await userEvent.click(screen.getByAltText('Settings'));
+
+        await userEvent.click(screen.getByText('×'));
+
+        expect(screen.queryByRole('heading', { name: 'Settings' })).not.toBeInTheDocument();
+    });
+});
+
+describe('Footer', () => {
+    it('renders the GitHub link', () => {
+        render(<Footer />);
+        expect(screen.getByRole('link', { name: 'GitHub' })).toHaveAttribute(
+            'href',
+            'https://github.com/hdjirdeh/angular2-hn'
+        );
+    });
+});

--- a/react-app/src/styles/_core-ui.scss
+++ b/react-app/src/styles/_core-ui.scss
@@ -1,0 +1,3 @@
+@import "./header";
+@import "./settings";
+@import "./footer";

--- a/react-app/src/styles/_footer.scss
+++ b/react-app/src/styles/_footer.scss
@@ -1,0 +1,23 @@
+@import "./media";
+@import "./theme_variables";
+
+#footer {
+  position: relative;
+  padding: 10px;
+  height: 60px;
+  letter-spacing: 0.7px;
+  text-align: center;
+
+  a {
+    font-weight: bold;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  @media #{$mobile-only} {
+    display: none;
+  }
+}

--- a/react-app/src/styles/_header.scss
+++ b/react-app/src/styles/_header.scss
@@ -1,0 +1,149 @@
+@import "./media";
+@import "./theme_variables";
+
+#header {
+  color: #fff;
+  padding: 6px 0;
+  line-height: 18px;
+  vertical-align: middle;
+  position: relative;
+  z-index: 1;
+  width: 100%;
+
+  @media #{$mobile-only} {
+    height: 50px;
+    position: fixed;
+    top: 0;
+  }
+
+  a {
+    display: inline;
+  }
+
+  .home-link {
+    width: 50px;
+    height: 66px;
+  }
+
+  .logo-inner {
+    width: 32px;
+    position: absolute;
+    left: 17px;
+    top: 18px;
+    z-index: -1;
+    height: 32px;
+    border-radius: 50%;
+
+    @media #{$mobile-only} {
+      left: 16px;
+      top: 12px;
+    }
+  }
+
+  .logo {
+    width: 50px;
+    padding: 3px 8px 0;
+
+    @media #{$mobile-only} {
+      width: 45px;
+      padding: 0 0 0 10px;
+    }
+  }
+
+  h1 {
+    font-weight: normal;
+    display: inline-block;
+    vertical-align: middle;
+    margin: 0;
+    font-size: 16px;
+
+    a {
+      color: #fff;
+      text-decoration: none;
+    }
+  }
+
+  .name {
+    margin-right: 30px;
+    margin-bottom: 2px;
+
+    @media #{$mobile-only} {
+      display: none;
+    }
+  }
+
+  .header-text {
+    position: absolute;
+    width: inherit;
+    height: 20px;
+    left: 10px;
+    top: 27px;
+    z-index: -1;
+
+    @media #{$mobile-only} {
+      top: 22px;
+    }
+  }
+
+  .left {
+    position: absolute;
+    left: 60px;
+    font-size: 16px;
+
+    @media #{$mobile-only} {
+      width: 100%;
+      left: 0;
+    }
+  }
+
+  .header-nav {
+    display: inline-block;
+    margin-left: 20px;
+
+    @media #{$mobile-only} {
+      margin-left: 60px;
+    }
+
+    a {
+      color: hsla(0, 0%, 100%, .9);
+      text-decoration: none;
+      margin: 0 5px;
+      letter-spacing: 1.8px;
+
+      &:hover {
+        color: #fff;
+      }
+    }
+
+    .active {
+      color: #fff;
+    }
+  }
+
+  .info {
+    position: absolute;
+    top: 0;
+    right: 20px;
+    height: 100%;
+
+    @media #{$mobile-only} {
+      right: 10px;
+    }
+
+    img {
+      opacity: 0.8;
+      width: 25px;
+      margin-top: 21.5px;
+      display: block;
+
+      &:hover {
+        opacity: 1;
+        cursor: pointer;
+      }
+
+      @media #{$mobile-only} {
+        margin-top: 15px;
+      }
+    }
+  }
+}

--- a/react-app/src/styles/_settings.scss
+++ b/react-app/src/styles/_settings.scss
@@ -1,0 +1,81 @@
+@import "./media";
+@import "./theme_variables";
+
+.overlay {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: rgba(0, 0, 0, 0.7);
+  opacity: 1;
+  z-index: 1;
+
+  .popup {
+    margin: 70px auto;
+    padding: 30px;
+    border-radius: 5px;
+    width: 30%;
+    position: relative;
+
+    h1 {
+      margin-top: 0;
+      margin-bottom: 0px;
+      color: #fff;
+      text-align: center;
+      letter-spacing: 1px;
+    }
+
+    h2 {
+      padding-top: 10px;
+    }
+
+    hr {
+      width: 40%;
+      margin-bottom: 20px;
+    }
+
+    .close {
+      position: absolute;
+      top: 12px;
+      right: 20px;
+      font-size: 30px;
+      font-weight: bold;
+      text-decoration: none;
+      color: rgba(255, 255, 255, 0.8);
+
+      &:hover {
+        color: #fff;
+        cursor: pointer;
+      }
+    }
+
+    .content {
+      max-height: 30%;
+      color: #fff;
+      letter-spacing: 1px;
+      overflow: auto;
+    }
+
+    input[type=number] {
+      display: block;
+      width: 80%;
+      height: 20px;
+      margin-bottom: 15px;
+      border-radius: 5px;
+      padding: 2px;
+    }
+  }
+
+  .control-section {
+    margin-bottom: 15px;
+    padding-bottom: 15px;
+    border-bottom: 1px solid white;
+  }
+
+  @media screen and (max-width: 700px) {
+    .box, .popup {
+      width: 70%;
+    }
+  }
+}

--- a/react-app/src/styles/index.scss
+++ b/react-app/src/styles/index.scss
@@ -44,3 +44,5 @@ pre {
 #root:empty + .app-loader .logo {
     width: 20vh;
 }
+
+@import "./core-ui";


### PR DESCRIPTION
## Summary

Phase 2d of the Angular → React migration: full ports of `src/app/core/header`, `src/app/core/footer` and `src/app/core/settings` into `react-app/src/core/`. Angular sources are untouched.

- `Header.tsx` — the placeholder is replaced with the complete `#header` markup: logo `Link` to `/news/1`, `.header-nav` `NavLink`s (`new | show | ask | jobs`) using `className={({isActive}) => isActive ? 'active' : ''}` to reproduce `routerLinkActive`, every link calling `window.scrollTo(0, 0)`, and the `.info` cog calling `toggleSettings()`. `{settings.showSettings && <Settings />}` replaces `*ngIf`.
- `Settings.tsx` (new) — `#popup1.overlay > .popup` port. Angular's template-ref pattern (`#night ... [checked]="settings.theme === night.value"`) becomes controlled inputs against the settings context, so theme/font/spacing/new-tab changes hit `localStorage` immediately. Angular used `(keyup)` on the number inputs; React uses `onChange`, which also covers spinner clicks and paste.
- Styles ported verbatim into `styles/_header.scss`, `_settings.scss`, `_footer.scss`, each wrapped in its root selector (`#header`, `.overlay`, `#footer`) so the previously view-encapsulated bare `a { }` / `img { }` rules don't leak globally. The three are aggregated in `_core-ui.scss` so `index.scss` gains exactly one appended import line.
- Tests: `src/core/core.test.tsx` (nav links + active class, scroll-to-top, cog toggle, theme switch → wrapper class + localStorage, font/spacing inputs, new-tab checkbox, close button) and `e2e/settings.spec.ts` (network stubbed via `page.route()`; opens the panel, selects Night, asserts the root wrapper class and that it survives a reload).

`npm run build`, `npm test`, `npm run lint` and `npm run e2e` all pass from `react-app/`.

Verified in the browser (Night theme applied, persisted across reload):

![Settings panel, Night theme](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfNjlJWEpGTHJsang4elNBdyIsInVzZXJfaWQiOm51bGwsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZ182OUlYSkZMcmxqeDh6U0F3LzBlNWUxZDQwLTM1OGUtNDQ1NS05Y2M1LTgyNjczZmE5M2Q2OCIsImlhdCI6MTc4Njk4MDA4NiwiZXhwIjoxNzg3NTg0ODg2LCJmaWxlbmFtZSI6InNzXzY4OTA5MmJjLnBuZyJ9.fsSmL-0yhzX7FXS2iex17Wq_kEV5FyDQkH5QlhPosgU)

![AMOLED + font 24 / spacing 8 persisted after reload](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfNjlJWEpGTHJsang4elNBdyIsInVzZXJfaWQiOm51bGwsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZ182OUlYSkZMcmxqeDh6U0F3LzMzNDBiZTZhLWMwZTMtNGNmYi05NDZjLWRkNDE4YjdlMTk5ZSIsImlhdCI6MTc4Njk4MDA4NiwiZXhwIjoxNzg3NTg0ODg2LCJmaWxlbmFtZSI6InNzX2UxZmZlYzYxLnBuZyJ9.hlM93hYaVVlENxfsyd-O3SH1aactgSpRCWKig42O9EM)

Note: feed pages are still placeholders on this branch, so the font-size and list-spacing settings were verified as updating and persisting, not as restyling a story list.


Link to Devin session: https://app.devin.ai/sessions/1e7d027abf8e43849d400bfe35ae5d6d
Requested by: @vibhaseshadri-cognition
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/643?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/643" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->