### PR TITLE
[4/8] React migration: header, footer and settings chrome

### DIFF
--- a/src/react/App.tsx
+++ b/src/react/App.tsx
@@ -2,7 +2,9 @@ import { useEffect } from 'react';
 import { BrowserRouter, Navigate, Route, Routes, useLocation } from 'react-router-dom';
 
 import '../app/app.component.scss';
-import { content } from './scope';
+import { Footer } from './core/Footer';
+import { Header } from './core/Header';
+import { content, host } from './scope';
 import { SettingsProvider, useSettings } from './settings/SettingsContext';
 
 declare const ga: undefined | ((...args: unknown[]) => void);
@@ -35,6 +37,9 @@ function Shell() {
         <div className={settings.theme} {...c}>
             <div className="body-cover" {...c}></div>
             <div className="wrapper" {...c}>
+                <app-header {...c} {...host('header')}>
+                    <Header />
+                </app-header>
                 <router-outlet {...c}></router-outlet>
                 <Routes>
                     <Route path="/" element={<Navigate to="/news/1" replace />} />
@@ -44,6 +49,9 @@ function Shell() {
                     <Route path="/item/:id" element={null} />
                     <Route path="/user/:id" element={null} />
                 </Routes>
+                <app-footer {...c} {...host('footer')}>
+                    <Footer />
+                </app-footer>
             </div>
         </div>
     );

--- a/src/react/core/Footer.tsx
+++ b/src/react/core/Footer.tsx
@@ -1,0 +1,17 @@
+import '../../app/core/footer/footer.component.scss';
+import { content } from '../scope';
+
+const c = content('footer');
+
+export function Footer() {
+    return (
+        <div id="footer" {...c}>
+            <p {...c}>
+                Show this project some ❤ on{' '}
+                <a href="https://github.com/hdjirdeh/angular2-hn" target="_blank" rel="noopener" {...c}>
+                    GitHub
+                </a>
+            </p>
+        </div>
+    );
+}

--- a/src/react/core/Header.tsx
+++ b/src/react/core/Header.tsx
@@ -1,0 +1,66 @@
+import { NavLink } from 'react-router-dom';
+
+import '../../app/core/header/header.component.scss';
+import { content, host } from '../scope';
+import { useSettings } from '../settings/SettingsContext';
+import { Settings } from './Settings';
+
+const c = content('header');
+
+function scrollTop() {
+    window.scrollTo(0, 0);
+}
+
+function activeClass(baseClass?: string) {
+    return ({ isActive }: { isActive: boolean }) => [baseClass, isActive ? 'active' : null].filter(Boolean).join(' ');
+}
+
+export function Header() {
+    const { settings, toggleSettings } = useSettings();
+
+    return (
+        <header {...c}>
+            <div id="header" {...c}>
+                <NavLink className={activeClass('home-link')} to="/news/1" onClick={scrollTop} {...c}>
+                    <div className="logo-inner" {...c}></div>
+                    <img className="logo" src="/assets/images/logo.svg" alt="Logo" {...c} />
+                </NavLink>
+                <div className="header-text" {...c}>
+                    <div className="left" {...c}>
+                        <span className="header-nav" {...c}>
+                            <NavLink className={activeClass()} to="/newest/1" onClick={scrollTop} {...c}>
+                                new
+                            </NavLink>
+                            {' | '}
+                            <NavLink className={activeClass()} to="/show/1" onClick={scrollTop} {...c}>
+                                show
+                            </NavLink>
+                            {' | '}
+                            <NavLink className={activeClass()} to="/ask/1" onClick={scrollTop} {...c}>
+                                ask
+                            </NavLink>
+                            {' | '}
+                            <NavLink className={activeClass()} to="/jobs/1" onClick={scrollTop} {...c}>
+                                jobs
+                            </NavLink>
+                        </span>
+                    </div>
+                </div>
+                <div className="info" {...c}>
+                    <img
+                        className="settings"
+                        src="/assets/images/cog.svg"
+                        alt="Settings"
+                        onClick={toggleSettings}
+                        {...c}
+                    />
+                </div>
+            </div>
+            {settings.showSettings && (
+                <app-settings {...c} {...host('settings')}>
+                    <Settings />
+                </app-settings>
+            )}
+        </header>
+    );
+}

--- a/src/react/core/Header.tsx
+++ b/src/react/core/Header.tsx
@@ -12,7 +12,8 @@ function scrollTop() {
 }
 
 function activeClass(baseClass?: string) {
-    return ({ isActive }: { isActive: boolean }) => [baseClass, isActive ? 'active' : null].filter(Boolean).join(' ');
+    return ({ isActive }: { isActive: boolean }) =>
+        [baseClass, isActive ? 'active' : null].filter(Boolean).join(' ') || undefined;
 }
 
 export function Header() {

--- a/src/react/core/Settings.tsx
+++ b/src/react/core/Settings.tsx
@@ -1,0 +1,106 @@
+import '../../app/core/settings/settings.component.scss';
+import { content } from '../scope';
+import { useSettings } from '../settings/SettingsContext';
+
+const c = content('settings');
+
+export function Settings() {
+    const { settings, toggleSettings, toggleOpenLinksInNewTab, setTheme, setFont, setSpacing } = useSettings();
+
+    return (
+        <div id="popup1" className="overlay" {...c}>
+            <div className="popup" {...c}>
+                <h1 {...c}>Settings</h1>
+                <hr {...c} />
+                <span className="close" onClick={toggleSettings} {...c}>
+                    &times;
+                </span>
+                <div className="content" {...c}>
+                    <div className="control-section" {...c}>
+                        <h2 {...c}>Links</h2>
+                        <input
+                            type="checkbox"
+                            checked={settings.openLinkInNewTab}
+                            onChange={toggleOpenLinksInNewTab}
+                            {...c}
+                        />
+                        Open links in a new tab
+                    </div>
+                    <div className="theme-controls" {...c}>
+                        <div className="control-section" {...c}>
+                            <h2 {...c}>Select a theme</h2>
+                            <div {...c}>
+                                <label {...c}>
+                                    <input
+                                        name="theme"
+                                        type="radio"
+                                        value="default"
+                                        checked={settings.theme === 'default'}
+                                        onChange={() => setTheme('default')}
+                                        {...c}
+                                    />
+                                    Default
+                                </label>
+                            </div>
+                            <div {...c}>
+                                <label {...c}>
+                                    <input
+                                        name="theme"
+                                        type="radio"
+                                        value="night"
+                                        checked={settings.theme === 'night'}
+                                        onChange={() => setTheme('night')}
+                                        {...c}
+                                    />
+                                    Night
+                                </label>
+                            </div>
+                            <div {...c}>
+                                <label {...c}>
+                                    <input
+                                        name="theme"
+                                        type="radio"
+                                        value="amoledblack"
+                                        checked={settings.theme === 'amoledblack'}
+                                        onChange={() => setTheme('amoledblack')}
+                                        {...c}
+                                    />
+                                    Black (AMOLED)
+                                </label>
+                            </div>
+                        </div>
+                        <div className="control-section" {...c}>
+                            <h2 {...c}>Change Font</h2>
+                            <div {...c}>
+                                <label {...c}>
+                                    Font size:
+                                    <input
+                                        min="1"
+                                        defaultValue={settings.titleFontSize}
+                                        name="theme"
+                                        type="number"
+                                        onKeyUp={event => setFont(event.currentTarget.value)}
+                                        {...c}
+                                    />
+                                </label>
+                            </div>
+                            <div {...c}>
+                                <label {...c}>
+                                    List spacing:
+                                    <input
+                                        min="0"
+                                        defaultValue={settings.listSpacing}
+                                        name="theme"
+                                        type="number"
+                                        onKeyUp={event => setSpacing(event.currentTarget.value)}
+                                        {...c}
+                                    />
+                                </label>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/react/core/Settings.tsx
+++ b/src/react/core/Settings.tsx
@@ -23,7 +23,7 @@ export function Settings() {
                             checked={settings.openLinkInNewTab}
                             onChange={toggleOpenLinksInNewTab}
                             {...c}
-                        />
+                        />{' '}
                         Open links in a new tab
                     </div>
                     <div className="theme-controls" {...c}>
@@ -38,7 +38,7 @@ export function Settings() {
                                         checked={settings.theme === 'default'}
                                         onChange={() => setTheme('default')}
                                         {...c}
-                                    />
+                                    />{' '}
                                     Default
                                 </label>
                             </div>
@@ -51,7 +51,7 @@ export function Settings() {
                                         checked={settings.theme === 'night'}
                                         onChange={() => setTheme('night')}
                                         {...c}
-                                    />
+                                    />{' '}
                                     Night
                                 </label>
                             </div>
@@ -64,7 +64,7 @@ export function Settings() {
                                         checked={settings.theme === 'amoledblack'}
                                         onChange={() => setTheme('amoledblack')}
                                         {...c}
-                                    />
+                                    />{' '}
                                     Black (AMOLED)
                                 </label>
                             </div>


### PR DESCRIPTION
## Summary

Ports `src/app/core/{header,footer,settings}` and hangs them off the shell from #660, so the app now renders its real chrome. Feeds/item/user still resolve to `null` (PRs 5-7).

Two places where a literal JSX transcription of the templates would have changed rendering:

- **`routerLinkActive="active"`** becomes `NavLink` with a className callback. Angular's default match is prefix-based on the *whole* link URL, so `/news/1` is not active on `/news/2` — that is what `NavLink` does by default, so the highlight follows the same rule. The home link keeps its `home-link` class alongside `active`:
  ```tsx
  <NavLink className={activeClass('home-link')} to="/news/1" onClick={scrollTop}>
  ```
- **Whitespace between inputs and their labels.** Angular templates keep the newline between `<input>` and `Open links in a new tab` as a space; JSX strips whitespace containing a newline, which rendered the checkbox and all three theme radios flush against their text. Restored with explicit `{' '}` (verified against the Angular popup side by side).

Settings inputs mirror Angular's binding directions rather than being blanket-controlled: the checkbox and radios are controlled (`[checked]` + event), while font size and list spacing use `defaultValue` + `onKeyUp`, matching `[value]`'s one-way binding — a controlled value there would fight the user's typing on every keystroke.

Screenshots of the popup in both apps (`localhost:4200` vs `localhost:5173`) match, including the header, the overlay dimming and the divider rules.

Stacked on #660.

Devin-Org: engineering

Link to Devin session: https://app.devin.ai/sessions/298bc2f4952e4556a441b8d3b09d3bc2
Requested by: @charityquinn-cognition
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/661?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/661" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/angular2-hn/pull/661" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->