### PR TITLE
feature: Phase 2D — React core layout + shared UI (Layout, Header, Footer, Settings, GA hook)

### DIFF
--- a/react/src/core/Footer.scss
+++ b/react/src/core/Footer.scss
@@ -1,0 +1,23 @@
+@import '../styles/media';
+@import '../styles/theme_variables';
+
+#footer {
+    position: relative;
+    padding: 10px;
+    height: 60px;
+    letter-spacing: 0.7px;
+    text-align: center;
+
+    a {
+        font-weight: bold;
+        text-decoration: none;
+
+        &:hover {
+            text-decoration: underline;
+        }
+    }
+
+    @media #{$mobile-only} {
+        display: none;
+    }
+}

--- a/react/src/core/Footer.test.tsx
+++ b/react/src/core/Footer.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+
+import { Footer } from './Footer';
+
+describe('Footer', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+        delete window.ga;
+    });
+
+    it('renders the project message and GitHub link', () => {
+        render(<Footer />);
+
+        expect(screen.getByText(/Show this project some ❤ on/)).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: 'GitHub' })).toHaveAttribute(
+            'href',
+            'https://github.com/hdjirdeh/angular2-hn'
+        );
+        expect(screen.getByRole('link', { name: 'GitHub' })).toHaveAttribute('target', '_blank');
+        expect(screen.getByRole('link', { name: 'GitHub' })).toHaveAttribute('rel', 'noopener');
+    });
+});

--- a/react/src/core/Footer.tsx
+++ b/react/src/core/Footer.tsx
@@ -1,0 +1,14 @@
+import './Footer.scss';
+
+export function Footer() {
+    return (
+        <div id="footer">
+            <p>
+                Show this project some ❤ on{' '}
+                <a href="https://github.com/hdjirdeh/angular2-hn" target="_blank" rel="noopener">
+                    GitHub
+                </a>
+            </p>
+        </div>
+    );
+}

--- a/react/src/core/Header.scss
+++ b/react/src/core/Header.scss
@@ -1,0 +1,149 @@
+@import '../styles/media';
+@import '../styles/theme_variables';
+
+#header {
+    color: #fff;
+    padding: 6px 0;
+    line-height: 18px;
+    vertical-align: middle;
+    position: relative;
+    z-index: 1;
+    width: 100%;
+
+    @media #{$mobile-only} {
+        height: 50px;
+        position: fixed;
+        top: 0;
+    }
+
+    a {
+        display: inline;
+    }
+}
+
+.home-link {
+    width: 50px;
+    height: 66px;
+}
+
+.logo-inner {
+    width: 32px;
+    position: absolute;
+    left: 17px;
+    top: 18px;
+    z-index: -1;
+    height: 32px;
+    border-radius: 50%;
+
+    @media #{$mobile-only} {
+        left: 16px;
+        top: 12px;
+    }
+}
+
+.logo {
+    width: 50px;
+    padding: 3px 8px 0;
+
+    @media #{$mobile-only} {
+        width: 45px;
+        padding: 0 0 0 10px;
+    }
+}
+
+h1 {
+    font-weight: normal;
+    display: inline-block;
+    vertical-align: middle;
+    margin: 0;
+    font-size: 16px;
+
+    a {
+        color: #fff;
+        text-decoration: none;
+    }
+}
+
+.name {
+    margin-right: 30px;
+    margin-bottom: 2px;
+
+    @media #{$mobile-only} {
+        display: none;
+    }
+}
+
+.header-text {
+    position: absolute;
+    width: inherit;
+    height: 20px;
+    left: 10px;
+    top: 27px;
+    z-index: -1;
+
+    @media #{$mobile-only} {
+        top: 22px;
+    }
+}
+
+.left {
+    position: absolute;
+    left: 60px;
+    font-size: 16px;
+
+    @media #{$mobile-only} {
+        width: 100%;
+        left: 0;
+    }
+}
+
+.header-nav {
+    display: inline-block;
+    margin-left: 20px;
+
+    @media #{$mobile-only} {
+        margin-left: 60px;
+    }
+
+    a {
+        color: hsla(0, 0%, 100%, 0.9);
+        text-decoration: none;
+        margin: 0 5px;
+        letter-spacing: 1.8px;
+
+        &:hover {
+            color: #fff;
+        }
+    }
+
+    .active {
+        color: #fff;
+    }
+}
+
+.info {
+    position: absolute;
+    top: 0;
+    right: 20px;
+    height: 100%;
+
+    @media #{$mobile-only} {
+        right: 10px;
+    }
+
+    img {
+        opacity: 0.8;
+        width: 25px;
+        margin-top: 21.5px;
+        display: block;
+
+        &:hover {
+            opacity: 1;
+            cursor: pointer;
+        }
+
+        @media #{$mobile-only} {
+            margin-top: 15px;
+        }
+    }
+}

