### PR TITLE
Phase 2C: React User profile (PR 5)

### DIFF
--- a/react/src/user/UserProfile.test.tsx
+++ b/react/src/user/UserProfile.test.tsx
@@ -1,0 +1,151 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Link, MemoryRouter, Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { fetchUser } from '../api/hackernews-api';
+import type { User } from '../models';
+import { UserProfile } from './index';
+
+vi.mock('../api/hackernews-api');
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('react-router-dom')>();
+    return { ...actual, useNavigate: () => mockNavigate };
+});
+
+const mockedFetchUser = vi.mocked(fetchUser);
+
+const sampleUser: User = {
+    id: 'pg',
+    crated_time: 1160418092,
+    created: '17 years ago',
+    karma: 155111,
+    avg: 0,
+    about: 'Bug fixer.',
+};
+
+function renderAt(path: string) {
+    return render(
+        <MemoryRouter initialEntries={[path]}>
+            <Routes>
+                <Route path="/user/:id" element={<UserProfile />} />
+            </Routes>
+        </MemoryRouter>
+    );
+}
+
+describe('UserProfile', () => {
+    beforeEach(() => {
+        mockedFetchUser.mockReset();
+        mockNavigate.mockReset();
+    });
+
+    it('shows the loader while the user is loading', () => {
+        mockedFetchUser.mockReturnValue(new Promise(() => {}));
+        const { container } = renderAt('/user/pg');
+
+        expect(container.querySelector('.loader')).not.toBeNull();
+        expect(mockedFetchUser).toHaveBeenCalledWith('pg', expect.any(AbortSignal));
+    });
+
+    it('shows an error message when the request fails', async () => {
+        mockedFetchUser.mockRejectedValue(new Error('boom'));
+        renderAt('/user/pg');
+
+        expect(await screen.findByText('Could not load user pg.')).toBeInTheDocument();
+        expect(screen.queryByText('Profile: pg')).not.toBeInTheDocument();
+    });
+
+    it('renders id, karma and created date', async () => {
+        mockedFetchUser.mockResolvedValue(sampleUser);
+        const { container } = renderAt('/user/pg');
+
+        expect(await screen.findByText('Profile: pg')).toBeInTheDocument();
+        expect(container.querySelector('.main-details .name')).toHaveTextContent('pg');
+        expect(container.querySelector('.main-details .right')).toHaveTextContent('155111 ★');
+        expect(container.querySelector('.main-details .age')).toHaveTextContent('Created 17 years ago');
+        expect(container.querySelector('.profile .mobile.item-header p.title-block .back-button')).not.toBeNull();
+    });
+
+    it('renders the about section as HTML', async () => {
+        mockedFetchUser.mockResolvedValue({ ...sampleUser, about: 'Hello <b>bio</b>' });
+        const { container } = renderAt('/user/pg');
+
+        await screen.findByText('Profile: pg');
+        const about = container.querySelector('.other-details p');
+        expect(about).not.toBeNull();
+        expect(about?.querySelector('b')).toHaveTextContent('bio');
+    });
+
+    it('omits the about section when about is empty', async () => {
+        mockedFetchUser.mockResolvedValue({ ...sampleUser, about: '' });
+        const { container } = renderAt('/user/pg');
+
+        await screen.findByText('Profile: pg');
+        expect(container.querySelector('.other-details')).toBeNull();
+    });
+
+    it('omits the about section when about is undefined', async () => {
+        const { about: _about, ...withoutAbout } = sampleUser;
+        void _about;
+        mockedFetchUser.mockResolvedValue(withoutAbout as User);
+        const { container } = renderAt('/user/pg');
+
+        await screen.findByText('Profile: pg');
+        expect(container.querySelector('.other-details')).toBeNull();
+    });
+
+    it('navigates back when the back button is clicked', async () => {
+        mockedFetchUser.mockResolvedValue(sampleUser);
+        const { container } = renderAt('/user/pg');
+        await screen.findByText('Profile: pg');
+
+        const backButton = container.querySelector('.back-button');
+        expect(backButton).not.toBeNull();
+        await userEvent.click(backButton as Element);
+
+        expect(mockNavigate).toHaveBeenCalledWith(-1);
+    });
+
+    it('refetches when the :id param changes', async () => {
+        mockedFetchUser.mockImplementation((id) => Promise.resolve({ ...sampleUser, id }));
+        render(
+            <MemoryRouter initialEntries={['/user/pg']}>
+                <Link to="/user/dang">go to dang</Link>
+                <Routes>
+                    <Route path="/user/:id" element={<UserProfile />} />
+                </Routes>
+            </MemoryRouter>
+        );
+        await screen.findByText('Profile: pg');
+
+        await userEvent.click(screen.getByText('go to dang'));
+
+        expect(await screen.findByText('Profile: dang')).toBeInTheDocument();
+        expect(mockedFetchUser).toHaveBeenCalledTimes(2);
+        expect(mockedFetchUser).toHaveBeenLastCalledWith('dang', expect.any(AbortSignal));
+    });
+
+    it('ignores results and errors after the request is aborted', async () => {
+        let resolve: (user: User) => void = () => {};
+        mockedFetchUser.mockImplementation(
+            (_id, signal) =>
+                new Promise<User>((res, rej) => {
+                    resolve = res;
+                    signal?.addEventListener('abort', () => rej(new Error('aborted')));
+                })
+        );
+        const { unmount, container } = renderAt('/user/pg');
+        expect(container.querySelector('.loader')).not.toBeNull();
+
+        const signal = mockedFetchUser.mock.calls[0][1];
+        unmount();
+        expect(signal?.aborted).toBe(true);
+        resolve(sampleUser);
+
+        await waitFor(() => expect(screen.queryByText('Profile: pg')).not.toBeInTheDocument());
+        expect(screen.queryByText('Could not load user pg.')).not.toBeInTheDocument();
+    });
+});

