### PR TITLE
[7/8] React migration: user profile

### DIFF
--- a/src/react/App.tsx
+++ b/src/react/App.tsx
@@ -5,6 +5,7 @@ import '../app/app.component.scss';
 import { Footer } from './core/Footer';
 import { Feed } from './feeds/Feed';
 import { ItemDetails } from './item-details/ItemDetails';
+import { UserProfile } from './user/UserProfile';
 import { Header } from './core/Header';
 import { content, host } from './scope';
 import { SettingsProvider, useSettings } from './settings/SettingsContext';
@@ -64,7 +65,14 @@ function Shell() {
                             </app-item-details>
                         }
                     />
-                    <Route path="/user/:id" element={null} />
+                    <Route
+                        path="/user/:id"
+                        element={
+                            <app-user {...c} {...host('user')}>
+                                <UserProfile />
+                            </app-user>
+                        }
+                    />
                 </Routes>
                 <app-footer {...c} {...host('footer')}>
                     <Footer />

--- a/src/react/user/UserProfile.tsx
+++ b/src/react/user/UserProfile.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+
+import { fetchUser } from '../../api/hackernews';
+import '../../app/user/user.component.scss';
+import { User } from '../models/user';
+import { content, host } from '../scope';
+import { ErrorMessage } from '../shared/ErrorMessage';
+import { Loader } from '../shared/Loader';
+
+const c = content('user');
+
+export function UserProfile() {
+    const { id } = useParams();
+    const navigate = useNavigate();
+
+    const [user, setUser] = useState<User | undefined>(undefined);
+    const [errorMessage, setErrorMessage] = useState('');
+
+    useEffect(() => {
+        let cancelled = false;
+
+        fetchUser(id as string).then(
+            loaded => {
+                if (!cancelled) {
+                    setUser(loaded);
+                }
+            },
+            () => {
+                if (!cancelled) {
+                    setErrorMessage(`Could not load user ${id}.`);
+                }
+            }
+        );
+
+        return () => {
+            cancelled = true;
+        };
+    }, [id]);
+
+    return (
+        <>
+            {!user && errorMessage === '' && (
+                <app-loader {...c} {...host('loader')}>
+                    <Loader />
+                </app-loader>
+            )}
+            {!user && errorMessage !== '' && (
+                <app-error-message {...c} {...host('error-message')}>
+                    <ErrorMessage message={errorMessage} />
+                </app-error-message>
+            )}
+
+            {user && (
+                <div className="profile" {...c}>
+                    <div className="mobile item-header" {...c}>
+                        <p className="title-block" {...c}>
+                            <span className="back-button" onClick={() => navigate(-1)} {...c}></span>
+                            Profile: {user.id}
+                        </p>
+                    </div>
+                    <div className="main-details" {...c}>
+                        <span className="name" {...c}>
+                            {user.id}
+                        </span>
+                        <span className="right" {...c}>
+                            {user.karma} ★
+                        </span>
+                        <p className="age" {...c}>
+                            Created {user.created}
+                        </p>
+                    </div>
+                    {user.about && (
+                        <div className="other-details" {...c}>
+                            <p dangerouslySetInnerHTML={{ __html: user.about }} {...c}></p>
+                        </div>
+                    )}
+                </div>
+            )}
+        </>
+    );
+}


### PR DESCRIPTION
## Summary

Ports `UserComponent` to `UserProfile`, completing the route table: `/user/:id` fetches the profile, shows karma/created/about, and `goBack()` maps to `navigate(-1)` as in PR 6.

`user.component.html` has no wrapper element of its own — loader, error and `.profile` are siblings directly under the `app-user` host — so the component returns a fragment rather than introducing a `<div>`, keeping `user.component.scss`'s `:host` rules (compiled to `[data-h-user]`) applied to the same element Angular applied them to.

`user.about` is rendered with `dangerouslySetInnerHTML`, matching the template's `[innerHTML]`; `user.component.scss` styles it via `:host >>> pre`, which the scoping plugin already emits unscoped exactly like Angular's `::ng-deep`.

Verified against `localhost:4200` for the same id. Note the API host in this environment returns 404 for `/user/*`, so both versions render the error state — identically, down to the skull illustration, "Could not load user rvz." and the offline hint, which exercises the shared `ErrorMessage` path rather than the profile markup.

Stacked on #663.

Devin-Org: engineering

Link to Devin session: https://app.devin.ai/sessions/298bc2f4952e4556a441b8d3b09d3bc2
Requested by: @charityquinn-cognition
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/664?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/664" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/angular2-hn/pull/664" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->