--- a/react/src/core/Header.test.tsx
+++ b/react/src/core/Header.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+
+import { SettingsProvider } from '../shared/settings/SettingsContext';
+import { Header } from './Header';
+
+function renderHeader(initialEntries = ['/news/1']) {
+    return render(
+        <MemoryRouter initialEntries={initialEntries}>
+            <SettingsProvider>
+                <Header />
+            </SettingsProvider>
+        </MemoryRouter>
+    );
+}
+
+describe('Header', () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        delete window.ga;
+    });
+
+    it('renders the logo and navigation links', () => {
+        renderHeader();
+
+        expect(screen.getByRole('link', { name: 'Logo' })).toHaveAttribute('href', '/news/1');
+        expect(screen.getByRole('link', { name: 'Logo' })).toHaveClass('home-link');
+        expect(screen.getByRole('img', { name: 'Logo' })).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: 'new' })).toHaveAttribute('href', '/newest/1');
+        expect(screen.getByRole('link', { name: 'show' })).toHaveAttribute('href', '/show/1');
+        expect(screen.getByRole('link', { name: 'ask' })).toHaveAttribute('href', '/ask/1');
+        expect(screen.getByRole('link', { name: 'jobs' })).toHaveAttribute('href', '/jobs/1');
+    });
+
+    it('scrolls to the top when a navigation link is clicked', async () => {
+        const scrollTo = vi.spyOn(window, 'scrollTo').mockImplementation(() => undefined);
+        renderHeader();
+
+        await userEvent.click(screen.getByRole('link', { name: 'ask' }));
+
+        expect(scrollTo).toHaveBeenCalledWith(0, 0);
+    });
+
+    it('marks the current navigation link active', () => {
+        renderHeader(['/ask/1']);
+
+        expect(screen.getByRole('link', { name: 'ask' })).toHaveClass('active');
+    });
+
+    it('toggles settings from the settings icon', async () => {
+        renderHeader();
+
+        await userEvent.click(screen.getByRole('img', { name: 'Settings' }));
+        expect(screen.getByRole('heading', { name: 'Settings' })).toBeInTheDocument();
+
+        await userEvent.click(screen.getByRole('img', { name: 'Settings' }));
+        expect(screen.queryByRole('heading', { name: 'Settings' })).not.toBeInTheDocument();
+    });
+});

--- a/react/src/core/Header.tsx
+++ b/react/src/core/Header.tsx
@@ -1,0 +1,66 @@
+import { NavLink } from 'react-router-dom';
+
+import { useSettings } from '../shared/settings/SettingsContext';
+import { Settings } from './Settings';
+import './Header.scss';
+
+export function Header() {
+    const { settings, toggleSettings } = useSettings();
+    const scrollTop = () => window.scrollTo(0, 0);
+
+    return (
+        <header>
+            <div id="header">
+                <NavLink
+                    className={({ isActive }) => (isActive ? 'home-link active' : 'home-link')}
+                    to="/news/1"
+                    onClick={scrollTop}
+                >
+                    <div className="logo-inner"></div>
+                    <img className="logo" src="assets/images/logo.svg" alt="Logo" />
+                </NavLink>
+                <div className="header-text">
+                    <div className="left">
+                        <span className="header-nav">
+                            <NavLink
+                                to="/newest/1"
+                                className={({ isActive }) => (isActive ? 'active' : undefined)}
+                                onClick={scrollTop}
+                            >
+                                new
+                            </NavLink>{' '}
+                            |{' '}
+                            <NavLink
+                                to="/show/1"
+                                className={({ isActive }) => (isActive ? 'active' : undefined)}
+                                onClick={scrollTop}
+                            >
+                                show
+                            </NavLink>{' '}
+                            |{' '}
+                            <NavLink
+                                to="/ask/1"
+                                className={({ isActive }) => (isActive ? 'active' : undefined)}
+                                onClick={scrollTop}
+                            >
+                                ask
+                            </NavLink>{' '}
+                            |{' '}
+                            <NavLink
+                                to="/jobs/1"
+                                className={({ isActive }) => (isActive ? 'active' : undefined)}
+                                onClick={scrollTop}
+                            >
+                                jobs
+                            </NavLink>
+                        </span>
+                    </div>
+                </div>
+                <div className="info">
+                    <img className="settings" src="assets/images/cog.svg" alt="Settings" onClick={toggleSettings} />
+                </div>
+            </div>
+            {settings.showSettings && <Settings />}
+        </header>
+    );
+}

