### PR TITLE
feature: add "saved" link to header nav

### DIFF
--- a/src/app/core/header/header.component.html
+++ b/src/app/core/header/header.component.html
@@ -14,6 +14,8 @@
             <a routerLink="/ask/1" routerLinkActive="active" (click)="scrollTop()">ask</a>
               |
             <a routerLink="/jobs/1" routerLinkActive="active" (click)="scrollTop()">jobs</a>
+              |
+            <a routerLink="/saved" routerLinkActive="active" (click)="scrollTop()">saved</a>
           </span>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Adds a `saved` entry to the header nav, following the existing `new | show | ask | jobs` pattern (`routerLink` + `routerLinkActive="active"` + `scrollTop()`). Unlike the feed links it targets `/saved` with no page segment, since the saved list isn't paginated.

Based on the SavedService foundation PR (#651); the destination route itself lands in the `/saved` page PR (#654), so on this branch alone the link resolves to nothing until that merges.

## Screenshot

Header with the new `saved` link (shown with the `/saved` branch merged in locally):

![Header with saved link](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfNjlJWEpGTHJsang4elNBdyIsInVzZXJfaWQiOm51bGwsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZ182OUlYSkZMcmxqeDh6U0F3LzIwMWQzYWJmLWVhZGEtNGZiYi1hYTZlLTI3NTY0ZDQwMTRkYyIsImlhdCI6MTc4NzA4NTEzNywiZXhwIjoxNzg3Njg5OTM3LCJmaWxlbmFtZSI6InNzXzMwNzg5M2FhLnBuZyJ9.aqx3yUCsBWRvzUXrNHssw9h0m_7arrE5yeq_s0gsL0c)

Devin-Org: engineering

Link to Devin session: https://app.devin.ai/sessions/d014cad8711c40cab86d41cff5fc07f4
Requested by: @vibhaseshadri-cognition
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/655?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/655" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->