### PR TITLE
PR 5 — Item details, comments & user pages

### DIFF
--- a/src/components/item-details/Comment.scss
+++ b/src/components/item-details/Comment.scss
@@ -1,7 +1,7 @@
-@import "../../shared/scss/media";
-@import "../../shared/scss/theme_variables";
+@import "../../styles/media";
+@import "../../styles/theme_variables";
 
-:host >>> {
+.comment-tree {
   a {
     font-weight: bold;
     text-decoration: none;

--- a/src/components/item-details/Comment.tsx
+++ b/src/components/item-details/Comment.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+
+import { Comment as CommentModel } from '../../models';
+import './Comment.scss';
+
+export function Comment({ comment }: { comment: CommentModel }) {
+    const [collapse, setCollapse] = useState(false);
+
+    if (comment.deleted) {
+        return (
+            <div>
+                <div className="deleted-meta">
+                    <span className="collapse">[deleted]</span> | Comment Deleted
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div>
+            <div className={collapse ? 'meta meta-collapse' : 'meta'}>
+                <span className="collapse" onClick={() => setCollapse(!collapse)}>
+                    [{collapse ? '+' : '-'}]
+                </span>{' '}
+                <Link to={`/user/${comment.user}`}>{comment.user}</Link>
+                <span className="time">{comment.time_ago}</span>
+            </div>
+            <div className="comment-tree">
+                <div hidden={collapse}>
+                    <p className="comment-text" dangerouslySetInnerHTML={{ __html: comment.content }}></p>
+                    <ul className="subtree">
+                        {comment.comments.map((subComment) => (
+                            <li key={subComment.id}>
+                                <Comment comment={subComment} />
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/item-details/ItemDetails.scss
+++ b/src/components/item-details/ItemDetails.scss
@@ -1,5 +1,5 @@
-@import "../shared/scss/media";
-@import "../shared/scss/theme_variables";
+@import "../../styles/media";
+@import "../../styles/theme_variables";
 
 .main-content {
   position: relative;

--- a/src/components/item-details/ItemDetails.tsx
+++ b/src/components/item-details/ItemDetails.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+
+import { fetchItemContent } from '../../api/hackernews';
+import { useSettings } from '../../context/SettingsContext';
+import { Story } from '../../models';
+import { formatCommentCount } from '../../utils/formatCommentCount';
+import { ErrorMessage } from '../shared/ErrorMessage';
+import { Loader } from '../shared/Loader';
+import { Comment } from './Comment';
+import './ItemDetails.scss';
+
+export function ItemDetails() {
+    const { id } = useParams();
+    const navigate = useNavigate();
+    const { settings } = useSettings();
+    const [item, setItem] = useState<Story | null>(null);
+    const [errorMessage, setErrorMessage] = useState('');
+
+    useEffect(() => {
+        const controller = new AbortController();
+
+        setItem(null);
+        setErrorMessage('');
+        window.scrollTo(0, 0);
+
+        fetchItemContent(Number(id), controller.signal)
+            .then(setItem)
+            .catch((error: unknown) => {
+                if (!controller.signal.aborted) {
+                    setErrorMessage('Could not load item comments.');
+                    console.error(error);
+                }
+            });
+
+        return () => controller.abort();
+    }, [id]);
+
+    if (!item) {
+        return (
+            <div className="main-content">
+                {!errorMessage && <Loader />}
+                {errorMessage !== '' && <ErrorMessage message={errorMessage} />}
+            </div>
+        );
+    }
+
+    const hasUrl = item.url.indexOf('http') === 0;
+    const laptopClasses = ['laptop'];
+    if (item.comments_count > 0 || item.type === 'job') {
+        laptopClasses.push('item-header');
+    }
+    if (item.text) {
+        laptopClasses.push('head-margin');
+    }
+
+    const titleLink = hasUrl ? (
+        <a
+            className="title"
+            href={item.url}
+            target={settings.openLinkInNewTab ? '_blank' : undefined}
+            rel={settings.openLinkInNewTab ? 'noopener' : undefined}
+        >
+            {item.title}
+        </a>
+    ) : (
+        <Link className="title" to={`/item/${item.id}`}>
+            {item.title}
+        </Link>
+    );
+
+    return (
+        <div className="main-content">
+            <div className="item">
+                <div className="mobile item-header">
+                    <p className="title-block">
+                        <span className="back-button" onClick={() => navigate(-1)}></span>
+                        {titleLink}
+                    </p>
+                </div>
+                <div className={laptopClasses.join(' ')}>
+                    <p>
+                        {titleLink}
+                        {hasUrl && item.domain && <span className="domain">({item.domain})</span>}
+                    </p>
+                    <div className="subtext">
+                        {item.type !== 'job' && (
+                            <span>
+                                {item.points} points by <Link to={`/user/${item.user}`}>{item.user}</Link>
+                            </span>
+                        )}
+                        <span className={item.type !== 'job' ? 'item-details' : undefined}>
+                            {item.time_ago}
+                            {item.type !== 'job' && (
+                                <span>
+                                    {' | '}
+                                    <Link to={`/item/${item.id}`}>{formatCommentCount(item.comments_count)}</Link>
+                                </span>
+                            )}
+                        </span>
+                    </div>
+                </div>
+                {item.type === 'poll' && (
+                    <div className="pollResults">
+                        {item.poll.map((pollResult, index) => (
+                            <div key={index} className="pollContent">
+                                <div dangerouslySetInnerHTML={{ __html: pollResult.content }}></div>
+                                <div className="subtext">{pollResult.points} points</div>
+                                <div
+                                    className="pollBar"
+                                    style={{ width: `${(pollResult.points / item.poll_votes_count) * 100}%` }}
+                                ></div>
+                            </div>
+                        ))}
+                    </div>
+                )}
+                <p className="subject" dangerouslySetInnerHTML={{ __html: item.content ?? '' }}></p>
+                <ul className="comment-list">
+                    {item.comments.map((comment) => (
+                        <li key={comment.id}>
+                            <Comment comment={comment} />
+                        </li>
+                    ))}
+                </ul>
+            </div>
+        </div>
+    );
+}

--- a/src/components/user/UserProfile.scss
+++ b/src/components/user/UserProfile.scss
@@ -1,7 +1,7 @@
-@import "../shared/scss/media";
-@import "../shared/scss/theme_variables";
+@import "../../styles/media";
+@import "../../styles/theme_variables";
 
-:host >>> pre {
+.profile pre {
   white-space: pre-wrap;
 }
 

--- a/src/components/user/UserProfile.tsx
+++ b/src/components/user/UserProfile.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+
+import { fetchUser } from '../../api/hackernews';
+import { User } from '../../models';
+import { ErrorMessage } from '../shared/ErrorMessage';
+import { Loader } from '../shared/Loader';
+import './UserProfile.scss';
+
+export function UserProfile() {
+    const { id } = useParams();
+    const navigate = useNavigate();
+    const [user, setUser] = useState<User | null>(null);
+    const [errorMessage, setErrorMessage] = useState('');
+
+    useEffect(() => {
+        const controller = new AbortController();
+
+        setUser(null);
+        setErrorMessage('');
+
+        fetchUser(String(id), controller.signal)
+            .then(setUser)
+            .catch((error: unknown) => {
+                if (!controller.signal.aborted) {
+                    setErrorMessage(`Could not load user ${id}.`);
+                    console.error(error);
+                }
+            });
+
+        return () => controller.abort();
+    }, [id]);
+
+    if (!user) {
+        return (
+            <>
+                {!errorMessage && <Loader />}
+                {errorMessage !== '' && <ErrorMessage message={errorMessage} />}
+            </>
+        );
+    }
+
+    return (
+        <div className="profile">
+            <div className="mobile item-header">
+                <p className="title-block">
+                    <span className="back-button" onClick={() => navigate(-1)}></span>
+                    Profile: {user.id}
+                </p>
+            </div>
+            <div className="main-details">
+                <span className="name">{user.id}</span>
+                <span className="right">{user.karma} ★</span>
+                <p className="age">Created {user.created}</p>
+            </div>
+            {user.about && (
+                <div className="other-details">
+                    <p dangerouslySetInnerHTML={{ __html: user.about }}></p>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,11 +1,19 @@
-import React from 'react';
+import React, { Suspense, lazy } from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
 
 import { App } from './App';
 import { Feed } from './components/feeds/Feed';
+import { Loader } from './components/shared/Loader';
 import { SettingsProvider } from './context/SettingsContext';
 import './styles/global.scss';
+
+const ItemDetails = lazy(() =>
+    import('./components/item-details/ItemDetails').then((module) => ({ default: module.ItemDetails }))
+);
+const UserProfile = lazy(() =>
+    import('./components/user/UserProfile').then((module) => ({ default: module.UserProfile }))
+);
 
 const FEED_TYPES = ['news', 'newest', 'show', 'ask', 'jobs'];
 
@@ -23,6 +31,22 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
                                 element={<Feed feedType={feedType} />}
                             />
                         ))}
+                        <Route
+                            path="item/:id"
+                            element={
+                                <Suspense fallback={<Loader />}>
+                                    <ItemDetails />
+                                </Suspense>
+                            }
+                        />
+                        <Route
+                            path="user/:id"
+                            element={
+                                <Suspense fallback={<Loader />}>
+                                    <UserProfile />
+                                </Suspense>
+                            }
+                        />
                     </Route>
                 </Routes>
             </BrowserRouter>


### PR DESCRIPTION
## Summary
Completes the UI port: every route the Angular app had now renders in React.

- `item-details/` → `src/components/item-details/ItemDetails.tsx`: `id` from `useParams`, `fetchItemContent` in an abortable effect, `goBack` → `useNavigate(-1)`, the `hasUrl` getter → a local const, and the poll bar (`points / poll_votes_count * 100 + '%'`) and `[innerHTML]` blocks kept via `dangerouslySetInnerHTML`.
- `item-details/comment/` → `Comment.tsx`, recursive over `comment.comments` with per-node `const [collapse, setCollapse] = useState(false)` replacing the Angular instance field. The deleted-comment branch and the `[hidden]`-not-unmount collapse behaviour are preserved, so subtree state survives toggling.
- `user/` → `src/components/user/UserProfile.tsx`, same params/fetch/goBack shape.
- Routes are lazy, mirroring the original lazy NgModules — each a `React.lazy` chunk behind `<Suspense fallback={<Loader/>}>`:
  ```tsx
  <Route path="item/:id" element={<Suspense fallback={<Loader/>}><ItemDetails/></Suspense>} />
  <Route path="user/:id" element={<Suspense fallback={<Loader/>}><UserProfile/></Suspense>} />
  ```
  The build confirms the split: `ItemDetails-*.js` and `UserProfile-*.js` emit as separate chunks.
- SCSS moved with import paths rewritten. Angular's `:host >>>` piercing selectors have no React equivalent, so they are re-scoped to a class the component actually renders: `.comment-tree a` and `.profile pre`.

## Verification
`npm run build`, `npm test`, `npm run dev`.


Link to Devin session: https://app.devin.ai/sessions/aba225b0bbcb4631be6b8eee6d6b2be1
Requested by: @devanshi-gpta
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/675?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/angular2-hn/pull/675" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-staging-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-staging-light.svg?v=3" alt="Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->