--- a/react/src/core/Layout.scss
+++ b/react/src/core/Layout.scss
@@ -1,0 +1,25 @@
+@import '../styles/media';
+@import '../styles/theme_variables';
+
+.body-cover {
+    width: 100%;
+    z-index: 0;
+    position: fixed;
+    height: 100%;
+}
+
+.wrapper {
+    position: relative;
+    width: 85%;
+    min-height: 80px;
+    margin: 0 auto;
+    font-family: 'HelveticaNeue-Light', 'Helvetica Neue Light', 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande',
+        sans-serif;
+    font-size: 15px;
+    height: 100%;
+    line-height: 1.3;
+
+    @media #{$mobile-only} {
+        width: 100%;
+    }
+}

--- a/react/src/core/Layout.test.tsx
+++ b/react/src/core/Layout.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { SettingsProvider } from '../shared/settings/SettingsContext';
+import { Layout } from './Layout';
+
+function renderLayout() {
+    return render(
+        <MemoryRouter>
+            <SettingsProvider>
+                <Layout>child content</Layout>
+            </SettingsProvider>
+        </MemoryRouter>
+    );
+}
+
+describe('Layout', () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        delete window.ga;
+    });
+
+    it('uses the saved theme and renders the application shell', () => {
+        localStorage.setItem('theme', 'night');
+
+        const { container } = renderLayout();
+
+        expect(container.firstElementChild).toHaveClass('night');
+        expect(screen.getByRole('img', { name: 'Logo' })).toBeInTheDocument();
+        expect(screen.getByText('child content')).toBeInTheDocument();
+        expect(screen.getByText(/Show this project some/)).toBeInTheDocument();
+    });
+});

--- a/react/src/core/Layout.tsx
+++ b/react/src/core/Layout.tsx
@@ -1,0 +1,24 @@
+import { ReactNode } from 'react';
+
+import { useSettings } from '../shared/settings/SettingsContext';
+import { Footer } from './Footer';
+import { Header } from './Header';
+import { useGoogleAnalytics } from './useGoogleAnalytics';
+import './Layout.scss';
+
+export function Layout({ children }: { children: ReactNode }) {
+    const { settings } = useSettings();
+
+    useGoogleAnalytics();
+
+    return (
+        <div className={settings.theme}>
+            <div className="body-cover"></div>
+            <div className="wrapper">
+                <Header />
+                {children}
+                <Footer />
+            </div>
+        </div>
+    );
+}

