### PR TITLE
Add saved posts with editable per-post notes

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,5 +1,6 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
+import { FormsModule } from '@angular/forms';
 
 import { routing } from './app.routes';
 
@@ -7,17 +8,20 @@ import { AppComponent } from './app.component';
 import { CoreModule } from './core/core.module';
 import { FeedComponent } from './feeds/feed/feed.component';
 import { ItemComponent } from './feeds/item/item.component';
+import { SavedComponent } from './feeds/saved/saved.component';
 import { SharedComponentsModule } from './shared/components/shared-components.module';
 import { PipesModule } from './shared/pipes/pipes.module';
 import { ServiceWorkerModule } from '@angular/service-worker';
 import { environment } from '../environments/environment';
 import { HackerNewsAPIService } from './shared/services/hackernews-api.service';
 import { SettingsService } from './shared/services/settings.service';
+import { SavedPostsService } from './shared/services/saved-posts.service';
 
 @NgModule({
-    declarations: [AppComponent, FeedComponent, ItemComponent],
+    declarations: [AppComponent, FeedComponent, ItemComponent, SavedComponent],
     imports: [
         BrowserModule,
+        FormsModule,
         routing,
         CoreModule,
         SharedComponentsModule,
@@ -26,7 +30,7 @@ import { SettingsService } from './shared/services/settings.service';
             enabled: environment.production,
         }),
     ],
-    providers: [HackerNewsAPIService, SettingsService],
+    providers: [HackerNewsAPIService, SettingsService, SavedPostsService],
     bootstrap: [AppComponent],
 })
 export class AppModule {}

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,6 +1,7 @@
 import { Routes, RouterModule } from '@angular/router';
 
 import { FeedComponent } from './feeds/feed/feed.component';
