### PR TITLE
feature: Phase 2A — React feed components (Feed, StoryItem)

### DIFF
--- a/react/src/features/feed/Feed.scss
+++ b/react/src/features/feed/Feed.scss
@@ -1,0 +1,107 @@
+@import '../../styles/media';
+@import '../../styles/theme_variables';
+
+a {
+    text-decoration: none;
+    font-weight: bold;
+
+    &:hover {
+        text-decoration: underline;
+    }
+}
+
+ol {
+    padding: 0 40px;
+    margin: 0;
+
+    @media #{$mobile-only} {
+        box-sizing: border-box;
+        list-style: none;
+        padding: 0 10px;
+    }
+
+    li {
+        position: relative;
+        -webkit-transition: background-color 0.2s ease;
+        transition: background-color 0.2s ease;
+    }
+}
+
+.list-margin {
+    @media #{$mobile-only} {
+        margin-top: 55px;
+    }
+}
+
+.main-content {
+    position: relative;
+    width: 100%;
+    min-height: 100vh;
+    -webkit-transition: opacity 0.2s ease;
+    transition: opacity 0.2s ease;
+    box-sizing: border-box;
+    padding: 8px 0;
+    z-index: 0;
+}
+
+.post {
+    padding: 10px 0 10px 5px;
+    transition: background-color 0.2s ease;
+    border-bottom: 1px solid #cececb;
+
+    .itemNum {
+        color: #696969;
+        position: absolute;
+        width: 30px;
+        text-align: right;
+        left: 0;
+        top: 4px;
+    }
+}
+
+.item-block {
+    display: block;
+}
+
+.nav {
+    padding: 10px 40px;
+    margin-top: 10px;
+    font-size: 17px;
+
+    a {
+        @media #{$mobile-only} {
+            text-decoration: none;
+        }
+    }
+
+    @media #{$mobile-only} {
+        margin: 20px 0;
+        text-align: center;
+        padding: 10px 80px;
+        height: 20px;
+    }
+
+    .prev {
+        padding-right: 20px;
+
+        @media #{$mobile-only} {
+            float: left;
+            padding-right: 0;
+        }
+    }
+
+    .more {
+        @media #{$mobile-only} {
+            float: right;
+        }
+    }
+}
+
+.job-header {
+    font-size: 15px;
+    padding: 0 40px 10px;
+
+    @media #{$mobile-only} {
+        padding: 60px 15px 25px 15px;
+    }
+}

