### PR TITLE
Phase 1: React core foundation (models, API client, settings store, routing shell)

### DIFF
--- a/react/e2e/app.spec.ts
+++ b/react/e2e/app.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test';
 
-test('renders the React placeholder', async ({ page }) => {
+test('redirects to the news feed', async ({ page }) => {
     await page.goto('/');
-    await expect(page.getByText('Angular 2 HN — React')).toBeVisible();
+    await expect(page).toHaveURL(/\/news\/1$/);
+    await expect(page.getByText('news feed page 1')).toBeVisible();
 });

--- a/react/src/App.test.tsx
+++ b/react/src/App.test.tsx
@@ -4,13 +4,13 @@ import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 
 describe('App', () => {
-    it('renders the React placeholder', () => {
+    it('redirects to the news feed', () => {
         render(
             <BrowserRouter>
                 <App />
             </BrowserRouter>
         );
 
-        expect(screen.getByText('Angular 2 HN — React')).toBeInTheDocument();
+        expect(screen.getByText('news feed page 1')).toBeInTheDocument();
     });
 });

--- a/react/src/App.tsx
+++ b/react/src/App.tsx
@@ -1,10 +1,12 @@
-import { Route, Routes } from 'react-router-dom';
+import { SettingsProvider } from './shared/settings/SettingsContext';
+import { AppRoutes } from './app/routes';
+import { FeedPlaceholder, ItemDetailsPlaceholder, UserPlaceholder } from './app/placeholders';
 
 function App() {
     return (
-        <Routes>
-            <Route index element={<div>Angular 2 HN — React</div>} />
-        </Routes>
+        <SettingsProvider>
+            <AppRoutes Feed={FeedPlaceholder} ItemDetails={ItemDetailsPlaceholder} User={UserPlaceholder} />
+        </SettingsProvider>
     );
 }
 

--- a/react/src/app/placeholders.tsx
+++ b/react/src/app/placeholders.tsx
@@ -1,0 +1,26 @@
+import { useParams } from 'react-router-dom';
+
+import { FeedRoute } from '../shared/models';
+import { useFeedPage } from './use-feed-page';
+
+export function FeedPlaceholder({ feedType }: { feedType: FeedRoute }) {
+    const page = useFeedPage();
+
+    return (
+        <div data-testid="feed">
+            {feedType} feed page {page}
+        </div>
+    );
+}
+
+export function ItemDetailsPlaceholder() {
+    const { id } = useParams();
+
+    return <div data-testid="item">item {id}</div>;
+}
+
+export function UserPlaceholder() {
+    const { id } = useParams();
+
+    return <div data-testid="user">user {id}</div>;
+}

--- a/react/src/app/routes.test.tsx
+++ b/react/src/app/routes.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { AppRoutes } from './routes';
+import { FeedPlaceholder, ItemDetailsPlaceholder, UserPlaceholder } from './placeholders';
+import { FeedRoute, FEED_ROUTES } from '../shared/models';
+
+function renderRoutes(path: string) {
+    return render(
+        <MemoryRouter initialEntries={[path]}>
+            <AppRoutes Feed={FeedPlaceholder} ItemDetails={ItemDetailsPlaceholder} User={UserPlaceholder} />
+        </MemoryRouter>
+    );
+}
+
+describe('AppRoutes', () => {
+    it('redirects the root route to the first news page', () => {
+        renderRoutes('/');
+
+        expect(screen.getByText('news feed page 1')).toBeInTheDocument();
+    });
+
+    it.each(FEED_ROUTES)('renders the %s feed at page 2', (feedType: FeedRoute) => {
+        renderRoutes(`/${feedType}/2`);
+
+        expect(screen.getByText(`${feedType} feed page 2`)).toBeInTheDocument();
+    });
+
+    it('renders item details', () => {
+        renderRoutes('/item/123');
+
+        expect(screen.getByText('item 123')).toBeInTheDocument();
+    });
+
+    it('renders a user', () => {
+        renderRoutes('/user/pg');
+
+        expect(screen.getByText('user pg')).toBeInTheDocument();
+    });
+});

--- a/react/src/app/routes.tsx
+++ b/react/src/app/routes.tsx
@@ -1,0 +1,23 @@
+import { ComponentType } from 'react';
+import { Navigate, Route, Routes } from 'react-router-dom';
+
+import { FEED_ROUTES, FeedRoute } from '../shared/models';
+
+export interface AppRouteComponents {
+    Feed: ComponentType<{ feedType: FeedRoute }>;
+    ItemDetails: ComponentType;
+    User: ComponentType;
+}
+
+export function AppRoutes({ Feed, ItemDetails, User }: AppRouteComponents) {
+    return (
+        <Routes>
+            <Route path="/" element={<Navigate to="/news/1" replace />} />
+            {FEED_ROUTES.map((feedType) => (
+                <Route key={feedType} path={`/${feedType}/:page`} element={<Feed feedType={feedType} />} />
+            ))}
+            <Route path="/item/:id" element={<ItemDetails />} />
+            <Route path="/user/:id" element={<User />} />
+        </Routes>
+    );
+}

--- a/react/src/app/use-feed-page.test.ts
+++ b/react/src/app/use-feed-page.test.ts
@@ -1,0 +1,14 @@
+import { renderHook } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { useFeedPage } from './use-feed-page';
+
+describe('useFeedPage', () => {
+    it('returns 1 when the page parameter is missing', () => {
+        const { result } = renderHook(() => useFeedPage(), {
+            wrapper: MemoryRouter,
+        });
+
+        expect(result.current).toBe(1);
+    });
+});

--- a/react/src/app/use-feed-page.ts
+++ b/react/src/app/use-feed-page.ts
@@ -1,0 +1,7 @@
+import { useParams } from 'react-router-dom';
+
+export function useFeedPage(): number {
+    const { page } = useParams();
+
+    return page ? +page : 1;
+}

--- a/react/src/shared/components/ErrorMessage.scss
+++ b/react/src/shared/components/ErrorMessage.scss
@@ -1,0 +1,119 @@
+@use 'sass:math';
+
+@import '../../styles/media';
+@import '../../styles/theme_variables';
+
+.error-section {
+    height: 300px;
+    margin: 200px;
+
+    @media #{$mobile-only} {
+        height: 0;
+        display: block;
+        position: relative;
+        margin: 30vh 0;
+    }
+
+    p {
+        text-align: center;
+        padding: 0 25px;
+
+        &.strong {
+            margin-top: 25px;
+            font-weight: bold;
+        }
+    }
+
+    .skull {
+        width: $skull-size;
+        height: $skull-size;
+        position: relative;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        margin: auto;
+
+        .head {
+            width: 100%;
+            height: 75%;
+            border-radius: 15% / 20%;
+            position: absolute;
+            top: 0;
+            left: 0;
+            &:before,
+            &:after {
+                content: '';
+                position: absolute;
+                border-radius: 50%;
+                width: 20%;
+                height: 30%;
+                bottom: 10%;
+            }
+            &:before {
+                left: 10%;
+            }
+            &:after {
+                right: 10%;
+            }
+            .crack {
+                width: 10%;
+                height: 10%;
+                position: absolute;
+                top: 0;
+                right: 25%;
+                transform: skew(-15deg);
+
+                &:before {
+                    content: '';
+                    position: absolute;
+                    top: 100%;
+                    left: math.div($skull-size, 15);
+                    border-right: math.div($skull-size, 20) solid transparent;
+                    border-left: math.div($skull-size, 40) solid transparent;
+                }
+            }
+        }
+        .mouth {
+            width: 40%;
+            height: 25%;
+            position: absolute;
+            top: 75%;
+            left: 30%;
+            border-radius: 0 0 math.div($skull-size, 10) math.div($skull-size, 10);
+            &:before {
+                content: '';
+                position: absolute;
+                width: 15%;
+                height: 50%;
+                border-radius: 50% / 30%;
+                left: 42.5%;
+                top: -25%;
+            }
+            .teeth {
+                position: absolute;
+                bottom: 0;
+                left: 45%;
+                width: 10%;
+                height: 50%;
+                margin-bottom: -5%;
+                border-radius: 50% / 20%;
+
+                &:before,
+                &:after {
+                    content: '';
+                    position: absolute;
+                    width: 100%;
+                    height: 100%;
+                    border-radius: 50% / 20%;
+                }
+                &:before {
+                    left: -250%;
+                }
+                &:after {
+                    right: -250%;
+                }
+            }
+        }
+    }
+}

--- a/react/src/shared/components/ErrorMessage.test.tsx
+++ b/react/src/shared/components/ErrorMessage.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+
+import { ErrorMessage } from './ErrorMessage';
+
+describe('ErrorMessage', () => {
+    it('renders the message, offline note, and skull markup', () => {
+        render(<ErrorMessage message="Something went wrong" />);
+
+        expect(screen.getByText('Something went wrong')).toHaveClass('strong');
+        expect(
+            screen.getByText(
+                "If you are offline viewing, you'll need to visit this page with a network connection first before it can work offline."
+            )
+        ).toBeInTheDocument();
+        expect(document.querySelector('.error-section')).toBeInTheDocument();
+        expect(document.querySelector('.skull .head .crack')).toBeInTheDocument();
+        expect(document.querySelector('.skull .mouth .teeth')).toBeInTheDocument();
+    });
+});

--- a/react/src/shared/components/ErrorMessage.tsx
+++ b/react/src/shared/components/ErrorMessage.tsx
@@ -1,0 +1,21 @@
+import './ErrorMessage.scss';
+
+export function ErrorMessage({ message }: { message: string }) {
+    return (
+        <div className="error-section">
+            <div className="skull">
+                <div className="head">
+                    <div className="crack"></div>
+                </div>
+                <div className="mouth">
+                    <div className="teeth"></div>
+                </div>
+            </div>
+            <p className="strong">{message}</p>
+            <p>
+                If you are offline viewing, you'll need to visit this page with a network connection first before it can
+                work offline.
+            </p>
+        </div>
+    );
+}

--- a/react/src/shared/components/Loader.scss
+++ b/react/src/shared/components/Loader.scss
@@ -1,0 +1,111 @@
+@import '../../styles/media';
+@import '../../styles/theme_variables';
+
+.loader {
+    -webkit-animation: load1 1s infinite ease-in-out;
+    animation: load1 1s infinite ease-in-out;
+    width: 1em;
+    height: 4em;
+    &:before,
+    &:after {
+        -webkit-animation: load1 1s infinite ease-in-out;
+        animation: load1 1s infinite ease-in-out;
+        width: 1em;
+        height: 4em;
+    }
+    &:before,
+    &:after {
+        position: absolute;
+        top: 0;
+        content: '';
+    }
+    &:before {
+        left: -1.5em;
+        -webkit-animation-delay: -0.32s;
+        animation-delay: -0.32s;
+    }
+}
+
+.loading-section {
+    height: 70px;
+    margin: 40px 0 40px 40px;
+
+    @media #{$mobile-only} {
+        display: block;
+        position: relative;
+        margin: 45vh 0;
+    }
+}
+
+.loader {
+    text-indent: -9999em;
+    margin: 20px 20px;
+    position: relative;
+    font-size: 11px;
+    -webkit-transform: translateZ(0);
+    -ms-transform: translateZ(0);
+    transform: translateZ(0);
+    -webkit-animation-delay: -0.16s;
+    animation-delay: -0.16s;
+    &:after {
+        left: 1.5em;
+    }
+
+    @media #{$mobile-only} {
+        margin: 20px auto;
+    }
+}
+
+@-webkit-keyframes load1 {
+    0%,
+    80%,
+    100% {
+        box-shadow: 0 0;
+        height: 2em;
+    }
+    40% {
+        box-shadow: 0 -2em;
+        height: 3em;
+    }
+}
+
+@keyframes load1 {
+    0%,
+    80%,
+    100% {
+        box-shadow: 0 0;
+        height: 2em;
+    }
+    40% {
+        box-shadow: 0 -2em;
+        height: 3em;
+    }
+}
+
+@media #{$mobile-only} {
+    @-webkit-keyframes load1 {
+        0%,
+        80%,
+        100% {
+            box-shadow: 0 0;
+            height: 4em;
+        }
+        40% {
+            box-shadow: 0 -2em;
+            height: 5em;
+        }
+    }
+
+    @keyframes load1 {
+        0%,
+        80%,
+        100% {
+            box-shadow: 0 0;
+            height: 3em;
+        }
+        40% {
+            box-shadow: 0 -2em;
+            height: 4em;
+        }
+    }
+}

