### PR TITLE
feature: add headless Chrome karma launcher and test:ci script

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -25,6 +25,12 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
+    customLaunchers: {
+      ChromeHeadlessNoSandbox: {
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox', '--disable-gpu', '--disable-dev-shm-usage']
+      }
+    },
     browsers: ['Chrome'],
     singleRun: false,
     restartOnFileChange: true

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "start": "ng serve",
     "build": "ng build",
     "test": "ng test",
+    "test:ci": "ng test --watch=false --browsers=ChromeHeadlessNoSandbox",
     "lint": "ng lint",
     "e2e": "ng e2e"
   },


### PR DESCRIPTION
## Summary
Makes `ng test` runnable in a headless/CI environment. Karma's default `Chrome` launcher can't start in a sandboxless container, so this adds a `ChromeHeadlessNoSandbox` custom launcher (`--no-sandbox --disable-gpu --disable-dev-shm-usage`) and an `npm run test:ci` script that uses it with `--watch=false`.

Note: the suite currently contains zero `.spec.ts` files, so `test:ci` runs the harness and reports 0 specs.

Devin-Org: engineering

Link to Devin session: https://app.devin.ai/sessions/435ab99875ba42daaae12a3009543421
Requested by: @vibhaseshadri-cognition
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/647?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/647" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->