--- a/react/src/features/feed/Feed.test.tsx
+++ b/react/src/features/feed/Feed.test.tsx
@@ -1,0 +1,203 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Link, Route, Routes } from 'react-router-dom';
+import userEvent from '@testing-library/user-event';
+
+import { Feed } from './Feed';
+import { FeedRoute, Story } from '../../shared/models';
+import { hackerNewsApi } from '../../shared/services/hackernews-api';
+import { SettingsProvider } from '../../shared/settings/SettingsContext';
+
+function makeStory(overrides: Partial<Story> = {}): Story {
+    return {
+        id: 1,
+        title: 'A story',
+        points: 10,
+        user: 'alice',
+        time: 0,
+        time_ago: '1 hour ago' as unknown as number,
+        type: 'story',
+        url: 'https://example.com/story',
+        domain: 'example.com',
+        comments: [],
+        comments_count: 5,
+        poll: [],
+        poll_votes_count: 0,
+        deleted: false,
+        dead: false,
+        ...overrides,
+    };
+}
+
+function renderFeed(feedType: FeedRoute, path = `/${feedType}`) {
+    return render(
+        <MemoryRouter initialEntries={[path]}>
+            <SettingsProvider>
+                <Link to="/news/2">next</Link>
+                <Routes>
+                    <Route path="/:feed" element={<Feed feedType={feedType} />} />
+                    <Route path="/:feed/:page" element={<Feed feedType={feedType} />} />
+                </Routes>
+            </SettingsProvider>
+        </MemoryRouter>
+    );
+}
+
+describe('Feed', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        vi.spyOn(window, 'scrollTo').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('shows a loader while the feed is loading', () => {
+        vi.spyOn(hackerNewsApi, 'fetchFeed').mockReturnValue(new Promise(() => {}));
+
+        renderFeed('news');
+
+        expect(screen.getByText('Loading...')).toBeInTheDocument();
+        expect(screen.getByText('Loading...')).toHaveClass('loader');
+    });
+
+    it('renders stories with the correct rank start', async () => {
+        const fetchFeed = vi
+            .spyOn(hackerNewsApi, 'fetchFeed')
+            .mockResolvedValue([
+                makeStory({ id: 1, title: 'First story' }),
+                makeStory({ id: 2, title: 'Second story' }),
+            ]);
+
+        const firstRender = renderFeed('news');
+        expect(await screen.findByText('First story')).toBeInTheDocument();
+        expect(firstRender.container.querySelector('ol')).toHaveAttribute('start', '1');
+        firstRender.unmount();
+
+        fetchFeed.mockResolvedValue([makeStory({ id: 31, title: 'Page two story' })]);
+        renderFeed('news', '/news/2');
+        expect(await screen.findByText('Page two story')).toBeInTheDocument();
+        expect(document.querySelector('ol')).toHaveAttribute('start', '31');
+    });
+
+    it('shows the feed error message when loading fails', async () => {
+        vi.spyOn(hackerNewsApi, 'fetchFeed').mockRejectedValue(new Error('network error'));
+
+        renderFeed('news');
+
+        expect(await screen.findByText('Could not load news stories.')).toBeInTheDocument();
+    });
+
+    it('shows the jobs header only for the jobs feed', async () => {
+        vi.spyOn(hackerNewsApi, 'fetchFeed').mockResolvedValue([makeStory({ type: 'job' })]);
+
+        const { unmount } = renderFeed('jobs');
+        expect(await screen.findByText(/These are jobs at startups/)).toBeInTheDocument();
+        unmount();
+
+        renderFeed('news');
+        await screen.findByText('A story');
+        expect(screen.queryByText(/These are jobs at startups/)).not.toBeInTheDocument();
+    });
+
+    it('adds list-margin to non-job feeds only', async () => {
+        vi.spyOn(hackerNewsApi, 'fetchFeed').mockResolvedValue([makeStory()]);
+
+        const { unmount } = renderFeed('news');
+        await screen.findByText('A story');
+        expect(document.querySelector('ol')).toHaveClass('list-margin');
+        unmount();
+
+        renderFeed('jobs');
+        await screen.findByText('A story');
+        expect(document.querySelector('ol')).not.toHaveClass('list-margin');
+    });
+
+    it('renders pagination links for the current page and item count', async () => {
+        const fetchFeed = vi.spyOn(hackerNewsApi, 'fetchFeed');
+        fetchFeed
+            .mockResolvedValueOnce(Array.from({ length: 30 }, (_, index) => makeStory({ id: index + 1 })))
+            .mockResolvedValueOnce(Array.from({ length: 30 }, (_, index) => makeStory({ id: index + 1 })))
+            .mockResolvedValueOnce(
+                Array.from({ length: 29 }, (_, index) =>
+                    makeStory({ id: index + 1, title: index === 0 ? 'Short page story' : `Story ${index + 1}` })
+                )
+            );
+
+        const firstRender = renderFeed('news');
+        await screen.findByRole('link', { name: 'More ›' });
+        expect(screen.queryByRole('link', { name: '‹ Prev' })).not.toBeInTheDocument();
+        expect(screen.getByRole('link', { name: 'More ›' })).toHaveAttribute('href', '/news/2');
+        firstRender.unmount();
+
+        const secondRender = renderFeed('news', '/news/2');
+        await screen.findByRole('link', { name: '‹ Prev' });
+        expect(screen.getByRole('link', { name: '‹ Prev' })).toHaveAttribute('href', '/news/1');
+        secondRender.unmount();
+
+        renderFeed('news');
+        await screen.findByText('Short page story');
+        expect(screen.queryByRole('link', { name: 'More ›' })).not.toBeInTheDocument();
+    });
+
+    it('scrolls to the top after loading', async () => {
+        const scrollTo = vi.mocked(window.scrollTo);
+        vi.spyOn(hackerNewsApi, 'fetchFeed').mockResolvedValue([makeStory()]);
+
+        renderFeed('news');
+        await screen.findByText('A story');
+
+        expect(scrollTo).toHaveBeenCalledWith(0, 0);
+    });
+
+    it('refetches when navigating to another page', async () => {
+        const fetchFeed = vi.spyOn(hackerNewsApi, 'fetchFeed').mockResolvedValue([makeStory()]);
+
+        renderFeed('news');
+        await screen.findByText('A story');
+
+        const user = userEvent.setup();
+        await user.click(screen.getByRole('link', { name: 'next' }));
+
+        await waitFor(() => expect(fetchFeed).toHaveBeenCalledWith('news', 2));
+        expect(await screen.findByText('A story')).toBeInTheDocument();
+        expect(document.querySelector('ol')).toHaveAttribute('start', '31');
+    });
+
+    it('ignores stale responses after navigating to another page', async () => {
+        let resolveFirst!: (stories: Story[]) => void;
+        let resolveSecond!: (stories: Story[]) => void;
+        const first = new Promise<Story[]>((resolve) => {
+            resolveFirst = resolve;
+        });
+        const second = new Promise<Story[]>((resolve) => {
+            resolveSecond = resolve;
+        });
+        const fetchFeed = vi.spyOn(hackerNewsApi, 'fetchFeed').mockReturnValueOnce(first).mockReturnValueOnce(second);
+
+        renderFeed('news');
+        const user = userEvent.setup();
+        await user.click(screen.getByRole('link', { name: 'next' }));
+        await waitFor(() => expect(fetchFeed).toHaveBeenCalledWith('news', 2));
+
+        await act(async () => {
+            resolveSecond([makeStory({ id: 2, title: 'Page two story' })]);
+        });
+        expect(await screen.findByText('Page two story')).toBeInTheDocument();
+
+        await act(async () => {
+            resolveFirst([makeStory({ id: 1, title: 'Stale page one story' })]);
+        });
+        await waitFor(() => expect(screen.queryByText('Stale page one story')).not.toBeInTheDocument());
+        expect(screen.getByText('Page two story')).toBeInTheDocument();
+    });
+
+    it('renders each story inside the expected list wrapper', async () => {
+        vi.spyOn(hackerNewsApi, 'fetchFeed').mockResolvedValue([makeStory()]);
+
+        const { container } = renderFeed('news');
+        await screen.findByText('A story');
+
+        expect(container.querySelector('li.post > .item-block')).toBeInTheDocument();
+    });
+});