--- a/react/src/shared/components/Loader.test.tsx
+++ b/react/src/shared/components/Loader.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react';
+
+import { Loader } from './Loader';
+
+describe('Loader', () => {
+    it('renders the loading indicator', () => {
+        render(<Loader />);
+
+        expect(screen.getByText('Loading...')).toHaveClass('loader');
+        expect(screen.getByText('Loading...').parentElement).toHaveClass('loading-section');
+    });
+});

--- a/react/src/shared/components/Loader.tsx
+++ b/react/src/shared/components/Loader.tsx
@@ -1,0 +1,9 @@
+import './Loader.scss';
+
+export function Loader() {
+    return (
+        <div className="loading-section">
+            <div className="loader">Loading...</div>
+        </div>
+    );
+}

--- a/react/src/shared/components/index.ts
+++ b/react/src/shared/components/index.ts
@@ -1,0 +1,2 @@
+export { ErrorMessage } from './ErrorMessage';
+export { Loader } from './Loader';

--- a/react/src/shared/models/comment.ts
+++ b/react/src/shared/models/comment.ts
@@ -1,0 +1,10 @@
+export interface Comment {
+    id: number;
+    level: number;
+    user: string;
+    time: number;
+    time_ago: string;
+    content: string;
+    deleted: boolean;
+    comments: Comment[];
+}