+import { SavedComponent } from './feeds/saved/saved.component';
 
 const feedRoutes = [{
   path: ':page',
@@ -33,6 +34,10 @@ const routes: Routes = [
     path: 'jobs',
     children: feedRoutes,
     data: {feedType: 'jobs'}
+  },
+  {
+    path: 'saved',
+    component: SavedComponent
   },
   {path: 'item', loadChildren: () => import('./item-details/item-details.module').then(m => m.ItemDetailsModule)},
   {path: 'user', loadChildren: () => import('./user/user.module').then(m => m.UserModule)}

--- a/src/app/core/header/header.component.html
+++ b/src/app/core/header/header.component.html
@@ -14,6 +14,8 @@
             <a routerLink="/ask/1" routerLinkActive="active" (click)="scrollTop()">ask</a>
               |
             <a routerLink="/jobs/1" routerLinkActive="active" (click)="scrollTop()">jobs</a>
+              |
+            <a routerLink="/saved" routerLinkActive="active" (click)="scrollTop()">saved</a>
           </span>
         </div>
       </div>

--- a/src/app/feeds/item/item.component.html
+++ b/src/app/feeds/item/item.component.html
@@ -4,11 +4,13 @@
       {{item.title}}
     </a>
     <span *ngIf="item.domain" class="domain">({{item.domain}})</span>
+    <a class="save-toggle" (click)="toggleSaved()" [attr.title]="isSaved ? 'Unsave post' : 'Save post'">{{ isSaved ? '★' : '☆' }}</a>
   </p>
   <p *ngIf="!hasUrl">
     <a class="title" [ngStyle]="{'font-size': settings.titleFontSize+'px'}" [routerLink]="['/item', item.id]" routerLinkActive="active">
       {{item.title}}
     </a>
+    <a class="save-toggle" (click)="toggleSaved()" [attr.title]="isSaved ? 'Unsave post' : 'Save post'">{{ isSaved ? '★' : '☆' }}</a>
   </p>
   <div class="subtext-palm">
     <div class="details" *ngIf="item.type !== 'job'">

--- a/src/app/feeds/item/item.component.scss
+++ b/src/app/feeds/item/item.component.scss
@@ -58,6 +58,13 @@ p {
     }
   }
 
+  .save-toggle {
+    font-size: 13px;
+    font-weight: bold;
+    letter-spacing: 0.5px;
+    margin-left: 5px;
+  }
+
   .domain {
     color: #696969;
     letter-spacing: 0.5px;

--- a/src/app/feeds/item/item.component.ts
+++ b/src/app/feeds/item/item.component.ts
@@ -3,6 +3,7 @@ import { Story } from '../../shared/models/story';
 
 import { SettingsService } from '../../shared/services/settings.service';
 import { Settings } from '../../shared/models/settings';
+import { SavedPostsService } from '../../shared/services/saved-posts.service';
 
 @Component({
   selector: 'item',
@@ -13,7 +14,10 @@ export class ItemComponent implements OnInit {
   @Input() item: Story;
   settings: Settings;
 
-  constructor(private _settingsService: SettingsService) {
+  constructor(
+    private _settingsService: SettingsService,
+    private _savedPostsService: SavedPostsService
+  ) {
     this.settings = this._settingsService.settings;
   }
 
@@ -21,6 +25,14 @@ export class ItemComponent implements OnInit {
 
   get hasUrl(): boolean {
     return this.item.url.indexOf('http') === 0;
+  }
+
+  get isSaved(): boolean {
+    return this._savedPostsService.isSaved(this.item.id);
+  }
+
+  toggleSaved() {
+    this._savedPostsService.toggleSaved(this.item);
   }
 
 }

--- a/src/app/feeds/saved/saved.component.html
+++ b/src/app/feeds/saved/saved.component.html
@@ -1,0 +1,24 @@
+<div class="main-content">
+  <p class="empty" *ngIf="items.length === 0">
+    You have no saved posts yet. Tap the ☆ next to a post to save it for later.
+  </p>
+  <ol *ngIf="items.length > 0" class="list-margin">
+    <li *ngFor="let item of items" class="post">
+      <item class="item-block" [item]="item"></item>
+      <div class="note subtext-palm">
+        <div class="note-text" *ngIf="getNote(item.id) && editingId !== item.id">{{ getNote(item.id) }}</div>
+        <div class="note-actions" *ngIf="editingId !== item.id">
+          <a (click)="startEditing(item.id)">{{ getNote(item.id) ? 'edit note' : 'add note' }}</a>
+        </div>
+        <div class="note-editor" *ngIf="editingId === item.id">
+          <textarea rows="3" [(ngModel)]="draftNote" placeholder="Write a note..."></textarea>
+          <div class="note-actions">
+            <a (click)="saveNote(item.id)">save</a>
+            <a (click)="cancelEditing()">cancel</a>
+            <a *ngIf="getNote(item.id)" (click)="deleteNote(item.id)">delete</a>
+          </div>
+        </div>
+      </div>
+    </li>
+  </ol>
+</div>

--- a/src/app/feeds/saved/saved.component.scss
+++ b/src/app/feeds/saved/saved.component.scss
@@ -1,0 +1,82 @@
+@import "../../shared/scss/media";
+@import "../../shared/scss/theme_variables";
+
+ol {
+  padding: 0 40px;
+  margin: 0;
+
+  @media #{$mobile-only} {
+    box-sizing: border-box;
+    list-style: none;
+    padding: 0 10px;
+  }
+}
+
+.list-margin {
+  @media #{$mobile-only} {
+    margin-top: 55px;
+  }
+}
+
+.main-content {
+  position: relative;
+  width: 100%;
+  min-height: 100vh;
+  box-sizing: border-box;
+  padding: 8px 0;
+  z-index: 0;
+}
+
+.post {
+  padding: 10px 0 10px 5px;
+  border-bottom: 1px solid #CECECB;
+}
+
+.item-block {
+  display: block;
+}
+
+.empty {
+  font-size: 15px;
+  padding: 0 40px 10px;
+
+  @media #{$mobile-only} {
+    padding: 60px 15px 25px 15px;
+  }
+}
+
+.note {
+  font-size: 13px;
+  font-weight: bold;
+  letter-spacing: 0.5px;
+  margin-top: 5px;
+
+  a {
+    cursor: pointer;
+    text-decoration: none;
+    margin-right: 10px;
+
+    &:hover {
+      text-decoration: underline;
+    };
+  }
+
+  textarea {
+    width: 100%;
+    box-sizing: border-box;
+    font-family: inherit;
+    font-size: 13px;
+    letter-spacing: 0.5px;
+    padding: 5px;
+    margin-bottom: 5px;
+    background: transparent;
+    color: inherit;
+    border: 1px solid #CECECB;
+  }
+}
+
+.note-text {
+  margin-bottom: 5px;
+  font-weight: normal;
+  white-space: pre-wrap;
+}

--- a/src/app/feeds/saved/saved.component.ts
+++ b/src/app/feeds/saved/saved.component.ts
@@ -1,0 +1,49 @@
+import { Component } from '@angular/core';
+
+import { SavedPostsService } from '../../shared/services/saved-posts.service';
+import { Story } from '../../shared/models/story';
+
+@Component({
+  selector: 'app-saved',
+  templateUrl: './saved.component.html',
+  styleUrls: ['./saved.component.scss']
+})
+export class SavedComponent {
+  editingId: number = null;
+  draftNote = '';
+
+  constructor(private _savedPostsService: SavedPostsService) { }
+
+  get items(): Story[] {
+    return this._savedPostsService.savedPosts;
+  }
+
+  getNote(id: number): string {
+    return this._savedPostsService.getNote(id);
+  }
+
+  startEditing(id: number) {
+    this.editingId = id;
+    this.draftNote = this.getNote(id);
+  }
+
+  cancelEditing() {
+    this.editingId = null;
+    this.draftNote = '';
+  }
+
+  saveNote(id: number) {
+    const note = this.draftNote.trim();
+    if (note) {
+      this._savedPostsService.setNote(id, note);
+    } else {
+      this._savedPostsService.removeNote(id);
+    }
+    this.cancelEditing();
+  }
+
+  deleteNote(id: number) {
+    this._savedPostsService.removeNote(id);
+    this.cancelEditing();
+  }
+}

--- a/src/app/shared/services/saved-posts.service.ts
+++ b/src/app/shared/services/saved-posts.service.ts
@@ -1,0 +1,44 @@
+import { Injectable } from '@angular/core';
+
+import { Story } from '../models/story';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SavedPostsService {
+  savedPosts: Story[] = localStorage.getItem("savedPosts") ? JSON.parse(localStorage.getItem("savedPosts")) : [];
+  notes: { [id: number]: string } = localStorage.getItem("savedPostNotes") ? JSON.parse(localStorage.getItem("savedPostNotes")) : {};
+
+  isSaved(id: number): boolean {
+    return this.savedPosts.some(post => post.id === id);
+  }
+
+  toggleSaved(story: Story) {
+    if (this.isSaved(story.id)) {
+      this.removeSaved(story.id);
+    } else {
+      this.savedPosts = [story, ...this.savedPosts];
+      localStorage.setItem("savedPosts", JSON.stringify(this.savedPosts));
+    }
+  }
+
+  removeSaved(id: number) {
+    this.savedPosts = this.savedPosts.filter(post => post.id !== id);
+    localStorage.setItem("savedPosts", JSON.stringify(this.savedPosts));
+    this.removeNote(id);
+  }
+
+  getNote(id: number): string {
+    return this.notes[id] ? this.notes[id] : '';
+  }
+
+  setNote(id: number, note: string) {
+    this.notes[id] = note;
+    localStorage.setItem("savedPostNotes", JSON.stringify(this.notes));
+  }
+
+  removeNote(id: number) {
+    delete this.notes[id];
+    localStorage.setItem("savedPostNotes", JSON.stringify(this.notes));
+  }
+}


### PR DESCRIPTION
## Summary

The saved-posts feature did not exist on `master`, so this PR implements it and the requested per-post notes on top of it.

`SavedPostsService` holds two independently persisted, in-memory-synced structures following the `SettingsService` localStorage pattern (`getItem(...) ? JSON.parse(...) : default` on init, `setItem` on every mutation):

```ts
savedPosts: Story[]                  // localStorage "savedPosts"
notes: { [id: number]: string }      // localStorage "savedPostNotes"

removeSaved(id) { /* filter savedPosts, persist */ ; this.removeNote(id); }
```

Unsaving therefore always clears the orphaned note. `Story` is unchanged — notes live only in the notes map.

UI:
- `ItemComponent` gains a ☆/★ toggle next to the title (both the URL and non-URL title variants), calling `toggleSaved(item)`.
- New `SavedComponent` at route `/saved` (linked from the header nav) renders saved items with the note below each one. A single `editingId` gates which textarea is open; the textarea binds to a `draftNote` buffer so Cancel discards changes, and saving an empty/whitespace note removes it.
- Styling reuses the existing `.subtext-palm`/`.details` small-bold-letterspaced conventions and the `a { cursor: pointer; text-decoration: none; }` hover-underline pattern; the note block carries `subtext-palm` so the global theme rules color it in default/night/amoled.

`FormsModule` added to `AppModule` for `ngModel`.

Verified with `ng build` (needs `NODE_OPTIONS=--openssl-legacy-provider` on Node 20 for this webpack version). `npm run lint` fails on pre-existing files (e.g. `settings.service.ts`, `user.component.ts`) with the same double-quote/selector rules; the new files follow the surrounding conventions.

Devin-Org: engineering

Link to Devin session: https://app.devin.ai/sessions/509618b046804aa78c72fafc9d659bae
Requested by: @vibhaseshadri-cognition
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/669?analyze=true)

> 💡 [Connect your GitHub account](https://staging.itsdev.in/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/669" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->