--- a/react/src/features/feed/Feed.tsx
+++ b/react/src/features/feed/Feed.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+
+import { useFeedPage } from '../../app/use-feed-page';
+import { ErrorMessage, Loader } from '../../shared/components';
+import { FeedRoute, Story } from '../../shared/models';
+import { hackerNewsApi } from '../../shared/services/hackernews-api';
+import { StoryItem } from './StoryItem';
+import './Feed.scss';
+
+export function Feed({ feedType }: { feedType: FeedRoute }) {
+    const [items, setItems] = useState<Story[]>();
+    const [errorMessage, setErrorMessage] = useState('');
+    const [listStart, setListStart] = useState(1);
+    const page = useFeedPage();
+
+    useEffect(() => {
+        let cancelled = false;
+
+        setItems(undefined);
+        setErrorMessage('');
+        hackerNewsApi.fetchFeed(feedType, page).then(
+            (result) => {
+                if (cancelled) {
+                    return;
+                }
+
+                setItems(result);
+                setListStart((page - 1) * 30 + 1);
+                window.scrollTo(0, 0);
+            },
+            () => {
+                if (cancelled) {
+                    return;
+                }
+
+                setErrorMessage('Could not load ' + feedType + ' stories.');
+            }
+        );
+
+        return () => {
+            cancelled = true;
+        };
+    }, [feedType, page]);
+
+    return (
+        <div className="main-content">
+            {!items && !errorMessage && <Loader />}
+            {!items && errorMessage !== '' && <ErrorMessage message={errorMessage} />}
+            {items && (
+                <div>
+                    {feedType === 'jobs' && (
+                        <p className="job-header">
+                            These are jobs at startups that were funded by Y Combinator. You can also get a job at a YC
+                            startup through <a href="https://triplebyte.com/?ref=yc_jobs">Triplebyte</a>.
+                        </p>
+                    )}
+                    <ol className={feedType !== 'jobs' ? 'list-margin' : undefined} start={listStart}>
+                        {items.map((item) => (
+                            <li key={item.id} className="post">
+                                <div className="item-block">
+                                    <StoryItem item={item} />
+                                </div>
+                            </li>
+                        ))}
+                    </ol>
+                    <div className="nav">
+                        {listStart !== 1 && (
+                            <Link className="prev" to={`/${feedType}/${page - 1}`}>
+                                ‹ Prev
+                            </Link>
+                        )}
+                        {items.length === 30 && (
+                            <Link className="more" to={`/${feedType}/${page + 1}`}>
+                                More ›
+                            </Link>
+                        )}
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/react/src/features/feed/StoryItem.scss
+++ b/react/src/features/feed/StoryItem.scss
@@ -1,0 +1,68 @@
+@import '../../styles/media';
+@import '../../styles/theme_variables';
+
+p {
+    margin: 2px 0;
+
+    @media #{$mobile-only} {
+        margin-bottom: 5px;
+        margin-top: 0;
+    }
+}
+
+a {
+    cursor: pointer;
+    text-decoration: none;
+}
+
+.title {
+    font-size: 16px;
+    font-family: Verdana, Geneva, sans-serif;
+}
+
+.subtext-laptop {
+    font-size: 12px;
+    font-weight: bold;
+    letter-spacing: 0.5px;
+
+    a {
+        &:hover {
+            text-decoration: underline;
+        }
+    }
+    @media #{$mobile-only} {
+        display: none;
+    }
+}
+
+.subtext-palm {
+    font-size: 13px;
+    font-weight: bold;
+    letter-spacing: 0.5px;
+
+    a {
+        &:hover {
+            text-decoration: underline;
+        }
+    }
+
+    .details {
+        margin-top: 5px;
+
+        .right {
+            float: right;
+        }
+    }
+    @media #{$laptop-only} {
+        display: none;
+    }
+}
+
+.domain {
+    color: #696969;
+    letter-spacing: 0.5px;
+}
+
+.item-details {
+    padding: 10px;
+}

--- a/react/src/features/feed/StoryItem.test.tsx
+++ b/react/src/features/feed/StoryItem.test.tsx
@@ -1,0 +1,118 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { StoryItem } from './StoryItem';
+import { Story } from '../../shared/models';
+import { SettingsProvider } from '../../shared/settings/SettingsContext';
+
+function makeStory(overrides: Partial<Story> = {}): Story {
+    return {
+        id: 1,
+        title: 'A story',
+        points: 10,
+        user: 'alice',
+        time: 0,
+        time_ago: '1 hour ago' as unknown as number,
+        type: 'story',
+        url: 'https://example.com/story',
+        domain: 'example.com',
+        comments: [],
+        comments_count: 5,
+        poll: [],
+        poll_votes_count: 0,
+        deleted: false,
+        dead: false,
+        ...overrides,
+    };
+}
+
+function renderStory(item: Story) {
+    return render(
+        <MemoryRouter>
+            <SettingsProvider>
+                <StoryItem item={item} />
+            </SettingsProvider>
+        </MemoryRouter>
+    );
+}
+
+describe('StoryItem', () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    it('renders external URLs and their domain', () => {
+        renderStory(makeStory());
+
+        const title = screen.getByRole('link', { name: 'A story' });
+        expect(title).toHaveClass('title');
+        expect(title).toHaveAttribute('href', 'https://example.com/story');
+        expect(title).not.toHaveAttribute('target');
+        expect(title).not.toHaveAttribute('rel');
+        expect(screen.getByText('(example.com)')).toHaveClass('domain');
+    });
+
+    it('renders internal URLs as item links without a domain', () => {
+        renderStory(makeStory({ url: 'item?id=1', domain: 'example.com' }));
+
+        const title = screen.getByRole('link', { name: 'A story' });
+        expect(title).toHaveAttribute('href', '/item/1');
+        expect(screen.queryByText('(example.com)')).not.toBeInTheDocument();
+    });
+
+    it('opens external links in a new tab when configured', () => {
+        localStorage.setItem('openLinkInNewTab', 'true');
+
+        renderStory(makeStory());
+
+        expect(screen.getByRole('link', { name: 'A story' })).toHaveAttribute('target', '_blank');
+        expect(screen.getByRole('link', { name: 'A story' })).toHaveAttribute('rel', 'noopener');
+    });
+
+    it('applies configured title size and list spacing', () => {
+        localStorage.setItem('titleFontSize', '20');
+        localStorage.setItem('listSpacing', '12');
+
+        const { container } = renderStory(makeStory());
+
+        expect(screen.getByRole('link', { name: 'A story' })).toHaveStyle({ fontSize: '20px' });
+        expect(container.firstElementChild).toHaveStyle({ marginBottom: '12px' });
+    });
+
+    it('hides an empty domain', () => {
+        renderStory(makeStory({ domain: '' }));
+
+        expect(document.querySelector('.domain')).not.toBeInTheDocument();
+    });
+
+    it('omits user, points, and comments for jobs', () => {
+        const { container } = renderStory(makeStory({ type: 'job', url: 'item?id=1' }));
+
+        expect(screen.queryByRole('link', { name: 'alice' })).not.toBeInTheDocument();
+        expect(screen.queryByText(/10 ★/)).not.toBeInTheDocument();
+        expect(screen.queryByRole('link', { name: /discuss|comments?/ })).not.toBeInTheDocument();
+        expect(container.querySelector('.item-details')).not.toBeInTheDocument();
+        expect(container.querySelectorAll('.subtext-palm .details')).toHaveLength(1);
+    });
+
+    it('renders user links and responsive details for non-jobs', () => {
+        const { container } = renderStory(makeStory());
+
+        expect(screen.getAllByRole('link', { name: 'alice' })).toHaveLength(2);
+        expect(screen.getAllByRole('link', { name: 'alice' })[0]).toHaveAttribute('href', '/user/alice');
+        expect(container.querySelector('.item-details')).toBeInTheDocument();
+        expect(container.textContent).toContain(' • 5 comments');
+        expect(container.textContent).toContain(' | 5 comments');
+        expect(container.textContent).toContain('10 points by');
+    });
+
+    it.each([
+        [0, 'discuss'],
+        [1, '1 comment'],
+        [5, '5 comments'],
+    ])('formats %s comments', (commentsCount, expected) => {
+        renderStory(makeStory({ comments_count: commentsCount }));
+
+        expect(screen.getAllByText(expected).length).toBeGreaterThan(0);
+    });
+});