--- a/react/src/shared/models/feed-route.type.ts
+++ b/react/src/shared/models/feed-route.type.ts
@@ -1,0 +1,3 @@
+export type FeedRoute = 'news' | 'newest' | 'show' | 'ask' | 'jobs';
+
+export const FEED_ROUTES: FeedRoute[] = ['news', 'newest', 'show', 'ask', 'jobs'];

--- a/react/src/shared/models/feed-type.type.ts
+++ b/react/src/shared/models/feed-type.type.ts
@@ -1,0 +1,1 @@
+export type FeedType = 'poll' | 'story' | 'job';

--- a/react/src/shared/models/index.ts
+++ b/react/src/shared/models/index.ts
@@ -1,0 +1,8 @@
+export type { Comment } from './comment';
+export type { FeedRoute } from './feed-route.type';
+export { FEED_ROUTES } from './feed-route.type';
+export type { FeedType } from './feed-type.type';
+export type { PollResult } from './poll-result';
+export type { Settings } from './settings';
+export type { Story } from './story';
+export type { User } from './user';

--- a/react/src/shared/models/poll-result.ts
+++ b/react/src/shared/models/poll-result.ts
@@ -1,0 +1,4 @@
+export interface PollResult {
+    points: number;
+    content: string;
+}

--- a/react/src/shared/models/settings.ts
+++ b/react/src/shared/models/settings.ts
@@ -1,0 +1,7 @@
+export interface Settings {
+    showSettings: boolean;
+    openLinkInNewTab: boolean;
+    theme: string;
+    titleFontSize: string;
+    listSpacing: string;
+}

