### PR TITLE
[5/8] React migration: feed listing and item rows

### DIFF
--- a/src/react/App.tsx
+++ b/src/react/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Navigate, Route, Routes, useLocation } from 'react-route
 
 import '../app/app.component.scss';
 import { Footer } from './core/Footer';
+import { Feed } from './feeds/Feed';
 import { Header } from './core/Header';
 import { content, host } from './scope';
 import { SettingsProvider, useSettings } from './settings/SettingsContext';
@@ -44,7 +45,15 @@ function Shell() {
                 <Routes>
                     <Route path="/" element={<Navigate to="/news/1" replace />} />
                     {feedTypes.map(feedType => (
-                        <Route key={feedType} path={`/${feedType}/:page`} element={null} />
+                        <Route
+                            key={feedType}
+                            path={`/${feedType}/:page`}
+                            element={
+                                <app-feed {...c} {...host('feed')}>
+                                    <Feed feedType={feedType} />
+                                </app-feed>
+                            }
+                        />
                     ))}
                     <Route path="/item/:id" element={null} />
                     <Route path="/user/:id" element={null} />

--- a/src/react/App.tsx
+++ b/src/react/App.tsx
@@ -50,7 +50,7 @@ function Shell() {
                             path={`/${feedType}/:page`}
                             element={
                                 <app-feed {...c} {...host('feed')}>
-                                    <Feed feedType={feedType} />
+                                    <Feed key={feedType} feedType={feedType} />
                                 </app-feed>
                             }
                         />

--- a/src/react/feeds/Feed.tsx
+++ b/src/react/feeds/Feed.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+
+import { fetchFeed } from '../../api/hackernews';
+import '../../app/feeds/feed/feed.component.scss';
+import { Story } from '../models/story';
+import { content, host } from '../scope';
+import { ErrorMessage } from '../shared/ErrorMessage';
+import { Loader } from '../shared/Loader';
+import { Item } from './Item';
+
+const c = content('feed');
+
+export function Feed({ feedType }: { feedType: string }) {
+    const { page } = useParams();
+    const pageNum = page ? +page : 1;
+
+    const [items, setItems] = useState<Story[] | undefined>(undefined);
+    const [listStart, setListStart] = useState(1);
+    const [errorMessage, setErrorMessage] = useState('');
+
+    useEffect(() => {
+        let cancelled = false;
+
+        fetchFeed(feedType, pageNum).then(
+            loaded => {
+                if (cancelled) {
+                    return;
+                }
+                setItems(loaded);
+                setListStart((pageNum - 1) * 30 + 1);
+                window.scrollTo(0, 0);
+            },
+            () => {
+                if (!cancelled) {
+                    setErrorMessage(`Could not load ${feedType} stories.`);
+                }
+            }
+        );
+
+        return () => {
+            cancelled = true;
+        };
+    }, [feedType, pageNum]);
+
+    return (
+        <div className="main-content" {...c}>
+            {!items && errorMessage === '' && (
+                <app-loader {...c} {...host('loader')}>
+                    <Loader />
+                </app-loader>
+            )}
+            {!items && errorMessage !== '' && (
+                <app-error-message {...c} {...host('error-message')}>
+                    <ErrorMessage message={errorMessage} />
+                </app-error-message>
+            )}
+
+            {items && (
+                <div {...c}>
+                    {feedType === 'jobs' && (
+                        <p className="job-header" {...c}>
+                            These are jobs at startups that were funded by Y Combinator. You can also get a job at a YC
+                            startup through{' '}
+                            <a href="https://triplebyte.com/?ref=yc_jobs" {...c}>
+                                Triplebyte
+                            </a>
+                            .
+                        </p>
+                    )}
+                    <ol className={feedType !== 'jobs' ? 'list-margin' : undefined} start={listStart} {...c}>
+                        {items.map(item => (
+                            <li key={item.id} className="post" {...c}>
+                                <item className="item-block" {...c} {...host('item')}>
+                                    <Item item={item} />
+                                </item>
+                            </li>
+                        ))}
+                    </ol>
+                    <div className="nav" {...c}>
+                        {listStart !== 1 && (
+                            <Link to={`/${feedType}/${pageNum - 1}`} className="prev" {...c}>
+                                ‹ Prev
+                            </Link>
+                        )}
+                        {items.length === 30 && (
+                            <Link to={`/${feedType}/${pageNum + 1}`} className="more" {...c}>
+                                More ›
+                            </Link>
+                        )}
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/react/feeds/Item.tsx
+++ b/src/react/feeds/Item.tsx
@@ -1,0 +1,91 @@
+import { Link } from 'react-router-dom';
+
+import '../../app/feeds/item/item.component.scss';
+import { Story } from '../models/story';
+import { content } from '../scope';
+import { comment } from '../shared/comment';
+import { useSettings } from '../settings/SettingsContext';
+
+const c = content('item');
+
+export function Item({ item }: { item: Story }) {
+    const { settings } = useSettings();
+
+    const hasUrl = item.url.indexOf('http') === 0;
+    const titleStyle = { fontSize: `${settings.titleFontSize}px` };
+
+    return (
+        <div style={{ marginBottom: `${settings.listSpacing}px` }} {...c}>
+            {hasUrl ? (
+                <p {...c}>
+                    <a
+                        className="title"
+                        style={titleStyle}
+                        href={item.url}
+                        target={settings.openLinkInNewTab ? '_blank' : undefined}
+                        rel={settings.openLinkInNewTab ? 'noopener' : undefined}
+                        {...c}
+                    >
+                        {item.title}
+                    </a>{' '}
+                    {item.domain && (
+                        <span className="domain" {...c}>
+                            ({item.domain})
+                        </span>
+                    )}
+                </p>
+            ) : (
+                <p {...c}>
+                    <Link className="title" style={titleStyle} to={`/item/${item.id}`} {...c}>
+                        {item.title}
+                    </Link>
+                </p>
+            )}
+            <div className="subtext-palm" {...c}>
+                {item.type !== 'job' && (
+                    <div className="details" {...c}>
+                        <span className="name" {...c}>
+                            <Link to={`/user/${item.user}`} {...c}>
+                                {item.user}
+                            </Link>
+                        </span>
+                        <span className="right" {...c}>
+                            {item.points} ★
+                        </span>
+                    </div>
+                )}
+                <div className="details" {...c}>
+                    {item.time_ago}
+                    {item.type !== 'job' && (
+                        <Link to={`/item/${item.id}`} className="comment-number" {...c}>
+                            {' • '}
+                            {comment(item.comments_count)}
+                        </Link>
+                    )}
+                </div>
+            </div>
+            <div className="subtext-laptop" {...c}>
+                {item.type !== 'job' && (
+                    <span {...c}>
+                        {item.points} points by{' '}
+                        <Link to={`/user/${item.user}`} {...c}>
+                            {item.user}
+                        </Link>
+                    </span>
+                )}
+                <span className={item.type !== 'job' ? 'item-details' : undefined} {...c}>
+                    {item.time_ago}
+                    {item.type !== 'job' && (
+                        <span {...c}>
+                            {' '}
+                            |{' '}
+                            <Link to={`/item/${item.id}`} {...c}>
+                                {comment(item.comments_count)}
+                            </Link>
+                        </span>
+                    )}
+                </span>
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary

Ports `FeedComponent` + `ItemComponent`, so `/news/:page`, `/newest/:page`, `/show/:page`, `/ask/:page` and `/jobs/:page` now render real content. `feedType` came from route `data` in `app.routes.ts`; here it is a prop supplied per route in `App.tsx`, with `:page` still read from params.

Fetch effect mirrors the RxJS subscription's callback split — `listStart` and the scroll reset lived in `complete`, not `next`, so they must not run on the error path:

```ts
fetchFeed(feedType, pageNum).then(
  loaded => { setItems(loaded); setListStart((pageNum - 1) * 30 + 1); window.scrollTo(0, 0); },
  () => setErrorMessage(`Could not load ${feedType} stories.`)
);
```

`listStart` stays state rather than being derived from `pageNum` on purpose: the Prev/More links are gated on `listStart !== 1` and `items.length === 30`, i.e. on the *loaded* page, so deriving it would flip the pagination controls before the new page arrives. The cancelled flag drops responses from a superseded page, which the Angular version's unsubscribe did implicitly.

Whitespace is again load-bearing: the template's `> •\n {{count | comment}}` renders as `• 71 comments`, so the JSX uses explicit `{' • '}` / `{' '}` separators where a newline in the Angular template produced a space. Same for `(domain)` after the title and `points by <user>`.

Verified side by side against `localhost:4200`: rank numbering, ★/points, domain suffixes, the `discuss` fallback for zero-comment stories, and Prev/More placement all match; job rows correctly omit user/points/comments.

Stacked on #661.

Devin-Org: engineering

Link to Devin session: https://app.devin.ai/sessions/298bc2f4952e4556a441b8d3b09d3bc2
Requested by: @charityquinn-cognition
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/662?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/662" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/angular2-hn/pull/662" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->