--- a/react/src/features/feed/StoryItem.tsx
+++ b/react/src/features/feed/StoryItem.tsx
@@ -1,0 +1,73 @@
+import { Link } from 'react-router-dom';
+
+import { Story } from '../../shared/models';
+import { useSettings } from '../../shared/settings/SettingsContext';
+import { formatCommentCount } from '../../shared/utils/comment-count';
+import './StoryItem.scss';
+
+export function StoryItem({ item }: { item: Story }) {
+    const { settings } = useSettings();
+    const hasUrl = item.url.indexOf('http') === 0;
+
+    return (
+        <div style={{ marginBottom: settings.listSpacing + 'px' }}>
+            {hasUrl ? (
+                <p>
+                    <a
+                        className="title"
+                        style={{ fontSize: settings.titleFontSize + 'px' }}
+                        href={item.url}
+                        target={settings.openLinkInNewTab ? '_blank' : undefined}
+                        rel={settings.openLinkInNewTab ? 'noopener' : undefined}
+                    >
+                        {item.title}
+                    </a>
+                    {item.domain && <span className="domain">({item.domain})</span>}
+                </p>
+            ) : (
+                <p>
+                    <Link className="title" style={{ fontSize: settings.titleFontSize + 'px' }} to={'/item/' + item.id}>
+                        {item.title}
+                    </Link>
+                </p>
+            )}
+            <div className="subtext-palm">
+                {item.type !== 'job' && (
+                    <div className="details">
+                        <span className="name">
+                            <Link to={'/user/' + item.user}>{item.user}</Link>
+                        </span>
+                        <span className="right">{item.points} ★</span>
+                    </div>
+                )}
+                <div className="details">
+                    {item.time_ago}
+                    {item.type !== 'job' && (
+                        <Link to={'/item/' + item.id} className="comment-number">
+                            {' • '}
+                            {formatCommentCount(item.comments_count)}
+                        </Link>
+                    )}
+                </div>
+            </div>
+            <div className="subtext-laptop">
+                {item.type !== 'job' && (
+                    <span>
+                        {item.points}
+                        {' points by '}
+                        <Link to={'/user/' + item.user}>{item.user}</Link>
+                    </span>
+                )}
+                <span className={item.type !== 'job' ? 'item-details' : undefined}>
+                    {item.time_ago}
+                    {item.type !== 'job' && (
+                        <span>
+                            {' | '}
+                            <Link to={'/item/' + item.id}>{formatCommentCount(item.comments_count)}</Link>
+                        </span>
+                    )}
+                </span>
+            </div>
+        </div>
+    );
+}