--- a/react/src/core/Settings.scss
+++ b/react/src/core/Settings.scss
@@ -1,0 +1,75 @@
+@import '../styles/media';
+@import '../styles/theme_variables';
+
+.overlay {
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background: rgba(0, 0, 0, 0.7);
+    opacity: 1;
+    z-index: 1;
+}
+
+.popup {
+    margin: 70px auto;
+    padding: 30px;
+    border-radius: 5px;
+    width: 30%;
+    position: relative;
+    h1 {
+        margin-top: 0;
+        margin-bottom: 0px;
+        color: #fff;
+        text-align: center;
+        letter-spacing: 1px;
+    }
+    h2 {
+        padding-top: 10px;
+    }
+    hr {
+        width: 40%;
+        margin-bottom: 20px;
+    }
+    .close {
+        position: absolute;
+        top: 12px;
+        right: 20px;
+        font-size: 30px;
+        font-weight: bold;
+        text-decoration: none;
+        color: rgba(255, 255, 255, 0.8);
+        &:hover {
+            color: #fff;
+            cursor: pointer;
+        }
+    }
+    .content {
+        max-height: 30%;
+        color: #fff;
+        letter-spacing: 1px;
+        overflow: auto;
+    }
+    input[type='number'] {
+        display: block;
+        width: 80%;
+        height: 20px;
+        margin-bottom: 15px;
+        border-radius: 5px;
+        padding: 2px;
+    }
+}
+
+.control-section {
+    margin-bottom: 15px;
+    padding-bottom: 15px;
+    border-bottom: 1px solid white;
+}
+
+@media screen and (max-width: 700px) {
+    .box,
+    .popup {
+        width: 70%;
+    }
+}

--- a/react/src/core/Settings.test.tsx
+++ b/react/src/core/Settings.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+
+import { SettingsProvider } from '../shared/settings/SettingsContext';
+import { Header } from './Header';
+
+function renderSettings() {
+    return render(
+        <MemoryRouter>
+            <SettingsProvider>
+                <Header />
+            </SettingsProvider>
+        </MemoryRouter>
+    );
+}
+
+describe('Settings', () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        delete window.ga;
+    });
+
+    it('renders the popup controls and closes it with the close button', async () => {
+        renderSettings();
+
+        await userEvent.click(screen.getByRole('img', { name: 'Settings' }));
+        expect(screen.getByRole('heading', { name: 'Settings' })).toBeInTheDocument();
+        await userEvent.click(screen.getByText('×'));
+        expect(screen.queryByRole('heading', { name: 'Settings' })).not.toBeInTheDocument();
+    });
+
+    it('toggles opening links in a new tab', async () => {
+        renderSettings();
+
+        await userEvent.click(screen.getByRole('img', { name: 'Settings' }));
+        const checkbox = screen.getByRole('checkbox');
+        expect(checkbox).not.toBeChecked();
+        await userEvent.click(checkbox);
+        expect(checkbox).toBeChecked();
+        expect(localStorage.getItem('openLinkInNewTab')).toBe('true');
+    });
+
+    it.each([
+        ['default', 'Default'],
+        ['night', 'Night'],
+        ['amoledblack', 'Black (AMOLED)'],
+    ])('persists the %s theme selection', async (value, label) => {
+        renderSettings();
+
+        await userEvent.click(screen.getByRole('img', { name: 'Settings' }));
+        const radio = screen.getByRole('radio', { name: label });
+        await userEvent.click(radio);
+        expect(radio).toBeChecked();
+        expect(localStorage.getItem('theme')).toBe(value);
+    });
+
+    it('updates and persists the font size', async () => {
+        renderSettings();
+
+        await userEvent.click(screen.getByRole('img', { name: 'Settings' }));
+        const input = screen.getByRole('spinbutton', { name: /Font size/ });
+        await userEvent.clear(input);
+        await userEvent.type(input, '20');
+        expect(input).toHaveValue(20);
+        expect(localStorage.getItem('titleFontSize')).toBe('20');
+    });
+
+    it('updates and persists list spacing', async () => {
+        renderSettings();
+
+        await userEvent.click(screen.getByRole('img', { name: 'Settings' }));
+        const input = screen.getByRole('spinbutton', { name: /List spacing/ });
+        await userEvent.clear(input);
+        await userEvent.type(input, '5');
+        expect(input).toHaveValue(5);
+        expect(localStorage.getItem('listSpacing')).toBe('5');
+    });
+});