--- a/react/src/user/UserProfile.tsx
+++ b/react/src/user/UserProfile.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+
+import { fetchUser } from '../api/hackernews-api';
+import type { User } from '../models';
+import { ErrorMessage, Loader } from '../shared/components';
+import './user.scss';
+
+interface UserResult {
+    id: string;
+    user: User | null;
+    errorMessage: string;
+}
+
+export function UserProfile() {
+    const { id = '' } = useParams<{ id: string }>();
+    const navigate = useNavigate();
+    const [result, setResult] = useState<UserResult | null>(null);
+
+    useEffect(() => {
+        const controller = new AbortController();
+
+        fetchUser(id, controller.signal)
+            .then((data) => {
+                if (!controller.signal.aborted) {
+                    setResult({ id, user: data, errorMessage: '' });
+                }
+            })
+            .catch(() => {
+                if (!controller.signal.aborted) {
+                    setResult({ id, user: null, errorMessage: `Could not load user ${id}.` });
+                }
+            });
+
+        return () => controller.abort();
+    }, [id]);
+
+    const user = result?.id === id ? result.user : null;
+    const errorMessage = result?.id === id ? result.errorMessage : '';
+
+    if (!user && !errorMessage) {
+        return <Loader />;
+    }
+
+    if (!user) {
+        return <ErrorMessage message={errorMessage} />;
+    }
+
+    return (
+        <div className="profile">
+            <div className="mobile item-header">
+                <p className="title-block">
+                    <span className="back-button" onClick={() => navigate(-1)}></span>
+                    Profile: {user.id}
+                </p>
+            </div>
+            <div className="main-details">
+                <span className="name">{user.id}</span>
+                <span className="right">{user.karma} ★</span>
+                <p className="age">Created {user.created}</p>
+            </div>
+            {user.about && (
+                <div className="other-details">
+                    <p dangerouslySetInnerHTML={{ __html: user.about }} />
+                </div>
+            )}
+        </div>
+    );
+}

--- a/react/src/user/index.ts
+++ b/react/src/user/index.ts
@@ -1,0 +1,1 @@
+export { UserProfile } from './UserProfile';

--- a/react/src/user/user.scss
+++ b/react/src/user/user.scss
@@ -1,0 +1,89 @@
+@use '../styles/media' as *;
+@use '../styles/theme_variables' as *;
+
+.profile pre {
+    white-space: pre-wrap;
+}
+
+.profile {
+    padding: 30px;
+}
+
+@media #{$mobile-only} {
+    .profile {
+        padding: 110px 15px 0 15px;
+    }
+    .title-block {
+        font-size: 15px;
+        text-align: center;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        overflow: hidden;
+        margin: 0 75px;
+    }
+    .back-button {
+        position: absolute;
+        top: 52%;
+        width: 0.6rem;
+        height: 0.6rem;
+        background: transparent;
+        box-shadow: 0 0 0 lightgray;
+        transition: all 200ms ease;
+        left: 4%;
+        transform: translate3d(0, -50%, 0) rotate(-135deg);
+    }
+    .item-header {
+        padding-bottom: 10px;
+        background-color: #fff;
+        padding: 10px 0 10px 0;
+        position: fixed;
+        width: 100%;
+        left: 0;
+        top: 62px;
+        height: 20px;
+    }
+}
+
+@media #{$laptop-only} {
+    .mobile {
+        display: none;
+    }
+}
+
+.main-details {
+    .name {
+        font-weight: bold;
+        font-size: 32px;
+        letter-spacing: 2px;
+    }
+    .age {
+        font-weight: bold;
+        color: #696969;
+        padding-bottom: 0;
+    }
+    .right {
+        float: right;
+        font-weight: bold;
+        font-size: 32px;
+        letter-spacing: 2px;
+    }
+}
+
+@media #{$mobile-only} {
+    .main-details {
+        margin-top: 20px;
+        .name {
+            font-size: 18px;
+        }
+    }
+}
+
+@media #{$mobile-only} {
+    .main-details .right {
+        font-size: 18px;
+    }
+}
+
+.other-details {
+    word-wrap: break-word;
+}


