### PR TITLE
feature: /saved route and saved posts page

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -7,6 +7,7 @@ import { AppComponent } from './app.component';
 import { CoreModule } from './core/core.module';
 import { FeedComponent } from './feeds/feed/feed.component';
 import { ItemComponent } from './feeds/item/item.component';
+import { SavedComponent } from './saved/saved.component';
 import { SharedComponentsModule } from './shared/components/shared-components.module';
 import { PipesModule } from './shared/pipes/pipes.module';
 import { ServiceWorkerModule } from '@angular/service-worker';
@@ -16,7 +17,7 @@ import { SettingsService } from './shared/services/settings.service';
 import { SavedService } from './shared/services/saved.service';
 
 @NgModule({
-    declarations: [AppComponent, FeedComponent, ItemComponent],
+    declarations: [AppComponent, FeedComponent, ItemComponent, SavedComponent],
     imports: [
         BrowserModule,
         routing,

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,6 +1,7 @@
 import { Routes, RouterModule } from '@angular/router';
 
 import { FeedComponent } from './feeds/feed/feed.component';
+import { SavedComponent } from './saved/saved.component';
 
 const feedRoutes = [{
   path: ':page',
@@ -33,6 +34,10 @@ const routes: Routes = [
     path: 'jobs',
     children: feedRoutes,
     data: {feedType: 'jobs'}
+  },
+  {
+    path: 'saved',
+    component: SavedComponent
   },
   {path: 'item', loadChildren: () => import('./item-details/item-details.module').then(m => m.ItemDetailsModule)},
   {path: 'user', loadChildren: () => import('./user/user.module').then(m => m.UserModule)}

--- a/src/app/saved/saved.component.html
+++ b/src/app/saved/saved.component.html
@@ -1,0 +1,10 @@
+<div class="main-content">
+  <p class="empty-message" *ngIf="items.length === 0">
+    You haven't saved any posts yet. Tap save on a story to keep it here.
+  </p>
+  <ol class="list-margin" *ngIf="items.length > 0">
+    <li *ngFor="let item of items" class="post">
+      <item class="item-block" [item]="item"></item>
+    </li>
+  </ol>
+</div>

--- a/src/app/saved/saved.component.scss
+++ b/src/app/saved/saved.component.scss
@@ -1,0 +1,46 @@
+@import "../shared/scss/media";
+@import "../shared/scss/theme_variables";
+
+ol {
+  padding: 0 40px;
+  margin: 0;
+
+  @media #{$mobile-only} {
+    box-sizing: border-box;
+    list-style: none;
+    padding: 0 10px;
+  }
+}
+
+.list-margin {
+  @media #{$mobile-only} {
+    margin-top: 55px;
+  }
+}
+
+.main-content {
+  position: relative;
+  width: 100%;
+  min-height: 100vh;
+  box-sizing: border-box;
+  padding: 8px 0;
+  z-index: 0;
+}
+
+.post {
+  padding: 10px 0 10px 5px;
+  border-bottom: 1px solid #CECECB;
+}
+
+.item-block {
+  display: block;
+}
+
+.empty-message {
+  font-size: 15px;
+  padding: 0 40px 10px;
+
+  @media #{$mobile-only} {
+    padding: 60px 15px 25px 15px;
+  }
+}

--- a/src/app/saved/saved.component.ts
+++ b/src/app/saved/saved.component.ts
@@ -1,0 +1,20 @@
+import { Component, OnInit } from '@angular/core';
+
+import { SavedService } from '../shared/services/saved.service';
+import { Story } from '../shared/models/story';
+
+@Component({
+  selector: 'app-saved',
+  templateUrl: './saved.component.html',
+  styleUrls: ['./saved.component.scss']
+})
+export class SavedComponent implements OnInit {
+  items: Story[];
+
+  constructor(private _savedService: SavedService) {}
+
+  ngOnInit() {
+    this.items = this._savedService.savedPosts;
+    window.scrollTo(0, 0);
+  }
+}


### PR DESCRIPTION
## Summary

Adds the `/saved` page that lists the stories held by `SavedService`, reusing the existing `<item>` component for rendering. Based on the SavedService foundation PR (#651).

`SavedComponent` is deliberately thin — no HTTP, no route params; it just points at the service's in-memory array (the same reference the toggle mutates, so removals reflect immediately):

```ts
ngOnInit() { this.items = this._savedService.savedPosts; }
```

Registered eagerly in `AppModule` with a plain `{ path: 'saved', component: SavedComponent }` route rather than as a lazy module (like `user`/`item-details`), because `<item>` is declared in `AppModule` and is not exported by any shared module; lazy-loading would require moving that declaration and touching the feeds module structure.

The template mirrors `FeedComponent`'s list markup (`ol > li.post > item.item-block`) plus an empty state when nothing is saved.

## Screenshots

Saved list (persists across a full page reload) and the empty state after unsaving everything:

![Saved posts page](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfNjlJWEpGTHJsang4elNBdyIsInVzZXJfaWQiOm51bGwsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZ182OUlYSkZMcmxqeDh6U0F3L2MxOWYyYTA3LTM3MmQtNGQ3ZC1iZWFmLTY2NWU0YmZkOTExZCIsImlhdCI6MTc4NzA4NTEzMywiZXhwIjoxNzg3Njg5OTMzLCJmaWxlbmFtZSI6InNzXzMwNzg5M2FhLnBuZyJ9.DJMWCNDtzwP5plsD4iTf3-aEOZqQ_O1WOaIVKHOA5eo)

![Saved posts empty state](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfNjlJWEpGTHJsang4elNBdyIsInVzZXJfaWQiOm51bGwsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZ182OUlYSkZMcmxqeDh6U0F3LzAxMWVjYWJjLWRiNDgtNDI3MC05ODdkLTU3Njc4MzkwYjY0NCIsImlhdCI6MTc4NzA4NTEzMywiZXhwIjoxNzg3Njg5OTMzLCJmaWxlbmFtZSI6InNzXzZlYWYwZTI4LnBuZyJ9.CAiPRJ0FhfHMdgX3XcD3OnAEGZmD0SCwy3cIHBruY_c)

Devin-Org: engineering

Link to Devin session: https://app.devin.ai/sessions/d014cad8711c40cab86d41cff5fc07f4
Requested by: @vibhaseshadri-cognition
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/654?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/654" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->