--- a/react/src/core/Settings.tsx
+++ b/react/src/core/Settings.tsx
@@ -1,0 +1,95 @@
+import { useSettings } from '../shared/settings/SettingsContext';
+import './Settings.scss';
+
+export function Settings() {
+    const { settings, toggleSettings, toggleOpenLinksInNewTab, setTheme, setFont, setSpacing } = useSettings();
+
+    return (
+        <div id="popup1" className="overlay">
+            <div className="popup">
+                <h1>Settings</h1>
+                <hr />
+                <span className="close" onClick={toggleSettings}>
+                    &times;
+                </span>
+                <div className="content">
+                    <div className="control-section">
+                        <h2>Links</h2>
+                        <input
+                            type="checkbox"
+                            checked={settings.openLinkInNewTab}
+                            onChange={toggleOpenLinksInNewTab}
+                        />{' '}
+                        Open links in a new tab
+                    </div>
+                    <div className="theme-controls">
+                        <div className="control-section">
+                            <h2>Select a theme</h2>
+                            <div>
+                                <label>
+                                    <input
+                                        name="theme"
+                                        type="radio"
+                                        value="default"
+                                        checked={settings.theme === 'default'}
+                                        onChange={() => setTheme('default')}
+                                    />{' '}
+                                    Default
+                                </label>
+                            </div>
+                            <div>
+                                <label>
+                                    <input
+                                        name="theme"
+                                        type="radio"
+                                        value="night"
+                                        checked={settings.theme === 'night'}
+                                        onChange={() => setTheme('night')}
+                                    />{' '}
+                                    Night
+                                </label>
+                            </div>
+                            <div>
+                                <label>
+                                    <input
+                                        name="theme"
+                                        type="radio"
+                                        value="amoledblack"
+                                        checked={settings.theme === 'amoledblack'}
+                                        onChange={() => setTheme('amoledblack')}
+                                    />{' '}
+                                    Black (AMOLED)
+                                </label>
+                            </div>
+                        </div>
+                        <div className="control-section">
+                            <h2>Change Font</h2>
+                            <div>
+                                <label>
+                                    Font size:{' '}
+                                    <input
+                                        min="1"
+                                        type="number"
+                                        value={settings.titleFontSize}
+                                        onChange={(event) => setFont(event.target.value)}
+                                    />
+                                </label>
+                            </div>
+                            <div>
+                                <label>
+                                    List spacing:{' '}
+                                    <input
+                                        min="0"
+                                        type="number"
+                                        value={settings.listSpacing}
+                                        onChange={(event) => setSpacing(event.target.value)}
+                                    />
+                                </label>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/react/src/core/index.ts
+++ b/react/src/core/index.ts
@@ -1,0 +1,5 @@
+export { Footer } from './Footer';
+export { Header } from './Header';
+export { Layout } from './Layout';
+export { Settings } from './Settings';
+export { useGoogleAnalytics } from './useGoogleAnalytics';

--- a/react/src/core/useGoogleAnalytics.test.tsx
+++ b/react/src/core/useGoogleAnalytics.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, useNavigate } from 'react-router-dom';
+
+import { useGoogleAnalytics } from './useGoogleAnalytics';
+
+function AnalyticsHarness() {
+    const navigate = useNavigate();
+
+    useGoogleAnalytics();
+
+    return <button onClick={() => navigate('/ask/1')}>Navigate</button>;
+}
+
+describe('useGoogleAnalytics', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+        delete window.ga;
+    });
+
+    it('tracks the initial location and subsequent navigation', async () => {
+        const ga = vi.fn();
+        window.ga = ga;
+
+        render(
+            <MemoryRouter initialEntries={['/news/1?x=1']}>
+                <AnalyticsHarness />
+            </MemoryRouter>
+        );
+
+        expect(ga).toHaveBeenCalledWith('set', 'page', '/news/1?x=1');
+        expect(ga).toHaveBeenCalledWith('send', 'pageview');
+
+        await userEvent.click(screen.getByRole('button', { name: 'Navigate' }));
+
+        expect(ga).toHaveBeenCalledWith('set', 'page', '/ask/1');
+    });
+
+    it('does not throw when analytics is unavailable', () => {
+        expect(() =>
+            render(
+                <MemoryRouter>
+                    <AnalyticsHarness />
+                </MemoryRouter>
+            )
+        ).not.toThrow();
+    });
+});