### PR DESCRIPTION
## Summary
Phase 2C of the Angular → React migration: ports the lazy-loaded Angular `UserModule` (`/user/:id` profile page) to React under `react/src/user/`. Only new files are added; no Angular sources and no existing Phase 1 files are touched. Phase 3 will wire `UserProfile` into `routes/AppRoutes.tsx` via the existing `userPage` prop.

`UserProfile()` reads `:id` with `useParams`, calls `fetchUser(id, signal)` inside a `useEffect` with an `AbortController` (aborted on unmount / id change, results after abort ignored), and renders `<Loader/>` while pending, `<ErrorMessage message="Could not load user {id}."/>` on failure, and the exact Angular markup on success (`.profile > .mobile.item-header > p.title-block > span.back-button` + `Profile: {id}`, `.main-details` with `span.name`, `span.right` (`{karma} ★`), `p.age` (`Created {created}`), and `.other-details > p[innerHTML=about]` only when `about` is truthy). The back button calls `useNavigate()(-1)` (Angular `Location.back()`).

One non-obvious detail: to satisfy the repo's `react-hooks/set-state-in-effect` lint rule, loading/error state is not reset via `setState` in the effect. Instead a single `{ id, user, errorMessage }` result is stored and the render derives `user`/`errorMessage` only when `result.id === id`, so a param change naturally falls back to the loader until the new fetch resolves.

`user.scss` is a straight port of `user.component.scss`; the Angular `:host >>> pre` (piercing shadow-DOM rule for `pre` inside the user's about HTML) becomes `.profile pre`.

## Angular → React mapping

| Angular file | React file(s) |
| --- | --- |
| `src/app/user/user.component.ts` | `react/src/user/UserProfile.tsx` |
| `src/app/user/user.component.html` | `react/src/user/UserProfile.tsx` (JSX) |
| `src/app/user/user.component.scss` | `react/src/user/user.scss` |
| `src/app/user/user.module.ts` | `react/src/user/index.ts` (barrel export; routing handled by Phase 1 `routes/`) |
| — | `react/src/user/UserProfile.test.tsx` (new tests) |

## Verification (in `react/`)
- `npm run lint`: 0 errors, 0 warnings (ESLint + Prettier clean)
- `npm run typecheck`: passes
- `npm test`: 8 files / 42 tests passing (9 new in `UserProfile.test.tsx`: loading, error, id/karma/created, about as HTML, about absent when empty and when undefined, back button → `navigate(-1)`, refetch on `:id` change, aborted request ignored)
- `npm run test:coverage`: `src/user` 100% statements / branches / functions / lines
- `npm run build`: succeeds

## Screenshots
Rendered via a temporary Vite harness (not committed) with the `/user/pg` API response stubbed by Playwright (the `node-hnapi.herokuapp.com` backend currently returns 404).

Desktop:

![UserProfile desktop](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfNjlJWEpGTHJsang4elNBdyIsInVzZXJfaWQiOm51bGwsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZ182OUlYSkZMcmxqeDh6U0F3LzNjMTJiNDkxLWM2OGMtNDBlZS05NzQ5LWRmNzk2YjAwZTU0YyIsImlhdCI6MTc4ODM2MzA3OCwiZXhwIjoxNzg4OTY3ODc4LCJmaWxlbmFtZSI6InVzZXItcHJvZmlsZS5wbmcifQ.O6m_A32W1fChfW_eQ-Ll2DZcfIfABhQk7DuuvNDrad0)

Mobile (shows the `.mobile.item-header` title block / back button):

![UserProfile mobile](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfNjlJWEpGTHJsang4elNBdyIsInVzZXJfaWQiOm51bGwsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZ182OUlYSkZMcmxqeDh6U0F3LzIzYWY4MDA0LTY2Y2YtNDNmZC04NDFlLTliZTJlN2MyOWRhZCIsImlhdCI6MTc4ODM2MzA3OCwiZXhwIjoxNzg4OTY3ODc4LCJmaWxlbmFtZSI6InVzZXItcHJvZmlsZS1tb2JpbGUucG5nIn0.zDZMpEnimBf36ubtsaYyTn48M1nPHQoq_8oBwGXbqRI)

Devin-Org: engineering


Link to Devin session: https://app.devin.ai/sessions/debb17820b5c46d3bfd24b273b9471d3
Open in Devin Desktop: https://app.devin.ai/desktop/session/debb17820b5c46d3bfd24b273b9471d3?variant=devin
Requested by: @vibhaseshadri-cognition