### PR TITLE
[6/8] React migration: item details and recursive comments

### DIFF
--- a/src/react/App.tsx
+++ b/src/react/App.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter, Navigate, Route, Routes, useLocation } from 'react-route
 import '../app/app.component.scss';
 import { Footer } from './core/Footer';
 import { Feed } from './feeds/Feed';
+import { ItemDetails } from './item-details/ItemDetails';
 import { Header } from './core/Header';
 import { content, host } from './scope';
 import { SettingsProvider, useSettings } from './settings/SettingsContext';
@@ -55,7 +56,14 @@ function Shell() {
                             }
                         />
                     ))}
-                    <Route path="/item/:id" element={null} />
+                    <Route
+                        path="/item/:id"
+                        element={
+                            <app-item-details {...c} {...host('item-details')}>
+                                <ItemDetails />
+                            </app-item-details>
+                        }
+                    />
                     <Route path="/user/:id" element={null} />
                 </Routes>
                 <app-footer {...c} {...host('footer')}>

--- a/src/react/item-details/Comment.tsx
+++ b/src/react/item-details/Comment.tsx
@@ -40,7 +40,7 @@ export function Comment({ comment }: { comment: CommentModel }) {
                 <div hidden={collapse} {...c}>
                     <p className="comment-text" dangerouslySetInnerHTML={{ __html: comment.content }} {...c}></p>
                     <ul className="subtree" {...c}>
-                        {comment.comments.map(subComment => (
+                        {(comment.comments ?? []).map(subComment => (
                             <li key={subComment.id} {...c}>
                                 <app-comment {...c} {...host('comment')}>
                                     <Comment comment={subComment} />

--- a/src/react/item-details/Comment.tsx
+++ b/src/react/item-details/Comment.tsx
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+
+import '../../app/item-details/comment/comment.component.scss';
+import { Comment as CommentModel } from '../models/comment';
+import { content, host } from '../scope';
+
+const c = content('comment');
+
+export function Comment({ comment }: { comment: CommentModel }) {
+    const [collapse, setCollapse] = useState(false);
+
+    if (comment.deleted) {
+        return (
+            <div {...c}>
+                <div className="deleted-meta" {...c}>
+                    <span className="collapse" {...c}>
+                        [deleted]
+                    </span>{' '}
+                    | Comment Deleted
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div {...c}>
+            <div className={collapse ? 'meta meta-collapse' : 'meta'} {...c}>
+                <span className="collapse" onClick={() => setCollapse(!collapse)} {...c}>
+                    [{collapse ? '+' : '-'}]
+                </span>
+                <Link to={`/user/${comment.user}`} {...c}>
+                    {comment.user}
+                </Link>
+                <span className="time" {...c}>
+                    {comment.time_ago}
+                </span>
+            </div>
+            <div className="comment-tree" {...c}>
+                <div hidden={collapse} {...c}>
+                    <p className="comment-text" dangerouslySetInnerHTML={{ __html: comment.content }} {...c}></p>
+                    <ul className="subtree" {...c}>
+                        {comment.comments.map(subComment => (
+                            <li key={subComment.id} {...c}>
+                                <app-comment {...c} {...host('comment')}>
+                                    <Comment comment={subComment} />
+                                </app-comment>
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/react/item-details/ItemDetails.tsx
+++ b/src/react/item-details/ItemDetails.tsx
@@ -1,0 +1,166 @@
+import { useEffect, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+
+import { fetchItemContent } from '../../api/hackernews';
+import '../../app/item-details/item-details.component.scss';
+import { Story } from '../models/story';
+import { content, host } from '../scope';
+import { ErrorMessage } from '../shared/ErrorMessage';
+import { Loader } from '../shared/Loader';
+import { comment as commentCount } from '../shared/comment';
+import { useSettings } from '../settings/SettingsContext';
+import { Comment } from './Comment';
+
+const c = content('item-details');
+
+type ItemContent = Story & { text?: string; content?: string };
+
+export function ItemDetails() {
+    const { id } = useParams();
+    const navigate = useNavigate();
+    const { settings } = useSettings();
+
+    const [item, setItem] = useState<ItemContent | undefined>(undefined);
+    const [errorMessage, setErrorMessage] = useState('');
+
+    useEffect(() => {
+        let cancelled = false;
+
+        fetchItemContent(Number(id)).then(
+            loaded => {
+                if (!cancelled) {
+                    setItem(loaded);
+                }
+            },
+            () => {
+                if (!cancelled) {
+                    setErrorMessage('Could not load item comments.');
+                }
+            }
+        );
+
+        return () => {
+            cancelled = true;
+        };
+    }, [id]);
+
+    useEffect(() => {
+        window.scrollTo(0, 0);
+    }, []);
+
+    const hasUrl = item ? item.url.indexOf('http') === 0 : false;
+    const target = settings.openLinkInNewTab ? '_blank' : undefined;
+    const rel = settings.openLinkInNewTab ? 'noopener' : undefined;
+
+    return (
+        <div className="main-content" {...c}>
+            {!item && errorMessage === '' && (
+                <app-loader {...c} {...host('loader')}>
+                    <Loader />
+                </app-loader>
+            )}
+            {!item && errorMessage !== '' && (
+                <app-error-message {...c} {...host('error-message')}>
+                    <ErrorMessage message={errorMessage} />
+                </app-error-message>
+            )}
+
+            {item && (
+                <div className="item" {...c}>
+                    <div className="mobile item-header" {...c}>
+                        <p className="title-block" {...c}>
+                            <span className="back-button" onClick={() => navigate(-1)} {...c}></span>
+                            {hasUrl ? (
+                                <a className="title" href={item.url} target={target} rel={rel} {...c}>
+                                    {item.title}
+                                </a>
+                            ) : (
+                                <Link className="title" to={`/item/${item.id}`} {...c}>
+                                    {item.title}
+                                </Link>
+                            )}
+                        </p>
+                    </div>
+                    <div
+                        className={[
+                            'laptop',
+                            item.comments_count > 0 || item.type === 'job' ? 'item-header' : null,
+                            item.text ? 'head-margin' : null,
+                        ]
+                            .filter(Boolean)
+                            .join(' ')}
+                        {...c}
+                    >
+                        {hasUrl ? (
+                            <p {...c}>
+                                <a className="title" href={item.url} target={target} rel={rel} {...c}>
+                                    {item.title}
+                                </a>{' '}
+                                {item.domain && (
+                                    <span className="domain" {...c}>
+                                        ({item.domain})
+                                    </span>
+                                )}
+                            </p>
+                        ) : (
+                            <p {...c}>
+                                <Link className="title" to={`/item/${item.id}`} {...c}>
+                                    {item.title}
+                                </Link>
+                            </p>
+                        )}
+                        <div className="subtext" {...c}>
+                            {item.type !== 'job' && (
+                                <span {...c}>
+                                    {item.points} points by{' '}
+                                    <Link to={`/user/${item.user}`} {...c}>
+                                        {item.user}
+                                    </Link>
+                                </span>
+                            )}{' '}
+                            <span className={item.type !== 'job' ? 'item-details' : undefined} {...c}>
+                                {item.time_ago}
+                                {item.type !== 'job' && (
+                                    <span {...c}>
+                                        {' '}
+                                        |{' '}
+                                        <Link to={`/item/${item.id}`} {...c}>
+                                            {commentCount(item.comments_count)}
+                                        </Link>
+                                    </span>
+                                )}
+                            </span>
+                        </div>
+                    </div>
+                    {item.type === 'poll' && (
+                        <div className="pollResults" {...c}>
+                            {item.poll.map((pollResult, index) => (
+                                <div key={index} className="pollContent" {...c}>
+                                    <div dangerouslySetInnerHTML={{ __html: pollResult.content }} {...c}></div>
+                                    <div className="subtext" {...c}>
+                                        {pollResult.points} points
+                                    </div>
+                                    <div
+                                        className="pollBar"
+                                        style={{ width: `${(pollResult.points / item.poll_votes_count) * 100}%` }}
+                                        {...c}
+                                    ></div>
+                                </div>
+                            ))}
+                        </div>
+                    )}
+                    <p className="subject" dangerouslySetInnerHTML={{ __html: item.content ?? '' }} {...c}></p>
+                    <ul className="comment-list" {...c}>
+                        {item.comments.map(itemComment => (
+                            <li key={itemComment.id} {...c}>
+                                <app-comment {...c} {...host('comment')}>
+                                    <Comment comment={itemComment} />
+                                </app-comment>
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/react/item-details/ItemDetails.tsx
+++ b/src/react/item-details/ItemDetails.tsx
@@ -151,7 +151,7 @@ export function ItemDetails() {
                     )}
                     <p className="subject" dangerouslySetInnerHTML={{ __html: item.content ?? '' }} {...c}></p>
                     <ul className="comment-list" {...c}>
-                        {item.comments.map(itemComment => (
+                        {(item.comments ?? []).map(itemComment => (
                             <li key={itemComment.id} {...c}>
                                 <app-comment {...c} {...host('comment')}>
                                     <Comment comment={itemComment} />

--- a/src/react/item-details/ItemDetails.tsx
+++ b/src/react/item-details/ItemDetails.tsx
@@ -117,7 +117,7 @@ export function ItemDetails() {
                                         {item.user}
                                     </Link>
                                 </span>
-                            )}{' '}
+                            )}
                             <span className={item.type !== 'job' ? 'item-details' : undefined} {...c}>
                                 {item.time_ago}
                                 {item.type !== 'job' && (


### PR DESCRIPTION
## Summary

Ports `ItemDetailsComponent` and the recursive `CommentComponent`, so `/item/:id` renders the story header, poll results, self-post text and the full comment tree.

Direct translations of the Angular pieces:

- `goBack()` → `navigate(-1)`; `Location.back()` and the history-based router both pop browser history, so external referrers behave the same.
- `collapse` is per-`CommentComponent` instance state → `useState` per `Comment`, keeping subtrees independently collapsible. Collapsing still uses `hidden` (not unmounting), so scroll offsets and nested collapse states survive a toggle exactly as before.
- `[innerHTML]` on comment/poll/self-post bodies → `dangerouslySetInnerHTML`. The payload is HN's server-rendered HTML, same source and same trust boundary as the Angular version.
- `window.scrollTo(0, 0)` ran in `ngOnInit`, i.e. once per component instance rather than per param change — so it is a mount-only effect, deliberately not keyed on `id`.

`item.text` / `item.content` are read by the template but absent from `Story`, which the task says to copy verbatim; rather than editing the model, the component widens it locally:

```ts
type ItemContent = Story & { text?: string; content?: string };
```

Whitespace note, opposite direction from PR 5: Angular's default `preserveWhitespaces: false` deletes whitespace-*only* text nodes between elements, so `[-]</span> <a>user</a>` renders as `[-]srameshc` with no gap. A first pass had `[-] srameshc`; that JSX space is removed. Nodes like `</span> | Comment Deleted` are not whitespace-only and keep their leading space.

Verified against `localhost:4200` on the same item id — comment nesting/indentation, `[-]`/`[+]` toggles, timestamps and the header rule line all line up.

Stacked on #662.

Devin-Org: engineering

Link to Devin session: https://app.devin.ai/sessions/298bc2f4952e4556a441b8d3b09d3bc2
Requested by: @charityquinn-cognition
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/663?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/663" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/angular2-hn/pull/663" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->