### PR TITLE
User profile (migration 6/8)

### DIFF
--- a/src-react/App.tsx
+++ b/src-react/App.tsx
@@ -6,6 +6,7 @@ import Header from './core/header/Header';
 import Feed from './feeds/feed/Feed';
 import ItemDetails from './item-details/ItemDetails';
 import type { FeedName } from './shared/models';
+import User from './user/User';
 import './App.scss';
 
 const feedNames: FeedName[] = ['news', 'newest', 'show', 'ask', 'jobs'];
@@ -28,6 +29,7 @@ function App() {
                         />
                     ))}
                     <Route path="item/:id" element={<ItemDetails />} />
+                    <Route path="user/:id" element={<User />} />
                 </Routes>
                 <Footer />
             </div>

--- a/src-react/user/User.scss
+++ b/src-react/user/User.scss
@@ -1,0 +1,89 @@
+@import "../shared/scss/media";
+@import "../shared/scss/theme_variables";
+
+:host >>> pre {
+  white-space: pre-wrap;
+}
+
+.profile {
+  padding: 30px;
+}
+
+@media #{$mobile-only} {
+  .profile {
+    padding: 110px 15px 0 15px;
+  }
+  .title-block {
+    font-size: 15px;
+    text-align: center;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    margin: 0 75px;
+  }
+  .back-button {
+    position: absolute;
+    top: 52%;
+    width: 0.6rem;
+    height: 0.6rem;
+    background: transparent;
+    box-shadow: 0 0 0 lightgray;
+    transition: all 200ms ease;
+    left: 4%;
+    transform: translate3d(0, -50%, 0) rotate(-135deg);
+  }
+  .item-header {
+    padding-bottom: 10px;
+    background-color: #fff;
+    padding: 10px 0 10px 0;
+    position: fixed;
+    width: 100%;
+    left: 0;
+    top: 62px;
+    height: 20px;
+  }
+}
+
+@media #{$laptop-only} {
+  .mobile {
+    display: none;
+  }
+}
+
+.main-details {
+  .name {
+    font-weight: bold;
+    font-size: 32px;
+    letter-spacing: 2px;
+  }
+  .age {
+    font-weight: bold;
+    color: #696969;
+    padding-bottom: 0;
+  }
+  .right {
+    float: right;
+    font-weight: bold;
+    font-size: 32px;
+    letter-spacing: 2px;
+  }
+}
+
+@media #{$mobile-only} {
+  .main-details {
+    margin-top: 20px;
+    .name {
+      font-size: 18px;
+    }
+  }
+}
+
+@media #{$mobile-only} {
+  .main-details .right {
+    font-size: 18px;
+  }
+}
+
+.other-details {
+  word-wrap: break-word;
+}

--- a/src-react/user/User.scss
+++ b/src-react/user/User.scss
@@ -1,7 +1,7 @@
 @import "../shared/scss/media";
 @import "../shared/scss/theme_variables";
 
-:host >>> pre {
+.other-details pre {
   white-space: pre-wrap;
 }
 

--- a/src-react/user/User.tsx
+++ b/src-react/user/User.tsx
@@ -5,6 +5,7 @@ import { fetchUser } from '../shared/api/hackernewsApi';
 import ErrorMessage from '../shared/components/error-message/ErrorMessage';
 import Loader from '../shared/components/loader/Loader';
 import type { User as UserModel } from '../shared/models';
+import { sanitizeHtml } from '../shared/utils/sanitizeHtml';
 import './User.scss';
 
 function User() {
@@ -58,7 +59,7 @@ function User() {
                     </div>
                     {user.about && (
                         <div className="other-details">
-                            <p dangerouslySetInnerHTML={{ __html: user.about }} />
+                            <p dangerouslySetInnerHTML={{ __html: sanitizeHtml(user.about) }} />
                         </div>
                     )}
                 </div>

--- a/src-react/user/User.tsx
+++ b/src-react/user/User.tsx
@@ -1,0 +1,70 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+
+import { fetchUser } from '../shared/api/hackernewsApi';
+import ErrorMessage from '../shared/components/error-message/ErrorMessage';
+import Loader from '../shared/components/loader/Loader';
+import type { User as UserModel } from '../shared/models';
+import './User.scss';
+
+function User() {
+    const params = useParams<{ id?: string }>();
+    const userID = params.id ?? '';
+    const navigate = useNavigate();
+    const [user, setUser] = useState<UserModel>();
+    const [errorMessage, setErrorMessage] = useState('');
+
+    useEffect(() => {
+        let ignore = false;
+        setErrorMessage('');
+
+        fetchUser(userID)
+            .then((nextUser) => {
+                if (!ignore) {
+                    setUser(nextUser);
+                }
+            })
+            .catch(() => {
+                if (!ignore) {
+                    setErrorMessage(`Could not load user ${userID}.`);
+                }
+            });
+
+        return () => {
+            ignore = true;
+        };
+    }, [userID]);
+
+    const goBack = () => {
+        navigate(-1);
+    };
+
+    return (
+        <>
+            {!user && !errorMessage && <Loader />}
+            {!user && errorMessage !== '' && <ErrorMessage message={errorMessage} />}
+            {user && (
+                <div className="profile">
+                    <div className="mobile item-header">
+                        <p className="title-block">
+                            <span className="back-button" onClick={goBack} />
+                            Profile: {user.id}
+                        </p>
+                    </div>
+                    <div className="main-details">
+                        <span className="name">{user.id}</span>
+                        <span className="right">{user.karma} ★</span>
+                        <p className="age">Created {user.created}</p>
+                    </div>
+                    {user.about && (
+                        <div className="other-details">
+                            <p dangerouslySetInnerHTML={{ __html: user.about }} />
+                        </div>
+                    )}
+                </div>
+            )}
+        </>
+    );
+}
+
+export default User;


### PR DESCRIPTION
## Summary

Stacked on #693. Ports `user/user.component` to `src-react/user/User.tsx` and adds `/user/:id`, completing the route surface — the author links added in PR5 now resolve.

- `fetchUser(id)` in an effect keyed on the route param, same `ignore` staleness guard; error message is byte-identical (`Could not load user <id>.`).
- Markup matches the template exactly: mobile item-header with the back button (`navigate(-1)`), `main-details` with id / karma `★` / `Created {created}`, and the `other-details` block only when `about` is present. That `about` HTML goes through PR5's `sanitizeHtml()` wrapper — it's profile-owner-authored, and Angular's `[innerHTML]` sanitized it, so rendering it raw would have been a regression rather than parity. The Angular user view has no `main-content` wrapper, so neither does this one.
- `user.component.scss` is copied unchanged except its `:host >>> pre` rule, rescoped to `.other-details pre` for the same reason as PR5's comment styles.

Verified: `yarn react:build` passes; the error path renders the message rather than a blank page.

Two things left as-is, both matching the original: a failed load after a successful one keeps the previous profile on screen (Angular only assigned `user` on success, and `ItemDetails` behaves the same way), and a non-numeric route param is passed through to the API.

One gap worth flagging: the upstream API's `/user/<id>` endpoint currently 404s for every id tried (`pg`, `dang`, real story authors), so the populated profile — karma, created, `about` — could not be verified against live data. That's a node-hnapi outage, not a code issue; the loading/error paths and markup are verified, the happy path is not.

Devin-Org: engineering

Link to Devin session: https://app.devin.ai/sessions/1ff25c6cf2f949458f82cc596fc79c65
Requested by: @charityquinn-cognition
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/angular2-hn/pull/694" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->