### PR TITLE
Phase 1: React core foundation (models, API client, settings store, routing shell)

### DIFF
--- a/react/e2e/app.spec.ts
+++ b/react/e2e/app.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test';
 
-test('loads the application shell', async ({ page }) => {
+test('redirects / to /news/1 inside the theme wrapper', async ({ page }) => {
     await page.goto('/');
-    await expect(page.getByRole('heading', { name: 'Angular 2 HN' })).toBeVisible();
+    await expect(page).toHaveURL(/\/news\/1$/);
+    await expect(page.locator('.wrapper')).toBeVisible();
 });

--- a/react/src/App.test.tsx
+++ b/react/src/App.test.tsx
@@ -2,14 +2,33 @@ import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 
 import App from './App';
+import { mockMatchMedia } from './test/matchMedia';
 
 describe('App', () => {
-    it('renders the application shell', () => {
-        render(
-            <MemoryRouter>
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    it('wraps the routes in the active theme class and redirects to the news feed', async () => {
+        mockMatchMedia(false);
+        const { container } = render(
+            <MemoryRouter initialEntries={['/']}>
                 <App />
             </MemoryRouter>
         );
-        expect(screen.getByRole('heading', { name: 'Angular 2 HN' })).toBeInTheDocument();
+        expect(container.firstElementChild).toHaveClass('default');
+        expect(container.querySelector('.wrapper')).not.toBeNull();
+        expect(await screen.findByTestId('feed-page')).toHaveAttribute('data-feed-type', 'news');
+    });
+
+    it('applies the saved theme class', () => {
+        mockMatchMedia(false);
+        localStorage.setItem('theme', 'night');
+        const { container } = render(
+            <MemoryRouter initialEntries={['/ask/2']}>
+                <App />
+            </MemoryRouter>
+        );
+        expect(container.firstElementChild).toHaveClass('night');
     });
 });

--- a/react/src/App.tsx
+++ b/react/src/App.tsx
@@ -1,10 +1,22 @@
-export default function App() {
+import { AppRoutes } from './routes';
+import { SettingsProvider, useSettings } from './settings';
+
+function ThemedShell() {
+    const { settings } = useSettings();
     return (
-        <div className="default">
+        <div className={settings.theme}>
             <div className="body-cover"></div>
             <div className="wrapper">
-                <h1>Angular 2 HN</h1>
+                <AppRoutes />
             </div>
         </div>
+    );
+}
+
+export default function App() {
+    return (
+        <SettingsProvider>
+            <ThemedShell />
+        </SettingsProvider>
     );
 }

--- a/react/src/api/hackernews-api.test.ts
+++ b/react/src/api/hackernews-api.test.ts
@@ -1,0 +1,94 @@
+import type { Story, User } from '../models';
+import { BASE_URL, fetchFeed, fetchItemContent, fetchPollContent, fetchUser } from './hackernews-api';
+
+function jsonResponse(body: unknown): Response {
+    return { json: () => Promise.resolve(body) } as unknown as Response;
+}
+
+describe('hackernews-api', () => {
+    const fetchMock = vi.fn<typeof fetch>();
+
+    beforeEach(() => {
+        fetchMock.mockReset();
+        vi.stubGlobal('fetch', fetchMock);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('uses the node-hnapi base url', () => {
+        expect(BASE_URL).toBe('https://node-hnapi.herokuapp.com');
+    });
+
+    it('fetchFeed requests the feed endpoint with the page', async () => {
+        const stories = [{ id: 1, title: 'Hello' }] as Story[];
+        fetchMock.mockResolvedValueOnce(jsonResponse(stories));
+
+        await expect(fetchFeed('news', 2)).resolves.toEqual(stories);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(fetchMock.mock.calls[0][0]).toBe(`${BASE_URL}/news?page=2`);
+    });
+
+    it('fetchPollContent requests the item endpoint', async () => {
+        fetchMock.mockResolvedValueOnce(jsonResponse({ points: 3, content: 'Option' }));
+
+        await expect(fetchPollContent(42)).resolves.toEqual({ points: 3, content: 'Option' });
+        expect(fetchMock.mock.calls[0][0]).toBe(`${BASE_URL}/item/42`);
+    });
+
+    it('fetchUser requests the user endpoint', async () => {
+        const user = { id: 'pg', karma: 1 } as User;
+        fetchMock.mockResolvedValueOnce(jsonResponse(user));
+
+        await expect(fetchUser('pg')).resolves.toEqual(user);
+        expect(fetchMock.mock.calls[0][0]).toBe(`${BASE_URL}/user/pg`);
+    });
+
+    it('fetchItemContent returns a story untouched when it is not a poll', async () => {
+        const story = { id: 10, type: 'story', title: 'Story', comments: [] } as unknown as Story;
+        fetchMock.mockResolvedValueOnce(jsonResponse(story));
+
+        await expect(fetchItemContent(10)).resolves.toEqual(story);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(fetchMock.mock.calls[0][0]).toBe(`${BASE_URL}/item/10`);
+    });
+
+    it('fetchItemContent fetches each poll option (id + i) and sums poll_votes_count', async () => {
+        const poll = {
+            id: 100,
+            type: 'poll',
+            title: 'Poll',
+            poll: [{}, {}, {}],
+        } as unknown as Story;
+        fetchMock.mockImplementation((input) => {
+            const url = String(input);
+            if (url.endsWith('/item/100')) return Promise.resolve(jsonResponse(poll));
+            if (url.endsWith('/item/101')) return Promise.resolve(jsonResponse({ points: 5, content: 'A' }));
+            if (url.endsWith('/item/102')) return Promise.resolve(jsonResponse({ points: 7, content: 'B' }));
+            if (url.endsWith('/item/103')) return Promise.resolve(jsonResponse({ points: 1, content: 'C' }));
+            return Promise.reject(new Error(`unexpected url ${url}`));
+        });
+
+        const result = await fetchItemContent(100);
+
+        expect(fetchMock).toHaveBeenCalledTimes(4);
+        expect(fetchMock.mock.calls.map((call) => String(call[0]))).toEqual([
+            `${BASE_URL}/item/100`,
+            `${BASE_URL}/item/101`,
+            `${BASE_URL}/item/102`,
+            `${BASE_URL}/item/103`,
+        ]);
+        expect(result.poll).toEqual([
+            { points: 5, content: 'A' },
+            { points: 7, content: 'B' },
+            { points: 1, content: 'C' },
+        ]);
+        expect(result.poll_votes_count).toBe(13);
+    });
+
+    it('propagates fetch failures', async () => {
+        fetchMock.mockRejectedValueOnce(new Error('network down'));
+        await expect(fetchFeed('ask', 1)).rejects.toThrow('network down');
+    });
+});

--- a/react/src/api/hackernews-api.ts
+++ b/react/src/api/hackernews-api.ts
@@ -1,0 +1,38 @@
+import type { PollResult, Story, User } from '../models';
+
+export const BASE_URL = 'https://node-hnapi.herokuapp.com';
+
+export type FeedName = 'news' | 'newest' | 'show' | 'ask' | 'jobs';
+
+async function fetchJson<T>(url: string, signal?: AbortSignal): Promise<T> {
+    const response = await fetch(url, { signal });
+    return (await response.json()) as T;
+}
+
+export function fetchFeed(feedType: string, page: number, signal?: AbortSignal): Promise<Story[]> {
+    return fetchJson<Story[]>(`${BASE_URL}/${feedType}?page=${page}`, signal);
+}
+
+export function fetchPollContent(id: number, signal?: AbortSignal): Promise<PollResult> {
+    return fetchJson<PollResult>(`${BASE_URL}/item/${id}`, signal);
+}
+
+export async function fetchItemContent(id: number, signal?: AbortSignal): Promise<Story> {
+    const story = await fetchJson<Story>(`${BASE_URL}/item/${id}`, signal);
+    if (story.type === 'poll') {
+        const numberOfPollOptions = story.poll.length;
+        story.poll_votes_count = 0;
+        const pollResults = await Promise.all(
+            Array.from({ length: numberOfPollOptions }, (_, i) => fetchPollContent(story.id + i + 1, signal))
+        );
+        pollResults.forEach((pollResult, i) => {
+            story.poll[i] = pollResult;
+            story.poll_votes_count += pollResult.points;
+        });
+    }
+    return story;
+}
+
+export function fetchUser(id: string, signal?: AbortSignal): Promise<User> {
+    return fetchJson<User>(`${BASE_URL}/user/${id}`, signal);
+}

--- a/react/src/models/comment.ts
+++ b/react/src/models/comment.ts
@@ -1,0 +1,10 @@
+export interface Comment {
+    id: number;
+    level: number;
+    user: string;
+    time: number;
+    time_ago: string;
+    content: string;
+    deleted: boolean;
+    comments: Comment[];
+}

--- a/react/src/models/feed-type.ts
+++ b/react/src/models/feed-type.ts
@@ -1,0 +1,1 @@
+export type FeedType = 'poll' | 'story' | 'job';

--- a/react/src/models/index.ts
+++ b/react/src/models/index.ts
@@ -1,0 +1,6 @@
+export type { Comment } from './comment';
+export type { FeedType } from './feed-type';
+export type { PollResult } from './poll-result';
+export type { Settings } from './settings';
+export type { Story } from './story';
+export type { User } from './user';

--- a/react/src/models/poll-result.ts
+++ b/react/src/models/poll-result.ts
@@ -1,0 +1,4 @@
+export interface PollResult {
+    points: number;
+    content: string;
+}

--- a/react/src/models/settings.ts
+++ b/react/src/models/settings.ts
@@ -1,0 +1,7 @@
+export interface Settings {
+    showSettings: boolean;
+    openLinkInNewTab: boolean;
+    theme: string;
+    titleFontSize: string;
+    listSpacing: string;
+}

--- a/react/src/models/story.ts
+++ b/react/src/models/story.ts
@@ -1,0 +1,21 @@
+import type { Comment } from './comment';
+import type { FeedType } from './feed-type';
+import type { PollResult } from './poll-result';
+
+export interface Story {
+    id: number;
+    title: string;
+    points: number;
+    user: string;
+    time: number;
+    time_ago: number;
+    type: FeedType;
+    url: string;
+    domain: string;
+    comments: Comment[];
+    comments_count: number;
+    poll: PollResult[];
+    poll_votes_count: number;
+    deleted: boolean;
+    dead: boolean;
+}

--- a/react/src/models/user.ts
+++ b/react/src/models/user.ts
@@ -1,0 +1,8 @@
+export interface User {
+    id: string;
+    crated_time: number;
+    created: string;
+    karma: number;
+    avg: number;
+    about: string;
+}

--- a/react/src/routes/AppRoutes.test.tsx
+++ b/react/src/routes/AppRoutes.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { AppRoutes } from './AppRoutes';
+import { FEED_ROUTES } from './feed-routes';
+import type { FeedPageProps } from './placeholders';
+
+function renderAt(path: string, props = {}) {
+    return render(
+        <MemoryRouter initialEntries={[path]}>
+            <AppRoutes {...props} />
+        </MemoryRouter>
+    );
+}
+
+describe('AppRoutes', () => {
+    it('redirects / to /news/1', async () => {
+        renderAt('/');
+        const page = await screen.findByTestId('feed-page');
+        expect(page).toHaveAttribute('data-feed-type', 'news');
+        expect(page).toHaveAttribute('data-page', '1');
+    });
+
+    it.each(FEED_ROUTES.map((r) => [r.path, r.feedType] as const))(
+        'associates /%s/:page with feedType %s',
+        async (path, feedType) => {
+            renderAt(`/${path}/3`);
+            const page = await screen.findByTestId('feed-page');
+            expect(page).toHaveAttribute('data-feed-type', feedType);
+            expect(page).toHaveAttribute('data-page', '3');
+        }
+    );
+
+    it('lazily renders the item route with its id', async () => {
+        renderAt('/item/8863');
+        expect(await screen.findByTestId('item-page')).toHaveTextContent('item 8863');
+    });
+
+    it('lazily renders the user route with its id', async () => {
+        renderAt('/user/pg');
+        expect(await screen.findByTestId('user-page')).toHaveTextContent('user pg');
+    });
+
+    it('accepts injected page components', async () => {
+        const FeedPage = ({ feedType }: FeedPageProps) => <div>custom feed {feedType}</div>;
+        const ItemPage = () => <div>custom item</div>;
+        const UserPage = () => <div>custom user</div>;
+
+        const { unmount } = renderAt('/show/1', { feedPage: FeedPage, itemPage: ItemPage, userPage: UserPage });
+        expect(await screen.findByText('custom feed show')).toBeInTheDocument();
+        unmount();
+
+        renderAt('/item/1', { feedPage: FeedPage, itemPage: ItemPage, userPage: UserPage });
+        expect(await screen.findByText('custom item')).toBeInTheDocument();
+    });
+});

--- a/react/src/routes/AppRoutes.tsx
+++ b/react/src/routes/AppRoutes.tsx
@@ -1,0 +1,35 @@
+import { lazy, Suspense, type ComponentType, type ReactNode } from 'react';
+import { Navigate, Route, Routes } from 'react-router-dom';
+
+import { DEFAULT_ROUTE, FEED_ROUTES } from './feed-routes';
+import { FeedPlaceholder, type FeedPageProps } from './placeholders';
+
+const ItemPage = lazy(() => import('./placeholders').then((m) => ({ default: m.ItemPlaceholder })));
+const UserPage = lazy(() => import('./placeholders').then((m) => ({ default: m.UserPlaceholder })));
+
+export interface AppRoutesProps {
+    feedPage?: ComponentType<FeedPageProps>;
+    itemPage?: ComponentType;
+    userPage?: ComponentType;
+    fallback?: ReactNode;
+}
+
+export function AppRoutes({
+    feedPage: FeedPage = FeedPlaceholder,
+    itemPage: Item = ItemPage,
+    userPage: User = UserPage,
+    fallback = null,
+}: AppRoutesProps) {
+    return (
+        <Suspense fallback={fallback}>
+            <Routes>
+                <Route path="/" element={<Navigate to={DEFAULT_ROUTE} replace />} />
+                {FEED_ROUTES.map(({ path, feedType }) => (
+                    <Route key={path} path={`${path}/:page`} element={<FeedPage feedType={feedType} />} />
+                ))}
+                <Route path="item/:id" element={<Item />} />
+                <Route path="user/:id" element={<User />} />
+            </Routes>
+        </Suspense>
+    );
+}

--- a/react/src/routes/feed-routes.ts
+++ b/react/src/routes/feed-routes.ts
@@ -1,0 +1,16 @@
+import type { FeedName } from '../api/hackernews-api';
+
+export interface FeedRouteDefinition {
+    path: FeedName;
+    feedType: FeedName;
+}
+
+export const FEED_ROUTES: readonly FeedRouteDefinition[] = [
+    { path: 'news', feedType: 'news' },
+    { path: 'newest', feedType: 'newest' },
+    { path: 'show', feedType: 'show' },
+    { path: 'ask', feedType: 'ask' },
+    { path: 'jobs', feedType: 'jobs' },
+];
+
+export const DEFAULT_ROUTE = '/news/1';

--- a/react/src/routes/index.ts
+++ b/react/src/routes/index.ts
@@ -1,0 +1,5 @@
+export { AppRoutes } from './AppRoutes';
+export type { AppRoutesProps } from './AppRoutes';
+export { FEED_ROUTES, DEFAULT_ROUTE } from './feed-routes';
+export type { FeedRouteDefinition } from './feed-routes';
+export type { FeedPageProps } from './placeholders';

--- a/react/src/routes/placeholders.tsx
+++ b/react/src/routes/placeholders.tsx
@@ -1,0 +1,26 @@
+import { useParams } from 'react-router-dom';
+
+import type { FeedName } from '../api/hackernews-api';
+
+export interface FeedPageProps {
+    feedType: FeedName;
+}
+
+export function FeedPlaceholder({ feedType }: FeedPageProps) {
+    const { page } = useParams<{ page: string }>();
+    return (
+        <main data-testid="feed-page" data-feed-type={feedType} data-page={page}>
+            {feedType} / page {page}
+        </main>
+    );
+}
+
+export function ItemPlaceholder() {
+    const { id } = useParams<{ id: string }>();
+    return <main data-testid="item-page">item {id}</main>;
+}
+
+export function UserPlaceholder() {
+    const { id } = useParams<{ id: string }>();
+    return <main data-testid="user-page">user {id}</main>;
+}

--- a/react/src/settings/SettingsContext.test.tsx
+++ b/react/src/settings/SettingsContext.test.tsx
@@ -1,0 +1,110 @@
+import { act, renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+import { mockMatchMedia, type MatchMediaMock } from '../test/matchMedia';
+import { SettingsProvider } from './SettingsContext';
+import { useSettings } from './useSettings';
+
+function wrapper({ children }: { children: ReactNode }) {
+    return <SettingsProvider>{children}</SettingsProvider>;
+}
+
+describe('SettingsProvider / useSettings', () => {
+    let media: MatchMediaMock;
+
+    beforeEach(() => {
+        localStorage.clear();
+        media = mockMatchMedia(false);
+    });
+
+    it('throws when used outside a provider', () => {
+        expect(() => renderHook(() => useSettings())).toThrow('useSettings must be used within a SettingsProvider');
+    });
+
+    it('provides defaults when nothing is stored and the system prefers light', () => {
+        const { result } = renderHook(() => useSettings(), { wrapper });
+        expect(result.current.settings).toEqual({
+            showSettings: false,
+            openLinkInNewTab: false,
+            theme: 'default',
+            titleFontSize: '16',
+            listSpacing: '0',
+        });
+    });
+
+    it('uses the night theme when the system prefers dark and no theme is saved', () => {
+        media.setMatches(true);
+        const { result } = renderHook(() => useSettings(), { wrapper });
+        expect(result.current.settings.theme).toBe('night');
+    });
+
+    it('prefers a saved theme over the system colour scheme', () => {
+        media.setMatches(true);
+        localStorage.setItem('theme', 'amoledblack');
+        const { result } = renderHook(() => useSettings(), { wrapper });
+        expect(result.current.settings.theme).toBe('amoledblack');
+    });
+
+    it('restores persisted values from localStorage', () => {
+        localStorage.setItem('openLinkInNewTab', 'true');
+        localStorage.setItem('titleFontSize', '20');
+        localStorage.setItem('listSpacing', '4');
+        const { result } = renderHook(() => useSettings(), { wrapper });
+        expect(result.current.settings.openLinkInNewTab).toBe(true);
+        expect(result.current.settings.titleFontSize).toBe('20');
+        expect(result.current.settings.listSpacing).toBe('4');
+    });
+
+    it('reacts to prefers-color-scheme changes', () => {
+        const { result } = renderHook(() => useSettings(), { wrapper });
+        expect(media.addEventListener).toHaveBeenCalledWith('change', expect.any(Function));
+
+        act(() => media.dispatchChange(true));
+        expect(result.current.settings.theme).toBe('night');
+        expect(localStorage.getItem('theme')).toBe('night');
+
+        act(() => media.dispatchChange(false));
+        expect(result.current.settings.theme).toBe('default');
+        expect(localStorage.getItem('theme')).toBe('default');
+    });
+
+    it('removes the media listener on unmount', () => {
+        const { unmount } = renderHook(() => useSettings(), { wrapper });
+        unmount();
+        expect(media.removeEventListener).toHaveBeenCalledWith('change', expect.any(Function));
+    });
+
+    it('toggleSettings flips showSettings without persisting it', () => {
+        const { result } = renderHook(() => useSettings(), { wrapper });
+        act(() => result.current.toggleSettings());
+        expect(result.current.settings.showSettings).toBe(true);
+        act(() => result.current.toggleSettings());
+        expect(result.current.settings.showSettings).toBe(false);
+        expect(localStorage.getItem('showSettings')).toBeNull();
+    });
+
+    it('toggleOpenLinksInNewTab flips and persists the flag', () => {
+        const { result } = renderHook(() => useSettings(), { wrapper });
+        act(() => result.current.toggleOpenLinksInNewTab());
+        expect(result.current.settings.openLinkInNewTab).toBe(true);
+        expect(localStorage.getItem('openLinkInNewTab')).toBe('true');
+        act(() => result.current.toggleOpenLinksInNewTab());
+        expect(result.current.settings.openLinkInNewTab).toBe(false);
+        expect(localStorage.getItem('openLinkInNewTab')).toBe('false');
+    });
+
+    it('setTheme, setFont and setSpacing update state and localStorage', () => {
+        const { result } = renderHook(() => useSettings(), { wrapper });
+        act(() => {
+            result.current.setTheme('amoledblack');
+            result.current.setFont('18');
+            result.current.setSpacing('2');
+        });
+        expect(result.current.settings.theme).toBe('amoledblack');
+        expect(result.current.settings.titleFontSize).toBe('18');
+        expect(result.current.settings.listSpacing).toBe('2');
+        expect(localStorage.getItem('theme')).toBe('amoledblack');
+        expect(localStorage.getItem('titleFontSize')).toBe('18');
+        expect(localStorage.getItem('listSpacing')).toBe('2');
+    });
+});

--- a/react/src/settings/SettingsContext.tsx
+++ b/react/src/settings/SettingsContext.tsx
@@ -1,0 +1,55 @@
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
+
+import type { Settings } from '../models';
+import {
+    SettingsContext,
+    darkColorSchemeMedia,
+    loadInitialSettings,
+    themeForColorScheme,
+    type SettingsContextValue,
+} from './settings-context';
+
+export function SettingsProvider({ children }: { children: ReactNode }) {
+    const [settings, setSettings] = useState<Settings>(loadInitialSettings);
+
+    const setTheme = useCallback((theme: string) => {
+        localStorage.setItem('theme', theme);
+        setSettings((prev) => ({ ...prev, theme }));
+    }, []);
+
+    useEffect(() => {
+        const media = darkColorSchemeMedia();
+        const onChange = (event: MediaQueryListEvent) => setTheme(themeForColorScheme(event.matches));
+        media.addEventListener('change', onChange);
+        return () => media.removeEventListener('change', onChange);
+    }, [setTheme]);
+
+    const toggleSettings = useCallback(() => {
+        setSettings((prev) => ({ ...prev, showSettings: !prev.showSettings }));
+    }, []);
+
+    const toggleOpenLinksInNewTab = useCallback(() => {
+        setSettings((prev) => {
+            const openLinkInNewTab = !prev.openLinkInNewTab;
+            localStorage.setItem('openLinkInNewTab', JSON.stringify(openLinkInNewTab));
+            return { ...prev, openLinkInNewTab };
+        });
+    }, []);
+
+    const setFont = useCallback((titleFontSize: string) => {
+        localStorage.setItem('titleFontSize', titleFontSize);
+        setSettings((prev) => ({ ...prev, titleFontSize }));
+    }, []);
+
+    const setSpacing = useCallback((listSpacing: string) => {
+        localStorage.setItem('listSpacing', listSpacing);
+        setSettings((prev) => ({ ...prev, listSpacing }));
+    }, []);
+
+    const value = useMemo<SettingsContextValue>(
+        () => ({ settings, toggleSettings, toggleOpenLinksInNewTab, setTheme, setFont, setSpacing }),
+        [settings, toggleSettings, toggleOpenLinksInNewTab, setTheme, setFont, setSpacing]
+    );
+
+    return <SettingsContext.Provider value={value}>{children}</SettingsContext.Provider>;
+}

--- a/react/src/settings/index.ts
+++ b/react/src/settings/index.ts
@@ -1,0 +1,4 @@
+export { SettingsProvider } from './SettingsContext';
+export { SettingsContext, THEMES, loadInitialSettings } from './settings-context';
+export type { SettingsContextValue } from './settings-context';
+export { useSettings } from './useSettings';

--- a/react/src/settings/settings-context.ts
+++ b/react/src/settings/settings-context.ts
@@ -1,0 +1,38 @@
+import { createContext } from 'react';
+
+import type { Settings } from '../models';
+
+export const THEMES = ['default', 'night', 'amoledblack'] as const;
+
+export interface SettingsContextValue {
+    settings: Settings;
+    toggleSettings: () => void;
+    toggleOpenLinksInNewTab: () => void;
+    setTheme: (theme: string) => void;
+    setFont: (fontSize: string) => void;
+    setSpacing: (listSpace: string) => void;
+}
+
+export const SettingsContext = createContext<SettingsContextValue | null>(null);
+
+const DARK_SCHEME_QUERY = '(prefers-color-scheme: dark)';
+
+export function darkColorSchemeMedia(): MediaQueryList {
+    return window.matchMedia(DARK_SCHEME_QUERY);
+}
+
+export function themeForColorScheme(prefersDark: boolean): string {
+    return prefersDark ? 'night' : 'default';
+}
+
+export function loadInitialSettings(): Settings {
+    const openLinkInNewTab = localStorage.getItem('openLinkInNewTab');
+    const savedTheme = localStorage.getItem('theme');
+    return {
+        showSettings: false,
+        openLinkInNewTab: openLinkInNewTab ? (JSON.parse(openLinkInNewTab) as boolean) : false,
+        theme: savedTheme ? savedTheme : themeForColorScheme(darkColorSchemeMedia().matches),
+        titleFontSize: localStorage.getItem('titleFontSize') ?? '16',
+        listSpacing: localStorage.getItem('listSpacing') ?? '0',
+    };
+}

--- a/react/src/settings/useSettings.ts
+++ b/react/src/settings/useSettings.ts
@@ -1,0 +1,11 @@
+import { useContext } from 'react';
+
+import { SettingsContext, type SettingsContextValue } from './settings-context';
+
+export function useSettings(): SettingsContextValue {
+    const context = useContext(SettingsContext);
+    if (!context) {
+        throw new Error('useSettings must be used within a SettingsProvider');
+    }
+    return context;
+}

--- a/react/src/shared/components/ErrorMessage.test.tsx
+++ b/react/src/shared/components/ErrorMessage.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+
+import { ErrorMessage } from './ErrorMessage';
+
+describe('ErrorMessage', () => {
+    it('renders the skull graphic, the message and the offline note', () => {
+        const { container } = render(<ErrorMessage message="Could not load news stories." />);
+        expect(container.querySelector('.error-section .skull .head .crack')).not.toBeNull();
+        expect(container.querySelector('.error-section .skull .mouth .teeth')).not.toBeNull();
+        expect(screen.getByText('Could not load news stories.')).toHaveClass('strong');
+        expect(screen.getByText(/If you are offline viewing/)).toBeInTheDocument();
+    });
+});

--- a/react/src/shared/components/ErrorMessage.tsx
+++ b/react/src/shared/components/ErrorMessage.tsx
@@ -1,0 +1,25 @@
+import './error-message.scss';
+
+export interface ErrorMessageProps {
+    message: string;
+}
+
+export function ErrorMessage({ message }: ErrorMessageProps) {
+    return (
+        <div className="error-section">
+            <div className="skull">
+                <div className="head">
+                    <div className="crack"></div>
+                </div>
+                <div className="mouth">
+                    <div className="teeth"></div>
+                </div>
+            </div>
+            <p className="strong">{message}</p>
+            <p>
+                If you are offline viewing, you&apos;ll need to visit this page with a network connection first before
+                it can work offline.
+            </p>
+        </div>
+    );
+}

--- a/react/src/shared/components/Loader.test.tsx
+++ b/react/src/shared/components/Loader.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react';
+
+import { Loader } from './Loader';
+
+describe('Loader', () => {
+    it('renders the loading indicator', () => {
+        render(<Loader />);
+        const loader = screen.getByText('Loading...');
+        expect(loader).toHaveClass('loader');
+        expect(loader.parentElement).toHaveClass('loading-section');
+    });
+});

--- a/react/src/shared/components/Loader.tsx
+++ b/react/src/shared/components/Loader.tsx
@@ -1,0 +1,9 @@
+import './loader.scss';
+
+export function Loader() {
+    return (
+        <div className="loading-section">
+            <div className="loader">Loading...</div>
+        </div>
+    );
+}

--- a/react/src/shared/components/error-message.scss
+++ b/react/src/shared/components/error-message.scss
@@ -1,0 +1,118 @@
+@use 'sass:math';
+@use '../../styles/media' as *;
+@use '../../styles/theme_variables' as *;
+
+.error-section {
+    height: 300px;
+    margin: 200px;
+
+    @media #{$mobile-only} {
+        height: 0;
+        display: block;
+        position: relative;
+        margin: 30vh 0;
+    }
+
+    p {
+        text-align: center;
+        padding: 0 25px;
+
+        &.strong {
+            margin-top: 25px;
+            font-weight: bold;
+        }
+    }
+
+    .skull {
+        width: $skull-size;
+        height: $skull-size;
+        position: relative;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        margin: auto;
+
+        .head {
+            width: 100%;
+            height: 75%;
+            border-radius: 15% / 20%;
+            position: absolute;
+            top: 0;
+            left: 0;
+            &:before,
+            &:after {
+                content: '';
+                position: absolute;
+                border-radius: 50%;
+                width: 20%;
+                height: 30%;
+                bottom: 10%;
+            }
+            &:before {
+                left: 10%;
+            }
+            &:after {
+                right: 10%;
+            }
+            .crack {
+                width: 10%;
+                height: 10%;
+                position: absolute;
+                top: 0;
+                right: 25%;
+                transform: skew(-15deg);
+
+                &:before {
+                    content: '';
+                    position: absolute;
+                    top: 100%;
+                    left: math.div($skull-size, 15);
+                    border-right: math.div($skull-size, 20) solid transparent;
+                    border-left: math.div($skull-size, 40) solid transparent;
+                }
+            }
+        }
+        .mouth {
+            width: 40%;
+            height: 25%;
+            position: absolute;
+            top: 75%;
+            left: 30%;
+            border-radius: 0 0 math.div($skull-size, 10) math.div($skull-size, 10);
+            &:before {
+                content: '';
+                position: absolute;
+                width: 15%;
+                height: 50%;
+                border-radius: 50% / 30%;
+                left: 42.5%;
+                top: -25%;
+            }
+            .teeth {
+                position: absolute;
+                bottom: 0;
+                left: 45%;
+                width: 10%;
+                height: 50%;
+                margin-bottom: -5%;
+                border-radius: 50% / 20%;
+
+                &:before,
+                &:after {
+                    content: '';
+                    position: absolute;
+                    width: 100%;
+                    height: 100%;
+                    border-radius: 50% / 20%;
+                }
+                &:before {
+                    left: -250%;
+                }
+                &:after {
+                    right: -250%;
+                }
+            }
+        }
+    }
+}

--- a/react/src/shared/components/index.ts
+++ b/react/src/shared/components/index.ts
@@ -1,0 +1,3 @@
+export { Loader } from './Loader';
+export { ErrorMessage } from './ErrorMessage';
+export type { ErrorMessageProps } from './ErrorMessage';

--- a/react/src/shared/components/loader.scss
+++ b/react/src/shared/components/loader.scss
@@ -1,0 +1,112 @@
+@use 'sass:math';
+@use '../../styles/media' as *;
+@use '../../styles/theme_variables' as *;
+
+.loader {
+    -webkit-animation: load1 1s infinite ease-in-out;
+    animation: load1 1s infinite ease-in-out;
+    width: 1em;
+    height: 4em;
+    &:before,
+    &:after {
+        -webkit-animation: load1 1s infinite ease-in-out;
+        animation: load1 1s infinite ease-in-out;
+        width: 1em;
+        height: 4em;
+    }
+    &:before,
+    &:after {
+        position: absolute;
+        top: 0;
+        content: '';
+    }
+    &:before {
+        left: -1.5em;
+        -webkit-animation-delay: -0.32s;
+        animation-delay: -0.32s;
+    }
+}
+
+.loading-section {
+    height: 70px;
+    margin: 40px 0 40px 40px;
+
+    @media #{$mobile-only} {
+        display: block;
+        position: relative;
+        margin: 45vh 0;
+    }
+}
+
+.loader {
+    text-indent: -9999em;
+    margin: 20px 20px;
+    position: relative;
+    font-size: 11px;
+    -webkit-transform: translateZ(0);
+    -ms-transform: translateZ(0);
+    transform: translateZ(0);
+    -webkit-animation-delay: -0.16s;
+    animation-delay: -0.16s;
+    &:after {
+        left: 1.5em;
+    }
+
+    @media #{$mobile-only} {
+        margin: 20px auto;
+    }
+}
+
+@-webkit-keyframes load1 {
+    0%,
+    80%,
+    100% {
+        box-shadow: 0 0;
+        height: 2em;
+    }
+    40% {
+        box-shadow: 0 -2em;
+        height: 3em;
+    }
+}
+
+@keyframes load1 {
+    0%,
+    80%,
+    100% {
+        box-shadow: 0 0;
+        height: 2em;
+    }
+    40% {
+        box-shadow: 0 -2em;
+        height: 3em;
+    }
+}
+
+@media #{$mobile-only} {
+    @-webkit-keyframes load1 {
+        0%,
+        80%,
+        100% {
+            box-shadow: 0 0;
+            height: 4em;
+        }
+        40% {
+            box-shadow: 0 -2em;
+            height: 5em;
+        }
+    }
+
+    @keyframes load1 {
+        0%,
+        80%,
+        100% {
+            box-shadow: 0 0;
+            height: 3em;
+        }
+        40% {
+            box-shadow: 0 -2em;
+            height: 4em;
+        }
+    }
+}

--- a/react/src/test/matchMedia.ts
+++ b/react/src/test/matchMedia.ts
@@ -1,0 +1,42 @@
+import { vi } from 'vitest';
+
+type ChangeListener = (event: MediaQueryListEvent) => void;
+
+export interface MatchMediaMock {
+    setMatches: (matches: boolean) => void;
+    dispatchChange: (matches: boolean) => void;
+    addEventListener: ReturnType<typeof vi.fn>;
+    removeEventListener: ReturnType<typeof vi.fn>;
+}
+
+export function mockMatchMedia(initialMatches = false): MatchMediaMock {
+    let matches = initialMatches;
+    const listeners = new Set<ChangeListener>();
+    const addEventListener = vi.fn((_: string, listener: ChangeListener) => listeners.add(listener));
+    const removeEventListener = vi.fn((_: string, listener: ChangeListener) => listeners.delete(listener));
+
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+        get matches() {
+            return matches;
+        },
+        media: query,
+        onchange: null,
+        addEventListener,
+        removeEventListener,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+    }));
+
+    return {
+        setMatches: (value) => {
+            matches = value;
+        },
+        dispatchChange: (value) => {
+            matches = value;
+            listeners.forEach((listener) => listener({ matches: value } as MediaQueryListEvent));
+        },
+        addEventListener,
+        removeEventListener,
+    };
+}

--- a/react/src/utils/comment-format.test.ts
+++ b/react/src/utils/comment-format.test.ts
@@ -1,0 +1,18 @@
+import { formatCommentCount } from './comment-format';
+
+describe('formatCommentCount', () => {
+    it('pluralises when more than one comment', () => {
+        expect(formatCommentCount(2)).toBe('2 comments');
+        expect(formatCommentCount(30)).toBe('30 comments');
+    });
+
+    it('uses the singular for exactly one comment', () => {
+        expect(formatCommentCount(1)).toBe('1 comment');
+    });
+
+    it('returns "discuss" for zero or missing comments', () => {
+        expect(formatCommentCount(0)).toBe('discuss');
+        expect(formatCommentCount(-1)).toBe('discuss');
+        expect(formatCommentCount(undefined as unknown as number)).toBe('discuss');
+    });
+});

--- a/react/src/utils/comment-format.ts
+++ b/react/src/utils/comment-format.ts
@@ -1,0 +1,7 @@
+export function formatCommentCount(comment: number): string {
+    if (comment > 0) {
+        const st = comment === 1 ? 'comment' : 'comments';
+        return `${comment} ${st}`;
+    }
+    return 'discuss';
+}


### PR DESCRIPTION
## Summary
PR 2 of the Angular -> React migration, based on #720 (Phase 0). Adds the framework-agnostic core that all Phase 2 feature work builds on; routes render `data-testid` placeholders that Phase 2 replaces.

Key design points:
- **Models** are ported 1:1 but as `interface`s instead of uninitialised `class`es (which don't compile under `strict`). Field names — including the `crated_time` typo and `time_ago: number` on `Story` — are kept verbatim for API parity.
- **API client** (`fetchFeed`, `fetchItemContent`, `fetchPollContent`, `fetchUser`) is plain `async fetch` against `https://node-hnapi.herokuapp.com`, replacing the RxJS `lazyFetch` wrapper. Each accepts an optional `AbortSignal` so components can cancel on unmount (the old `cancelToken`). The Angular `fetchItemContent` fired poll-option fetches and mutated `story.poll[i]` / `poll_votes_count` asynchronously *after* emitting; here they are awaited via `Promise.all` so the resolved `Story` already carries the aggregated `poll_votes_count`:
  ```ts
  if (story.type === 'poll') {
      story.poll_votes_count = 0;
      const results = await Promise.all(story.poll.map((_, i) => fetchPollContent(story.id + i + 1)));
      results.forEach((r, i) => { story.poll[i] = r; story.poll_votes_count += r.points; });
  }
  ```
- **Settings store**: `SettingsProvider` + `useSettings()` mirror `SettingsService` (`toggleSettings`, `toggleOpenLinksInNewTab`, `setTheme`, `setFont`, `setSpacing`; same localStorage keys/defaults `'16'`/`'0'`). Theme init: saved `theme` wins, else `prefers-color-scheme: dark` => `night` / else `default`; a `change` listener keeps following the OS while mounted. Angular achieved the initial value by dispatching a synthetic `MediaQueryListEvent` through its own listener — same outcome, done directly here.
- **Routing shell** `AppRoutes`: `/` -> `Navigate to /news/1`, `FEED_ROUTES` (`news|newest|show|ask|jobs` + `/:page`) each pass their `feedType` prop, `item/:id` and `user/:id` are `React.lazy` (matching the Angular lazy modules). Page components are injectable (`feedPage`/`itemPage`/`userPage` props) so Phase 2 features can be tested in isolation and Phase 3 wires the real ones.
- `formatCommentCount` replaces `CommentPipe`.
- **Shared `Loader` / `ErrorMessage`** are ported here (markup + SCSS) rather than in Phase 2D because Feed, ItemDetails and User all render them — keeping them in Phase 1 lets the four Phase 2 PRs stay file-disjoint.

### Angular -> React file mapping
| Angular | React |
| --- | --- |
| `src/app/shared/models/*.ts` | `react/src/models/*.ts` (+ `index.ts`) |
| `src/app/shared/services/hackernews-api.service.ts` | `react/src/api/hackernews-api.ts` |
| `src/app/shared/services/settings.service.ts` | `react/src/settings/{settings-context.ts,SettingsContext.tsx,useSettings.ts}` |
| `src/app/app.routes.ts` (+ child routes in `item-details.module.ts`, `user.module.ts`) | `react/src/routes/{AppRoutes.tsx,feed-routes.ts,placeholders.tsx}` |
| `src/app/shared/pipes/comment.pipe.ts` | `react/src/utils/comment-format.ts` |
| `src/app/shared/components/loader/*` | `react/src/shared/components/{Loader.tsx,loader.scss}` |
| `src/app/shared/components/error-message/*` | `react/src/shared/components/{ErrorMessage.tsx,error-message.scss}` |
| `src/app/app.component.html` (theme class wrapper only) | `react/src/App.tsx` |

### Tests
33 Vitest tests, 100% statement/branch/function/line coverage on all non-type files: API client (every endpoint, non-poll and poll aggregation path with id+1..id+n, error propagation), settings store (defaults, localStorage restore, saved-theme precedence, dark/light media init and `change` events, listener cleanup, every mutator + persistence), routing (redirect, all five feedType associations, lazy item/user, injected pages), `formatCommentCount`, `Loader`, `ErrorMessage`. `npm run lint`, `typecheck`, `build`, and the Playwright e2e (`/` -> `/news/1`) pass.

Devin-Org: engineering

Link to Devin session: https://app.devin.ai/sessions/1e6f5b46badc4852993dc2299512cd3d
Open in Devin Desktop: https://app.devin.ai/desktop/session/1e6f5b46badc4852993dc2299512cd3d?variant=devin
Requested by: @vibhaseshadri-cognition