--- a/react/src/shared/models/story.ts
+++ b/react/src/shared/models/story.ts
@@ -1,0 +1,21 @@
+import { Comment } from './comment';
+import { FeedType } from './feed-type.type';
+import { PollResult } from './poll-result';
+
+export interface Story {
+    id: number;
+    title: string;
+    points: number;
+    user: string;
+    time: number;
+    time_ago: number;
+    type: FeedType;
+    url: string;
+    domain: string;
+    comments: Comment[];
+    comments_count: number;
+    poll: PollResult[];
+    poll_votes_count: number;
+    deleted: boolean;
+    dead: boolean;
+}

--- a/react/src/shared/models/user.ts
+++ b/react/src/shared/models/user.ts
@@ -1,0 +1,8 @@
+export interface User {
+    id: string;
+    crated_time: number;
+    created: string;
+    karma: number;
+    avg: number;
+    about: string;
+}

--- a/react/src/shared/services/hackernews-api.test.ts
+++ b/react/src/shared/services/hackernews-api.test.ts
@@ -1,0 +1,97 @@
+import { BASE_URL, fetchFeed, fetchItemContent, fetchPollContent, fetchUser } from './hackernews-api';
+import { Story } from '../models';
+
+describe('hackerNewsApi', () => {
+    const fetchMock = vi.fn();
+
+    beforeEach(() => {
+        fetchMock.mockReset();
+        vi.stubGlobal('fetch', fetchMock);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    function response(data: unknown, ok = true, status = 200) {
+        return {
+            ok,
+            status,
+            json: vi.fn().mockResolvedValue(data),
+        };
+    }
+
+    it('fetches a feed', async () => {
+        fetchMock.mockResolvedValue(response([]));
+
+        await fetchFeed('news', 2);
+
+        expect(fetchMock).toHaveBeenCalledWith(`${BASE_URL}/news?page=2`);
+    });
+
+    it('fetches item content', async () => {
+        const story = { id: 12, type: 'story' } as Story;
+        fetchMock.mockResolvedValue(response(story));
+
+        await fetchItemContent(12);
+
+        expect(fetchMock).toHaveBeenCalledWith(`${BASE_URL}/item/12`);
+    });
+
+    it('fills poll results and sums poll votes', async () => {
+        const story = { id: 100, type: 'poll', poll: [{}, {}] } as Story;
+        const firstResult = { points: 3, content: 'first' };
+        const secondResult = { points: 7, content: 'second' };
+        fetchMock
+            .mockResolvedValueOnce(response(story))
+            .mockResolvedValueOnce(response(firstResult))
+            .mockResolvedValueOnce(response(secondResult));
+
+        const result = await fetchItemContent(100);
+
+        expect(fetchMock).toHaveBeenNthCalledWith(1, `${BASE_URL}/item/100`);
+        expect(fetchMock).toHaveBeenNthCalledWith(2, `${BASE_URL}/item/101`);
+        expect(fetchMock).toHaveBeenNthCalledWith(3, `${BASE_URL}/item/102`);
+        expect(result.poll).toEqual([firstResult, secondResult]);
+        expect(result.poll_votes_count).toBe(10);
+    });
+
+    it('does not fetch poll results for non-poll stories', async () => {
+        const story = { id: 100, type: 'story' } as Story;
+        fetchMock.mockResolvedValue(response(story));
+
+        const result = await fetchItemContent(100);
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(result).toBe(story);
+        expect('poll_votes_count' in result).toBe(false);
+    });
+
+    it('fetches poll content', async () => {
+        fetchMock.mockResolvedValue(response({ points: 2, content: 'option' }));
+
+        await fetchPollContent(101);
+
+        expect(fetchMock).toHaveBeenCalledWith(`${BASE_URL}/item/101`);
+    });
+
+    it('fetches a user', async () => {
+        fetchMock.mockResolvedValue(response({ id: 'pg' }));
+
+        await fetchUser('pg');
+
+        expect(fetchMock).toHaveBeenCalledWith(`${BASE_URL}/user/pg`);
+    });
+
+    it('rejects for a non-ok response', async () => {
+        fetchMock.mockResolvedValue(response({}, false, 503));
+
+        await expect(fetchFeed('news', 1)).rejects.toThrow('Request failed: 503');
+    });
+
+    it('rejects for a network error', async () => {
+        fetchMock.mockRejectedValue(new Error('network error'));
+
+        await expect(fetchUser('pg')).rejects.toThrow('network error');
+    });
+});

--- a/react/src/shared/services/hackernews-api.ts
+++ b/react/src/shared/services/hackernews-api.ts
@@ -1,0 +1,47 @@
+import { PollResult, Story, User } from '../models';
+
+export const BASE_URL = 'https://node-hnapi.herokuapp.com';
+
+async function getJson<T>(url: string): Promise<T> {
+    const res = await fetch(url);
+
+    if (!res.ok) {
+        throw new Error(`Request failed: ${res.status}`);
+    }
+
+    return res.json() as Promise<T>;
+}
+
+export function fetchFeed(feedType: string, page: number): Promise<Story[]> {
+    return getJson<Story[]>(`${BASE_URL}/${feedType}?page=${page}`);
+}
+
+export async function fetchItemContent(id: number): Promise<Story> {
+    const story = await getJson<Story>(`${BASE_URL}/item/${id}`);
+
+    if (story.type === 'poll') {
+        const pollResults = await Promise.all(story.poll.map((_, index) => fetchPollContent(story.id + index + 1)));
+
+        pollResults.forEach((result, index) => {
+            story.poll[index] = result;
+        });
+        story.poll_votes_count = pollResults.reduce((total, result) => total + result.points, 0);
+    }
+
+    return story;
+}
+
+export function fetchPollContent(id: number): Promise<PollResult> {
+    return getJson<PollResult>(`${BASE_URL}/item/${id}`);
+}
+
+export function fetchUser(id: string): Promise<User> {
+    return getJson<User>(`${BASE_URL}/user/${id}`);
+}
+
+export const hackerNewsApi = {
+    fetchFeed,
+    fetchItemContent,
+    fetchPollContent,
+    fetchUser,
+};

--- a/react/src/shared/settings/SettingsContext.test.tsx
+++ b/react/src/shared/settings/SettingsContext.test.tsx
@@ -1,0 +1,133 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { SettingsProvider, useSettings } from './SettingsContext';
+
+describe('SettingsContext', () => {
+    let mediaQuery: {
+        matches: boolean;
+        media: string;
+        addEventListener: ReturnType<typeof vi.fn>;
+        removeEventListener: ReturnType<typeof vi.fn>;
+    };
+
+    beforeEach(() => {
+        localStorage.clear();
+        mediaQuery = {
+            matches: false,
+            media: '(prefers-color-scheme: dark)',
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+        };
+        Object.defineProperty(window, 'matchMedia', {
+            configurable: true,
+            writable: true,
+            value: vi.fn(() => mediaQuery),
+        });
+    });
+
+    it('uses the default settings', () => {
+        const { result } = renderHook(() => useSettings(), { wrapper: SettingsProvider });
+
+        expect(result.current.settings).toEqual({
+            showSettings: false,
+            openLinkInNewTab: false,
+            theme: 'default',
+            titleFontSize: '16',
+            listSpacing: '0',
+        });
+    });
+
+    it('reads persisted settings', () => {
+        localStorage.setItem('openLinkInNewTab', 'true');
+        localStorage.setItem('titleFontSize', '20');
+        localStorage.setItem('listSpacing', '2');
+
+        const { result } = renderHook(() => useSettings(), { wrapper: SettingsProvider });
+
+        expect(result.current.settings.openLinkInNewTab).toBe(true);
+        expect(result.current.settings.titleFontSize).toBe('20');
+        expect(result.current.settings.listSpacing).toBe('2');
+    });
+
+    it('prefers a saved theme without writing it', () => {
+        localStorage.setItem('theme', 'amoledblack');
+        const setItemSpy = vi.spyOn(Storage.prototype, 'setItem');
+
+        const { result } = renderHook(() => useSettings(), { wrapper: SettingsProvider });
+
+        expect(result.current.settings.theme).toBe('amoledblack');
+        expect(setItemSpy).not.toHaveBeenCalled();
+    });
+
+    it('persists night when no theme is saved and dark mode is preferred', () => {
+        mediaQuery.matches = true;
+
+        const { result } = renderHook(() => useSettings(), { wrapper: SettingsProvider });
+
+        expect(result.current.settings.theme).toBe('night');
+        expect(localStorage.getItem('theme')).toBe('night');
+    });
+
+    it('persists default when no theme is saved and light mode is preferred', () => {
+        const { result } = renderHook(() => useSettings(), { wrapper: SettingsProvider });
+
+        expect(result.current.settings.theme).toBe('default');
+        expect(localStorage.getItem('theme')).toBe('default');
+    });
+
+    it('updates theme when the media preference changes', () => {
+        const { result } = renderHook(() => useSettings(), { wrapper: SettingsProvider });
+        const listener = mediaQuery.addEventListener.mock.calls[0][1];
+
+        act(() => listener({ matches: true }));
+        expect(result.current.settings.theme).toBe('night');
+        expect(localStorage.getItem('theme')).toBe('night');
+
+        act(() => listener({ matches: false }));
+        expect(result.current.settings.theme).toBe('default');
+        expect(localStorage.getItem('theme')).toBe('default');
+    });
+
+    it('updates and persists each setting through its setter', () => {
+        const { result } = renderHook(() => useSettings(), { wrapper: SettingsProvider });
+
+        act(() => result.current.toggleOpenLinksInNewTab());
+        expect(result.current.settings.openLinkInNewTab).toBe(true);
+        expect(localStorage.getItem('openLinkInNewTab')).toBe('true');
+
+        act(() => result.current.setTheme('night'));
+        expect(result.current.settings.theme).toBe('night');
+        expect(localStorage.getItem('theme')).toBe('night');
+
+        act(() => result.current.setFont('22'));
+        expect(result.current.settings.titleFontSize).toBe('22');
+        expect(localStorage.getItem('titleFontSize')).toBe('22');
+
+        act(() => result.current.setSpacing('3'));
+        expect(result.current.settings.listSpacing).toBe('3');
+        expect(localStorage.getItem('listSpacing')).toBe('3');
+    });
+
+    it('toggles settings visibility', () => {
+        const { result } = renderHook(() => useSettings(), { wrapper: SettingsProvider });
+
+        act(() => result.current.toggleSettings());
+        expect(result.current.settings.showSettings).toBe(true);
+
+        act(() => result.current.toggleSettings());
+        expect(result.current.settings.showSettings).toBe(false);
+    });
+
+    it('removes the media listener on unmount', () => {
+        const { unmount } = renderHook(() => useSettings(), { wrapper: SettingsProvider });
+        const listener = mediaQuery.addEventListener.mock.calls[0][1];
+
+        unmount();
+
+        expect(mediaQuery.removeEventListener).toHaveBeenCalledWith('change', listener);
+    });
+
+    it('throws when used outside the provider', () => {
+        expect(() => renderHook(() => useSettings())).toThrow('useSettings must be used within a SettingsProvider');
+    });
+});

--- a/react/src/shared/settings/SettingsContext.tsx
+++ b/react/src/shared/settings/SettingsContext.tsx
@@ -1,0 +1,90 @@
+import { PropsWithChildren, createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+
+import { Settings } from '../models';
+import { readInitialSettings, resolveInitialTheme } from './settings-storage';
+
+interface SettingsContextValue {
+    settings: Settings;
+    toggleSettings: () => void;
+    toggleOpenLinksInNewTab: () => void;
+    setTheme: (theme: string) => void;
+    setFont: (fontSize: string) => void;
+    setSpacing: (listSpacing: string) => void;
+}
+
+const SettingsContext = createContext<SettingsContextValue | undefined>(undefined);
+
+export function SettingsProvider({ children }: PropsWithChildren) {
+    const [settings, setSettings] = useState<Settings>(readInitialSettings);
+
+    const toggleSettings = useCallback(() => {
+        setSettings((current) => ({ ...current, showSettings: !current.showSettings }));
+    }, []);
+
+    const toggleOpenLinksInNewTab = useCallback(() => {
+        setSettings((current) => {
+            const openLinkInNewTab = !current.openLinkInNewTab;
+            localStorage.setItem('openLinkInNewTab', JSON.stringify(openLinkInNewTab));
+            return { ...current, openLinkInNewTab };
+        });
+    }, []);
+
+    const setTheme = useCallback((theme: string) => {
+        localStorage.setItem('theme', theme);
+        setSettings((current) => ({ ...current, theme }));
+    }, []);
+
+    const setFont = useCallback((fontSize: string) => {
+        localStorage.setItem('titleFontSize', fontSize);
+        setSettings((current) => ({ ...current, titleFontSize: fontSize }));
+    }, []);
+
+    const setSpacing = useCallback((listSpacing: string) => {
+        localStorage.setItem('listSpacing', listSpacing);
+        setSettings((current) => ({ ...current, listSpacing }));
+    }, []);
+
+    useEffect(() => {
+        const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+        const savedTheme = localStorage.getItem('theme');
+        const handleColorSchemeChange = (event: MediaQueryListEvent) => {
+            setTheme(event.matches ? 'night' : 'default');
+        };
+
+        mediaQuery.addEventListener('change', handleColorSchemeChange);
+
+        if (savedTheme !== null) {
+            setSettings((current) => ({ ...current, theme: savedTheme }));
+        } else {
+            setTheme(resolveInitialTheme(null, mediaQuery.matches));
+        }
+
+        return () => {
+            mediaQuery.removeEventListener('change', handleColorSchemeChange);
+        };
+    }, [setTheme]);
+
+    const value = useMemo(
+        () => ({
+            settings,
+            toggleSettings,
+            toggleOpenLinksInNewTab,
+            setTheme,
+            setFont,
+            setSpacing,
+        }),
+        [settings, toggleSettings, toggleOpenLinksInNewTab, setTheme, setFont, setSpacing]
+    );
+
+    return <SettingsContext.Provider value={value}>{children}</SettingsContext.Provider>;
+}
+
+export function useSettings(): SettingsContextValue {
+    const context = useContext(SettingsContext);
+
+    if (!context) {
+        throw new Error('useSettings must be used within a SettingsProvider');
+    }
+
+    return context;
+}

--- a/react/src/shared/settings/settings-storage.test.ts
+++ b/react/src/shared/settings/settings-storage.test.ts
@@ -1,0 +1,26 @@
+import { readInitialSettings, resolveInitialTheme } from './settings-storage';
+
+describe('settings-storage', () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    it('reads default settings', () => {
+        expect(readInitialSettings()).toEqual({
+            showSettings: false,
+            openLinkInNewTab: false,
+            theme: 'default',
+            titleFontSize: '16',
+            listSpacing: '0',
+        });
+    });
+
+    it('resolves a saved theme before system preference', () => {
+        expect(resolveInitialTheme('amoledblack', true)).toBe('amoledblack');
+    });
+
+    it('resolves system preference when there is no saved theme', () => {
+        expect(resolveInitialTheme(null, true)).toBe('night');
+        expect(resolveInitialTheme(null, false)).toBe('default');
+    });
+});

--- a/react/src/shared/settings/settings-storage.ts
+++ b/react/src/shared/settings/settings-storage.ts
@@ -1,0 +1,17 @@
+import { Settings } from '../models';
+
+export function readInitialSettings(): Settings {
+    return {
+        showSettings: false,
+        openLinkInNewTab: localStorage.getItem('openLinkInNewTab')
+            ? JSON.parse(localStorage.getItem('openLinkInNewTab') as string)
+            : false,
+        theme: 'default',
+        titleFontSize: localStorage.getItem('titleFontSize') ?? '16',
+        listSpacing: localStorage.getItem('listSpacing') ?? '0',
+    };
+}
+
+export function resolveInitialTheme(saved: string | null, prefersDark: boolean): string {
+    return saved ?? (prefersDark ? 'night' : 'default');
+}

--- a/react/src/shared/utils/comment-count.test.ts
+++ b/react/src/shared/utils/comment-count.test.ts
@@ -1,0 +1,13 @@
+import { formatCommentCount } from './comment-count';
+
+describe('formatCommentCount', () => {
+    it.each([
+        [0, 'discuss'],
+        [1, '1 comment'],
+        [2, '2 comments'],
+        [30, '30 comments'],
+        [-1, 'discuss'],
+    ])('formats %s as %s', (count, expected) => {
+        expect(formatCommentCount(count)).toBe(expected);
+    });
+});

--- a/react/src/shared/utils/comment-count.ts
+++ b/react/src/shared/utils/comment-count.ts
@@ -1,0 +1,7 @@
+export function formatCommentCount(comment: number): string {
+    if (comment > 0) {
+        return `${comment} ${comment === 1 ? 'comment' : 'comments'}`;
+    }
+
+    return 'discuss';
+}

--- a/react/src/test/setup.ts
+++ b/react/src/test/setup.ts
@@ -1,1 +1,14 @@
 import '@testing-library/jest-dom/vitest';
+
+if (!window.matchMedia) {
+    Object.defineProperty(window, 'matchMedia', {
+        configurable: true,
+        value: (query: string) =>
+            ({
+                matches: false,
+                media: query,
+                addEventListener: () => undefined,
+                removeEventListener: () => undefined,
+            }) as unknown as MediaQueryList,
+    });
+}


### PR DESCRIPTION
## Summary
Phase 1 of the Angular → React migration (PR 2 of 7; based on the Phase 0 scaffold branch, #712). Provides the shared foundation that Phases 2A–2D build on. No feature UI yet — routes render placeholders that Phase 3 swaps for the real features.

Key points:
- `fetchItemContent` replaces the fire-and-forget RxJS poll aggregation with `Promise.all` over `fetchPollContent(story.id + i)` for `i = 1..poll.length`, filling `story.poll[i-1]` and summing `poll_votes_count` before resolving (same result, deterministic).
- `SettingsProvider` mirrors `SettingsService` exactly, including the subtle bit that when no saved theme exists the prefers-color-scheme result **is persisted** (Angular achieved this by dispatching a synthetic `MediaQueryListEvent` into `setTheme`); a saved theme is applied without writing. The `change` listener is always attached.
- Routing shell is injected with components so Phase 2 work stays in disjoint files:
  ```tsx
  <AppRoutes Feed={…/* ComponentType<{ feedType: FeedRoute }> */} ItemDetails={…} User={…} />
  // "/" → <Navigate to="/news/1" replace/>; "/{news|newest|show|ask|jobs}/:page"; "/item/:id"; "/user/:id"
  ```
  `useFeedPage()` reproduces `FeedComponent`'s `params.page ? +page : 1`.
- `hackerNewsApi` object export exists so feature tests can `vi.spyOn(hackerNewsApi, 'fetchFeed')`.
- `Loader` and `ErrorMessage` shared components are included here (rather than Phase 2D) because Feed/ItemDetails/User all consume them; keeping them in the foundation lets the four Phase 2 PRs stay file-disjoint. Component SCSS is imported globally (not CSS modules) because `_themes.scss` styles these class names.

### Angular → React file mapping
| Angular | React |
|---|---|
| `src/app/shared/models/{comment,feed-type.type,poll-result,settings,story,user}.ts` | `react/src/shared/models/*` (interfaces, fields verbatim) + new `feed-route.type.ts` (`FeedRoute`, `FEED_ROUTES`) |
| `src/app/shared/services/hackernews-api.service.ts` | `react/src/shared/services/hackernews-api.ts` |
| `src/app/shared/services/settings.service.ts` | `react/src/shared/settings/SettingsContext.tsx` + `settings-storage.ts` |
| `src/app/shared/pipes/comment.pipe.ts` | `react/src/shared/utils/comment-count.ts` (`formatCommentCount`) |
| `src/app/shared/components/loader/*` | `react/src/shared/components/Loader.tsx` + `.scss` |
| `src/app/shared/components/error-message/*` | `react/src/shared/components/ErrorMessage.tsx` + `.scss` |
| `src/app/app.routes.ts` + item/user module routes | `react/src/app/routes.tsx`, `use-feed-page.ts`, `placeholders.tsx` |

### Tests
38 unit/component tests across 9 files (API client incl. poll path/non-ok/network error, settings store incl. localStorage + media query, comment formatter, routes/redirect, `useFeedPage`, Loader, ErrorMessage); `npm run lint`, `format:check`, `build`, and the Playwright smoke test all pass.

Devin-Org: engineering

Link to Devin session: https://app.devin.ai/sessions/4b8f787ce33648ab865a05a3aa4d6cad
Open in Devin Desktop: https://app.devin.ai/desktop/session/4b8f787ce33648ab865a05a3aa4d6cad?variant=devin
Requested by: @vibhaseshadri-cognition