--- a/react/src/core/useGoogleAnalytics.ts
+++ b/react/src/core/useGoogleAnalytics.ts
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+declare global {
+    interface Window {
+        ga?: (...args: unknown[]) => void;
+    }
+}
+
+export function useGoogleAnalytics() {
+    const location = useLocation();
+
+    useEffect(() => {
+        if (typeof window.ga === 'function') {
+            window.ga('set', 'page', location.pathname + location.search);
+            window.ga('send', 'pageview');
+        }
+    }, [location.pathname, location.search]);
+}


### PR DESCRIPTION
## Summary
Phase 2D of the Angular → React migration: ports the app shell (`AppComponent`) and the `core` module (Header, Footer, Settings) into `react/src/core/`. Everything is confined to that directory; wiring into `App.tsx` is left for Phase 3 (`<Layout><AppRoutes .../></Layout>`).

- `Layout({ children })` reproduces `app.component.html` (`<div class={theme}><div.body-cover/><div.wrapper><Header/>{children}<Footer/></div></div>`) and calls `useGoogleAnalytics()`.
- `useGoogleAnalytics()` replaces the `NavigationEnd` subscription: on each `useLocation()` change it calls `ga('set','page', pathname + search)` then `ga('send','pageview')`, guarded by `typeof window.ga === 'function'` (no crash in tests / with ad blockers). `Window.ga` is declared via a global augmentation.
- `Header` uses `NavLink` with function `className` so the `active` class mirrors `routerLinkActive="active"`; every link calls `window.scrollTo(0, 0)`; the cog toggles `settings.showSettings` which conditionally renders `<Settings/>`.
- `Settings` is a controlled-input port: `(click)` on radios → `onChange` → `setTheme`, `(keyup)` on number inputs → `onChange` → `setFont`/`setSpacing` with the string value. Deviation: the stray `name="theme"` attributes Angular had on the two number inputs were dropped (harmless quirk, no behavioural effect).
- SCSS ported verbatim with `@import '../styles/media'` / `'../styles/theme_variables'` paths; global class names/ids (`.wrapper`, `#header`, `#footer`, `.overlay`, `.popup`, …) preserved so `_themes.scss` keeps styling them.

## Angular → React mapping
| Angular | React |
|---|---|
| `src/app/app.component.{ts,html,scss}` | `react/src/core/Layout.tsx`, `Layout.scss`, `useGoogleAnalytics.ts` |
| `src/app/core/header/header.component.{ts,html,scss}` | `react/src/core/Header.tsx`, `Header.scss` |
| `src/app/core/footer/footer.component.{ts,html,scss}` | `react/src/core/Footer.tsx`, `Footer.scss` |
| `src/app/core/settings/settings.component.{ts,html,scss}` | `react/src/core/Settings.tsx`, `Settings.scss` |
| `src/app/core/core.module.ts` | `react/src/core/index.ts` |

## Behaviours covered by tests
- Layout: theme class from persisted `localStorage.theme` (`night`), renders Header, children and Footer.
- GA hook: `ga('set','page',path+search)` + `ga('send','pageview')` on initial render and again after navigation; no-op when `window.ga` is undefined.
- Header: home link (`/news/1`, `.home-link`, logo img) and new/show/ask/jobs hrefs; `scrollTo(0,0)` on click; `active` class on the current route; cog opens and closes the Settings panel.
- Footer: text and GitHub link `target=_blank rel=noopener`.
- Settings: × closes the panel via the store; checkbox reflects/toggles `openLinkInNewTab` and persists it; each theme radio calls `setTheme` and persists `theme`; font size / list spacing inputs update settings and persist `titleFontSize` / `listSpacing`.

## Test counts
- `react/src/core`: 5 files, 15 tests. Whole suite: 14 files, 53 tests passing.
- Core coverage: 99.4% statements/lines, 84.6% branches, 88.2% functions.
- `npm run format:check`, `npm run lint` (only the pre-existing react-refresh warning), `npm run build`, `npm test` all pass.

Devin-Org: engineering

Link to Devin session: https://app.devin.ai/sessions/ec22cbaa4b9a4e16ac239e7d226e53c7
Open in Devin Desktop: https://app.devin.ai/desktop/session/ec22cbaa4b9a4e16ac239e7d226e53c7?variant=devin
Requested by: @vibhaseshadri-cognition