### PR TITLE
PR 2 — Models &amp; data layer

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "vite",
     "build": "tsc --noEmit && vite build",
     "preview": "vite preview",
-    "test": "vitest run --passWithNoTests",
+    "test": "vitest run",
     "test:watch": "vitest"
   },
   "private": true,

--- a/src/api/hackernews.test.ts
+++ b/src/api/hackernews.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { BASE_URL, fetchFeed, fetchItemContent, fetchPollContent, fetchUser } from './hackernews';
+
+function mockFetch(responder: (url: string) => unknown) {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => ({
+        ok: true,
+        status: 200,
+        json: async () => responder(String(input)),
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+    return fetchMock;
+}
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+describe('fetchFeed', () => {
+    it('requests the feed for the given type and page', async () => {
+        const fetchMock = mockFetch(() => [{ id: 1 }]);
+
+        await expect(fetchFeed('news', 2)).resolves.toEqual([{ id: 1 }]);
+        expect(fetchMock).toHaveBeenCalledWith(`${BASE_URL}/news?page=2`, { signal: undefined });
+    });
+
+    it('rejects on a non-ok response', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn(async () => ({ ok: false, status: 503, json: async () => ({}) }))
+        );
+
+        await expect(fetchFeed('news', 1)).rejects.toThrow('Request failed with status 503');
+    });
+});
+
+describe('fetchItemContent', () => {
+    it('returns a story unchanged when it is not a poll', async () => {
+        const fetchMock = mockFetch(() => ({ id: 7, type: 'story' }));
+
+        await expect(fetchItemContent(7)).resolves.toEqual({ id: 7, type: 'story' });
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('fetches each poll option by offset id and sums the votes', async () => {
+        const fetchMock = mockFetch((url) => {
+            if (url === `${BASE_URL}/item/100`) {
+                return { id: 100, type: 'poll', poll: [{}, {}] };
+            }
+            return { points: url.endsWith('101') ? 3 : 4, content: url };
+        });
+
+        const story = await fetchItemContent(100);
+
+        expect(fetchMock).toHaveBeenCalledWith(`${BASE_URL}/item/101`, { signal: undefined });
+        expect(fetchMock).toHaveBeenCalledWith(`${BASE_URL}/item/102`, { signal: undefined });
+        expect(story.poll).toEqual([
+            { points: 3, content: `${BASE_URL}/item/101` },
+            { points: 4, content: `${BASE_URL}/item/102` },
+        ]);
+        expect(story.poll_votes_count).toBe(7);
+    });
+});
+
+describe('fetchPollContent and fetchUser', () => {
+    it('hit the item and user endpoints', async () => {
+        const fetchMock = mockFetch(() => ({}));
+
+        await fetchPollContent(5);
+        await fetchUser('pg');
+
+        expect(fetchMock).toHaveBeenCalledWith(`${BASE_URL}/item/5`, { signal: undefined });
+        expect(fetchMock).toHaveBeenCalledWith(`${BASE_URL}/user/pg`, { signal: undefined });
+    });
+});

--- a/src/api/hackernews.ts
+++ b/src/api/hackernews.ts
@@ -1,0 +1,37 @@
+import { PollResult, Story, User } from '../models';
+
+export const BASE_URL = 'https://node-hnapi.herokuapp.com';
+
+async function getJson<T>(url: string, signal?: AbortSignal): Promise<T> {
+    const response = await fetch(url, { signal });
+    if (!response.ok) {
+        throw new Error(`Request failed with status ${response.status}`);
+    }
+    return (await response.json()) as T;
+}
+
+export function fetchFeed(feedType: string, page: number, signal?: AbortSignal): Promise<Story[]> {
+    return getJson<Story[]>(`${BASE_URL}/${feedType}?page=${page}`, signal);
+}
+
+export function fetchPollContent(id: number, signal?: AbortSignal): Promise<PollResult> {
+    return getJson<PollResult>(`${BASE_URL}/item/${id}`, signal);
+}
+
+export async function fetchItemContent(id: number, signal?: AbortSignal): Promise<Story> {
+    const story = await getJson<Story>(`${BASE_URL}/item/${id}`, signal);
+
+    if (story.type === 'poll') {
+        const pollOptions = await Promise.all(
+            story.poll.map((_, index) => fetchPollContent(story.id + index + 1, signal))
+        );
+        story.poll = pollOptions;
+        story.poll_votes_count = pollOptions.reduce((total, option) => total + option.points, 0);
+    }
+
+    return story;
+}
+
+export function fetchUser(id: string, signal?: AbortSignal): Promise<User> {
+    return getJson<User>(`${BASE_URL}/user/${id}`, signal);
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,0 +1,54 @@
+export type FeedType = 'poll' | 'story' | 'job';
+
+export interface Comment {
+    id: number;
+    level: number;
+    user: string;
+    time: number;
+    time_ago: string;
+    content: string;
+    deleted: boolean;
+    comments: Comment[];
+}
+
+export interface PollResult {
+    points: number;
+    content: string;
+}
+
+export interface Story {
+    id: number;
+    title: string;
+    points: number;
+    user: string;
+    time: number;
+    time_ago: number;
+    type: FeedType;
+    url: string;
+    domain: string;
+    text?: string;
+    content?: string;
+    comments: Comment[];
+    comments_count: number;
+    poll: PollResult[];
+    poll_votes_count: number;
+    deleted: boolean;
+    dead: boolean;
+}
+
+export interface User {
+    id: string;
+    crated_time: number;
+    created: string;
+    karma: number;
+    avg: number;
+    about: string;
+}
+
+export interface Settings {
+    showSettings: boolean;
+    openLinkInNewTab: boolean;
+    theme: string;
+    titleFontSize: string;
+    listSpacing: string;
+}

--- a/src/utils/formatCommentCount.test.ts
+++ b/src/utils/formatCommentCount.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatCommentCount } from './formatCommentCount';
+
+describe('formatCommentCount', () => {
+    it('returns "discuss" when there are no comments', () => {
+        expect(formatCommentCount(0)).toBe('discuss');
+        expect(formatCommentCount(-1)).toBe('discuss');
+    });
+
+    it('uses the singular form for a single comment', () => {
+        expect(formatCommentCount(1)).toBe('1 comment');
+    });
+
+    it('uses the plural form for several comments', () => {
+        expect(formatCommentCount(42)).toBe('42 comments');
+    });
+});

--- a/src/utils/formatCommentCount.ts
+++ b/src/utils/formatCommentCount.ts
@@ -1,0 +1,6 @@
+export function formatCommentCount(count: number): string {
+    if (count > 0) {
+        return `${count} ${count === 1 ? 'comment' : 'comments'}`;
+    }
+    return 'discuss';
+}


### PR DESCRIPTION
## Summary
Ports the Angular data layer to framework-free TypeScript (no UI yet). The Angular originals stay in place until PR 7.

- `src/app/shared/models/*` → `src/models/index.ts`, with the data-shape classes (`Story`, `User`, `Comment`, `PollResult`) becoming `interface`s. `Story` gains optional `text`/`content`, which the item-details template already reads but the class never declared.
- `HackerNewsAPIService` → `src/api/hackernews.ts`: the `Observable`-wrapped `unfetch` helper becomes `async/await` over native `fetch`, with an optional `AbortSignal` per call and an explicit non-ok check (`unfetch` silently resolved on 4xx/5xx). Base URL unchanged.
  Poll handling keeps the original id-offset scheme but awaits it, so the returned story is complete rather than mutating after the subscriber already saw it:
  ```ts
  const pollOptions = await Promise.all(story.poll.map((_, i) => fetchPollContent(story.id + i + 1, signal)));
  story.poll = pollOptions;
  story.poll_votes_count = pollOptions.reduce((t, o) => t + o.points, 0);
  ```
- `CommentPipe` → `src/utils/formatCommentCount.ts` (same `discuss` / `1 comment` / `n comments` output).
- Vitest specs for both; `npm test` drops `--passWithNoTests`.

## Verification
`npm test` (8 tests) and `npm run build` pass.


Link to Devin session: https://app.devin.ai/sessions/aba225b0bbcb4631be6b8eee6d6b2be1
Requested by: @devanshi-gpta
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/672?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/672" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-staging-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-staging-light.svg?v=3" alt="Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->