--- a/react/src/features/feed/index.ts
+++ b/react/src/features/feed/index.ts
@@ -1,0 +1,2 @@
+export { Feed } from './Feed';
+export { StoryItem } from './StoryItem';


### PR DESCRIPTION
## Summary
Phase 2A of the Angular → React migration: ports `FeedComponent` and `ItemComponent` into `react/src/features/feed/` on top of the Phase 1 foundation (#713). Nothing outside that directory is touched; Phase 3 wires `Feed` into `AppRoutes`.

`Feed({ feedType }: { feedType: FeedRoute })` mirrors the Angular subscription flow with a `useEffect` on `[feedType, page]`:

```
setItems(undefined); setErrorMessage('');
hackerNewsApi.fetchFeed(feedType, page).then(
  items => { if (!cancelled) { setItems(items); setListStart((page-1)*30+1); window.scrollTo(0,0); } },
  ()    => { if (!cancelled) setErrorMessage(`Could not load ${feedType} stories.`); }
);
return () => { cancelled = true; };   // stale-response guard
```

`StoryItem({ item }: { item: Story })` reads `useSettings().settings` for `listSpacing`/`titleFontSize`/`openLinkInNewTab`; external links get `target="_blank" rel="noopener"` only when the setting is on, otherwise the attributes are omitted (Angular `[attr.x]="cond ? … : null"`).

### Angular → React mapping
| Angular | React |
|---|---|
| `src/app/feeds/feed/feed.component.ts` / `.html` | `react/src/features/feed/Feed.tsx` |
| `src/app/feeds/feed/feed.component.scss` | `react/src/features/feed/Feed.scss` |
| `src/app/feeds/item/item.component.ts` / `.html` | `react/src/features/feed/StoryItem.tsx` |
| `src/app/feeds/item/item.component.scss` | `react/src/features/feed/StoryItem.scss` |
| `src/app/feeds/feed/feed.component.spec.ts`, `item.component.spec.ts` | `Feed.test.tsx`, `StoryItem.test.tsx` |
| — | `react/src/features/feed/index.ts` (barrel) |

### Deviations
- `*ngIf="feedType !== 'new'"` on the `<ol>` was dropped: `'new'` is never a `FeedRoute`, so the condition was always true.
- Angular's `<item class="item-block">` host element becomes an explicit `<div class="item-block">` wrapper around `StoryItem` so `.item-block { display: block }` still applies.
- Added an explicit stale-response guard (Angular relied on RxJS subscription ordering); tests cover it.

### Tests (20 new; suite total 58)
`Feed.test.tsx` (10): loader while pending; items render with `start=1` (page 1) and `start=31` (page 2); exact error text `Could not load news stories.`; jobs header only for `jobs`; `list-margin` except for `jobs`; Prev hidden on page 1 / shown on page 2 with `href=/news/1`; More shown with 30 items (`/news/2`) and hidden with 29; `window.scrollTo(0,0)` after load; refetch on page navigation; stale response ignored; `li.post > .item-block` wrapper.
`StoryItem.test.tsx` (10): external vs internal title link; no `target`/`rel` by default, `_blank`/`noopener` with `openLinkInNewTab`; font-size / list-spacing styles from localStorage settings; domain shown/hidden; job type hides points/user/comment links in both layouts and drops `item-details`; comment count `0 → discuss`, `1 → 1 comment`, `n → n comments`.

Coverage for `src/features/feed`: `Feed.tsx` 96.7% lines / 94.7% branches, `StoryItem.tsx` 100%.

Checks run from `react/`: `npm run format`, `npm run lint` (only the pre-existing react-refresh warning), `npm run format:check`, `npm run build`, `npm test`, `npm run test:coverage` — all pass. No `package.json` changes.

Devin-Org: engineering

Link to Devin session: https://app.devin.ai/sessions/2814fea53ed9469e83433c3f64f8b8f4
Open in Devin Desktop: https://app.devin.ai/desktop/session/2814fea53ed9469e83433c3f64f8b8f4?variant=devin
Requested by: @vibhaseshadri-cognition