### PR TITLE
Phase 2D: React core layout, Header, Footer, Settings, GA tracking (PR 6)

### DIFF
--- a/react/src/core/AppLayout.test.tsx
+++ b/react/src/core/AppLayout.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Link, MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import { SettingsProvider } from '../settings';
+import { mockMatchMedia } from '../test/matchMedia';
+import { AppLayout } from './AppLayout';
+
+function renderLayout(initialPath = '/news/1') {
+    return render(
+        <MemoryRouter initialEntries={[initialPath]}>
+            <SettingsProvider>
+                <AppLayout>
+                    <Routes>
+                        <Route path="/news/1" element={<Link to="/ask/1">go to ask</Link>} />
+                        <Route path="/ask/1" element={<p>ask page</p>} />
+                    </Routes>
+                </AppLayout>
+            </SettingsProvider>
+        </MemoryRouter>
+    );
+}
+
+describe('AppLayout', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        mockMatchMedia(false);
+        delete window.ga;
+    });
+
+    it('wraps header, children and footer in the theme container', () => {
+        localStorage.setItem('theme', 'night');
+        const { container } = renderLayout();
+        const themed = container.firstElementChild;
+        expect(themed).toHaveClass('night');
+        expect(themed?.querySelector('.body-cover')).not.toBeNull();
+
+        const wrapper = themed?.querySelector('.wrapper');
+        expect(wrapper).not.toBeNull();
+        const children = Array.from(wrapper?.children ?? []);
+        expect(children[0].tagName).toBe('HEADER');
+        expect(children[1]).toHaveTextContent('go to ask');
+        expect(children[2]).toHaveAttribute('id', 'footer');
+    });
+
+    it('uses the default theme when nothing is persisted', () => {
+        const { container } = renderLayout();
+        expect(container.firstElementChild).toHaveClass('default');
+    });
+
+    it('follows theme changes from the settings panel', async () => {
+        const user = userEvent.setup();
+        const { container } = renderLayout();
+        await user.click(screen.getByAltText('Settings'));
+        await user.click(screen.getByRole('radio', { name: 'Night' }));
+        expect(container.firstElementChild).toHaveClass('night');
+    });
+
+    it('sends a pageview to ga on mount and on every route change', async () => {
+        const user = userEvent.setup();
+        const ga = vi.fn();
+        window.ga = ga;
+        renderLayout();
+        expect(ga).toHaveBeenCalledWith('set', 'page', '/news/1');
+        expect(ga).toHaveBeenCalledWith('send', 'pageview');
+        expect(ga).toHaveBeenCalledTimes(2);
+
+        await user.click(screen.getByRole('link', { name: 'go to ask' }));
+        expect(screen.getByText('ask page')).toBeInTheDocument();
+        expect(ga).toHaveBeenCalledWith('set', 'page', '/ask/1');
+        expect(ga).toHaveBeenCalledTimes(4);
+    });
+
+    it('does not fail when window.ga is undefined', async () => {
+        const user = userEvent.setup();
+        renderLayout();
+        expect(window.ga).toBeUndefined();
+        await user.click(screen.getByRole('link', { name: 'go to ask' }));
+        expect(screen.getByText('ask page')).toBeInTheDocument();
+    });
+});

--- a/react/src/core/AppLayout.tsx
+++ b/react/src/core/AppLayout.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from 'react';
+
+import { useSettings } from '../settings';
+import { Footer } from './Footer';
+import { Header } from './Header';
+import { usePageviewTracking } from './usePageviewTracking';
+import './app.scss';
+
+export function AppLayout({ children }: { children: ReactNode }) {
+    const { settings } = useSettings();
+    usePageviewTracking();
+
+    return (
+        <div className={settings.theme}>
+            <div className="body-cover"></div>
+            <div className="wrapper">
+                <Header />
+                {children}
+                <Footer />
+            </div>
+        </div>
+    );
+}

--- a/react/src/core/Footer.test.tsx
+++ b/react/src/core/Footer.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react';
+
+import { Footer } from './Footer';
+
+describe('Footer', () => {
+    it('renders the GitHub link inside #footer', () => {
+        const { container } = render(<Footer />);
+        expect(container.querySelector('#footer p')).toHaveTextContent('Show this project some ❤ on GitHub');
+        const link = screen.getByRole('link', { name: 'GitHub' });
+        expect(link).toHaveAttribute('href', 'https://github.com/hdjirdeh/angular2-hn');
+        expect(link).toHaveAttribute('target', '_blank');
+        expect(link).toHaveAttribute('rel', 'noopener');
+    });
+});

--- a/react/src/core/Footer.tsx
+++ b/react/src/core/Footer.tsx
@@ -1,0 +1,14 @@
+import './footer.scss';
+
+export function Footer() {
+    return (
+        <div id="footer">
+            <p>
+                Show this project some ❤ on{' '}
+                <a href="https://github.com/hdjirdeh/angular2-hn" target="_blank" rel="noopener">
+                    GitHub
+                </a>
+            </p>
+        </div>
+    );
+}

--- a/react/src/core/Header.test.tsx
+++ b/react/src/core/Header.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+
+import { SettingsProvider } from '../settings';
+import { mockMatchMedia } from '../test/matchMedia';
+import { Header } from './Header';
+
+function renderHeader(initialPath = '/news/1') {
+    return render(
+        <MemoryRouter initialEntries={[initialPath]}>
+            <SettingsProvider>
+                <Header />
+            </SettingsProvider>
+        </MemoryRouter>
+    );
+}
+
+describe('Header', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        mockMatchMedia(false);
+    });
+
+    it('renders the logo link and nav links with the expected hrefs', () => {
+        const { container } = renderHeader();
+        const home = screen.getByRole('link', { name: 'Logo' });
+        expect(home).toHaveAttribute('href', '/news/1');
+        expect(home).toHaveClass('home-link', 'active');
+        expect(container.querySelector('.home-link .logo-inner')).not.toBeNull();
+        expect(screen.getByAltText('Logo')).toHaveAttribute('src', 'assets/images/logo.svg');
+
+        expect(screen.getByRole('link', { name: 'new' })).toHaveAttribute('href', '/newest/1');
+        expect(screen.getByRole('link', { name: 'show' })).toHaveAttribute('href', '/show/1');
+        expect(screen.getByRole('link', { name: 'ask' })).toHaveAttribute('href', '/ask/1');
+        expect(screen.getByRole('link', { name: 'jobs' })).toHaveAttribute('href', '/jobs/1');
+        expect(container.querySelector('#header .header-text .left .header-nav')).toHaveTextContent(
+            'new | show | ask | jobs'
+        );
+        expect(container.querySelector('.info img.settings')).toHaveAttribute('src', 'assets/images/cog.svg');
+    });
+
+    it('marks only the active nav link', () => {
+        renderHeader('/show/1');
+        expect(screen.getByRole('link', { name: 'show' })).toHaveClass('active');
+        expect(screen.getByRole('link', { name: 'new' })).not.toHaveClass('active');
+        expect(screen.getByRole('link', { name: 'Logo' })).not.toHaveClass('active');
+    });
+
+    it('toggles the settings panel with the cog', async () => {
+        const user = userEvent.setup();
+        const { container } = renderHeader();
+        expect(container.querySelector('#popup1')).toBeNull();
+
+        await user.click(screen.getByAltText('Settings'));
+        expect(container.querySelector('#popup1')).not.toBeNull();
+
+        await user.click(screen.getByAltText('Settings'));
+        expect(container.querySelector('#popup1')).toBeNull();
+    });
+
+    it('scrolls to the top when a nav link is clicked', async () => {
+        const user = userEvent.setup();
+        const scrollTo = vi.spyOn(window, 'scrollTo').mockImplementation(() => undefined);
+        renderHeader();
+
+        await user.click(screen.getByRole('link', { name: 'new' }));
+        expect(scrollTo).toHaveBeenCalledWith(0, 0);
+
+        await user.click(screen.getByRole('link', { name: 'Logo' }));
+        expect(scrollTo).toHaveBeenCalledTimes(2);
+        scrollTo.mockRestore();
+    });
+});

--- a/react/src/core/Header.tsx
+++ b/react/src/core/Header.tsx
@@ -1,0 +1,57 @@
+import { NavLink } from 'react-router-dom';
+
+import { useSettings } from '../settings';
+import { Settings } from './Settings';
+import './header.scss';
+
+function navClass({ isActive }: { isActive: boolean }): string | undefined {
+    return isActive ? 'active' : undefined;
+}
+
+function homeLinkClass({ isActive }: { isActive: boolean }): string {
+    return isActive ? 'home-link active' : 'home-link';
+}
+
+export function Header() {
+    const { settings, toggleSettings } = useSettings();
+
+    const scrollTop = () => {
+        window.scrollTo(0, 0);
+    };
+
+    return (
+        <header>
+            <div id="header">
+                <NavLink className={homeLinkClass} to="/news/1" onClick={scrollTop}>
+                    <div className="logo-inner"></div>
+                    <img className="logo" src="assets/images/logo.svg" alt="Logo" />
+                </NavLink>
+                <div className="header-text">
+                    <div className="left">
+                        <span className="header-nav">
+                            <NavLink to="/newest/1" className={navClass} onClick={scrollTop}>
+                                new
+                            </NavLink>{' '}
+                            |{' '}
+                            <NavLink to="/show/1" className={navClass} onClick={scrollTop}>
+                                show
+                            </NavLink>{' '}
+                            |{' '}
+                            <NavLink to="/ask/1" className={navClass} onClick={scrollTop}>
+                                ask
+                            </NavLink>{' '}
+                            |{' '}
+                            <NavLink to="/jobs/1" className={navClass} onClick={scrollTop}>
+                                jobs
+                            </NavLink>
+                        </span>
+                    </div>
+                </div>
+                <div className="info">
+                    <img className="settings" src="assets/images/cog.svg" alt="Settings" onClick={toggleSettings} />
+                </div>
+            </div>
+            {settings.showSettings && <Settings />}
+        </header>
+    );
+}

--- a/react/src/core/Settings.test.tsx
+++ b/react/src/core/Settings.test.tsx
@@ -1,0 +1,122 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { SettingsProvider, useSettings } from '../settings';
+import { mockMatchMedia } from '../test/matchMedia';
+import { Settings } from './Settings';
+
+function ShowSettingsFlag() {
+    const { settings } = useSettings();
+    return <span data-testid="show-settings">{String(settings.showSettings)}</span>;
+}
+
+function renderSettings() {
+    return render(
+        <SettingsProvider>
+            <Settings />
+            <ShowSettingsFlag />
+        </SettingsProvider>
+    );
+}
+
+describe('Settings', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        mockMatchMedia(false);
+    });
+
+    it('renders the popup structure', () => {
+        const { container } = renderSettings();
+        expect(container.querySelector('#popup1.overlay .popup h1')).toHaveTextContent('Settings');
+        expect(container.querySelector('.popup .close')).toHaveTextContent('×');
+        expect(container.querySelectorAll('.content .control-section')).toHaveLength(3);
+        expect(screen.getByText('Links')).toBeInTheDocument();
+        expect(screen.getByText('Select a theme')).toBeInTheDocument();
+        expect(screen.getByText('Change Font')).toBeInTheDocument();
+    });
+
+    it('closes via the × control', async () => {
+        const user = userEvent.setup();
+        renderSettings();
+        expect(screen.getByTestId('show-settings')).toHaveTextContent('false');
+        await user.click(screen.getByText('×'));
+        expect(screen.getByTestId('show-settings')).toHaveTextContent('true');
+    });
+
+    it('toggles the open-links checkbox and persists it', async () => {
+        const user = userEvent.setup();
+        renderSettings();
+        const checkbox = screen.getByRole('checkbox');
+        expect(checkbox).not.toBeChecked();
+
+        await user.click(checkbox);
+        expect(checkbox).toBeChecked();
+        expect(localStorage.getItem('openLinkInNewTab')).toBe('true');
+
+        await user.click(checkbox);
+        expect(checkbox).not.toBeChecked();
+        expect(localStorage.getItem('openLinkInNewTab')).toBe('false');
+    });
+
+    it('selects each theme radio and persists it', async () => {
+        const user = userEvent.setup();
+        renderSettings();
+        const defaultRadio = screen.getByRole('radio', { name: 'Default' });
+        const nightRadio = screen.getByRole('radio', { name: 'Night' });
+        const amoledRadio = screen.getByRole('radio', { name: 'Black (AMOLED)' });
+
+        expect(defaultRadio).toHaveAttribute('value', 'default');
+        expect(nightRadio).toHaveAttribute('value', 'night');
+        expect(amoledRadio).toHaveAttribute('value', 'amoledblack');
+        expect(defaultRadio).toBeChecked();
+
+        await user.click(nightRadio);
+        expect(nightRadio).toBeChecked();
+        expect(defaultRadio).not.toBeChecked();
+        expect(localStorage.getItem('theme')).toBe('night');
+
+        await user.click(amoledRadio);
+        expect(amoledRadio).toBeChecked();
+        expect(localStorage.getItem('theme')).toBe('amoledblack');
+
+        await user.click(defaultRadio);
+        expect(defaultRadio).toBeChecked();
+        expect(localStorage.getItem('theme')).toBe('default');
+    });
+
+    it('updates font size and list spacing and persists them', async () => {
+        const user = userEvent.setup();
+        renderSettings();
+        const fontInput = screen.getByLabelText('Font size:');
+        const spacingInput = screen.getByLabelText('List spacing:');
+
+        expect(fontInput).toHaveAttribute('type', 'number');
+        expect(fontInput).toHaveAttribute('min', '1');
+        expect(fontInput).toHaveValue(16);
+        expect(spacingInput).toHaveAttribute('type', 'number');
+        expect(spacingInput).toHaveAttribute('min', '0');
+        expect(spacingInput).toHaveValue(0);
+
+        await user.clear(fontInput);
+        await user.type(fontInput, '20');
+        expect(fontInput).toHaveValue(20);
+        expect(localStorage.getItem('titleFontSize')).toBe('20');
+
+        await user.clear(spacingInput);
+        await user.type(spacingInput, '5');
+        expect(spacingInput).toHaveValue(5);
+        expect(localStorage.getItem('listSpacing')).toBe('5');
+    });
+
+    it('reflects persisted store values on mount', () => {
+        localStorage.setItem('openLinkInNewTab', 'true');
+        localStorage.setItem('theme', 'amoledblack');
+        localStorage.setItem('titleFontSize', '22');
+        localStorage.setItem('listSpacing', '3');
+        renderSettings();
+        expect(screen.getByRole('checkbox')).toBeChecked();
+        expect(screen.getByRole('radio', { name: 'Black (AMOLED)' })).toBeChecked();
+        expect(screen.getByLabelText('Font size:')).toHaveValue(22);
+        expect(screen.getByLabelText('List spacing:')).toHaveValue(3);
+    });
+});

--- a/react/src/core/Settings.tsx
+++ b/react/src/core/Settings.tsx
@@ -1,0 +1,103 @@
+import type { ChangeEvent } from 'react';
+
+import { useSettings } from '../settings';
+import './settings.scss';
+
+export function Settings() {
+    const { settings, toggleSettings, toggleOpenLinksInNewTab, setTheme, setFont, setSpacing } = useSettings();
+
+    const changeTitleFont = (event: ChangeEvent<HTMLInputElement>) => {
+        setFont(event.currentTarget.value);
+    };
+
+    const changeSpacing = (event: ChangeEvent<HTMLInputElement>) => {
+        setSpacing(event.currentTarget.value);
+    };
+
+    return (
+        <div id="popup1" className="overlay">
+            <div className="popup">
+                <h1>Settings</h1>
+                <hr />
+                <span className="close" onClick={toggleSettings}>
+                    &times;
+                </span>
+                <div className="content">
+                    <div className="control-section">
+                        <h2>Links</h2>
+                        <input type="checkbox" checked={settings.openLinkInNewTab} onChange={toggleOpenLinksInNewTab} />
+                        Open links in a new tab
+                    </div>
+                    <div className="theme-controls">
+                        <div className="control-section">
+                            <h2>Select a theme</h2>
+                            <div>
+                                <label>
+                                    <input
+                                        name="theme"
+                                        type="radio"
+                                        value="default"
+                                        checked={settings.theme === 'default'}
+                                        onChange={() => setTheme('default')}
+                                    />
+                                    Default
+                                </label>
+                            </div>
+                            <div>
+                                <label>
+                                    <input
+                                        name="theme"
+                                        type="radio"
+                                        value="night"
+                                        checked={settings.theme === 'night'}
+                                        onChange={() => setTheme('night')}
+                                    />
+                                    Night
+                                </label>
+                            </div>
+                            <div>
+                                <label>
+                                    <input
+                                        name="theme"
+                                        type="radio"
+                                        value="amoledblack"
+                                        checked={settings.theme === 'amoledblack'}
+                                        onChange={() => setTheme('amoledblack')}
+                                    />
+                                    Black (AMOLED)
+                                </label>
+                            </div>
+                        </div>
+                        <div className="control-section">
+                            <h2>Change Font</h2>
+                            <div>
+                                <label>
+                                    Font size:
+                                    <input
+                                        min="1"
+                                        value={settings.titleFontSize}
+                                        name="theme"
+                                        type="number"
+                                        onChange={changeTitleFont}
+                                    />
+                                </label>
+                            </div>
+                            <div>
+                                <label>
+                                    List spacing:
+                                    <input
+                                        min="0"
+                                        value={settings.listSpacing}
+                                        name="theme"
+                                        type="number"
+                                        onChange={changeSpacing}
+                                    />
+                                </label>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/react/src/core/app.scss
+++ b/react/src/core/app.scss
@@ -1,0 +1,25 @@
+@use '../styles/media' as *;
+@use '../styles/theme_variables' as *;
+
+.body-cover {
+    width: 100%;
+    z-index: 0;
+    position: fixed;
+    height: 100%;
+}
+
+.wrapper {
+    position: relative;
+    width: 85%;
+    min-height: 80px;
+    margin: 0 auto;
+    font-family:
+        'HelveticaNeue-Light', 'Helvetica Neue Light', 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif;
+    font-size: 15px;
+    height: 100%;
+    line-height: 1.3;
+
+    @media #{$mobile-only} {
+        width: 100%;
+    }
+}

--- a/react/src/core/footer.scss
+++ b/react/src/core/footer.scss
@@ -1,0 +1,23 @@
+@use '../styles/media' as *;
+@use '../styles/theme_variables' as *;
+
+#footer {
+    position: relative;
+    padding: 10px;
+    height: 60px;
+    letter-spacing: 0.7px;
+    text-align: center;
+
+    a {
+        font-weight: bold;
+        text-decoration: none;
+
+        &:hover {
+            text-decoration: underline;
+        }
+    }
+
+    @media #{$mobile-only} {
+        display: none;
+    }
+}

--- a/react/src/core/header.scss
+++ b/react/src/core/header.scss
@@ -1,0 +1,149 @@
+@use '../styles/media' as *;
+@use '../styles/theme_variables' as *;
+
+#header {
+    color: #fff;
+    padding: 6px 0;
+    line-height: 18px;
+    vertical-align: middle;
+    position: relative;
+    z-index: 1;
+    width: 100%;
+
+    @media #{$mobile-only} {
+        height: 50px;
+        position: fixed;
+        top: 0;
+    }
+
+    a {
+        display: inline;
+    }
+}
+
+.home-link {
+    width: 50px;
+    height: 66px;
+}
+
+.logo-inner {
+    width: 32px;
+    position: absolute;
+    left: 17px;
+    top: 18px;
+    z-index: -1;
+    height: 32px;
+    border-radius: 50%;
+
+    @media #{$mobile-only} {
+        left: 16px;
+        top: 12px;
+    }
+}
+
+.logo {
+    width: 50px;
+    padding: 3px 8px 0;
+
+    @media #{$mobile-only} {
+        width: 45px;
+        padding: 0 0 0 10px;
+    }
+}
+
+h1 {
+    font-weight: normal;
+    display: inline-block;
+    vertical-align: middle;
+    margin: 0;
+    font-size: 16px;
+
+    a {
+        color: #fff;
+        text-decoration: none;
+    }
+}
+
+.name {
+    margin-right: 30px;
+    margin-bottom: 2px;
+
+    @media #{$mobile-only} {
+        display: none;
+    }
+}
+
+.header-text {
+    position: absolute;
+    width: inherit;
+    height: 20px;
+    left: 10px;
+    top: 27px;
+    z-index: -1;
+
+    @media #{$mobile-only} {
+        top: 22px;
+    }
+}
+
+.left {
+    position: absolute;
+    left: 60px;
+    font-size: 16px;
+
+    @media #{$mobile-only} {
+        width: 100%;
+        left: 0;
+    }
+}
+
+.header-nav {
+    display: inline-block;
+    margin-left: 20px;
+
+    @media #{$mobile-only} {
+        margin-left: 60px;
+    }
+
+    a {
+        color: hsla(0, 0%, 100%, 0.9);
+        text-decoration: none;
+        margin: 0 5px;
+        letter-spacing: 1.8px;
+
+        &:hover {
+            color: #fff;
+        }
+    }
+
+    .active {
+        color: #fff;
+    }
+}
+
+.info {
+    position: absolute;
+    top: 0;
+    right: 20px;
+    height: 100%;
+
+    @media #{$mobile-only} {
+        right: 10px;
+    }
+
+    img {
+        opacity: 0.8;
+        width: 25px;
+        margin-top: 21.5px;
+        display: block;
+
+        &:hover {
+            opacity: 1;
+            cursor: pointer;
+        }
+
+        @media #{$mobile-only} {
+            margin-top: 15px;
+        }
+    }
+}

--- a/react/src/core/index.test.ts
+++ b/react/src/core/index.test.ts
@@ -1,0 +1,11 @@
+import * as core from './index';
+
+describe('core index', () => {
+    it('exports the layout components and tracking hook', () => {
+        expect(core.AppLayout).toBeTypeOf('function');
+        expect(core.Header).toBeTypeOf('function');
+        expect(core.Footer).toBeTypeOf('function');
+        expect(core.Settings).toBeTypeOf('function');
+        expect(core.usePageviewTracking).toBeTypeOf('function');
+    });
+});

--- a/react/src/core/index.ts
+++ b/react/src/core/index.ts
@@ -1,0 +1,5 @@
+export { AppLayout } from './AppLayout';
+export { Header } from './Header';
+export { Footer } from './Footer';
+export { Settings } from './Settings';
+export { usePageviewTracking } from './usePageviewTracking';

--- a/react/src/core/settings.scss
+++ b/react/src/core/settings.scss
@@ -1,0 +1,75 @@
+@use '../styles/media' as *;
+@use '../styles/theme_variables' as *;
+
+.overlay {
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background: rgba(0, 0, 0, 0.7);
+    opacity: 1;
+    z-index: 1;
+}
+
+.popup {
+    margin: 70px auto;
+    padding: 30px;
+    border-radius: 5px;
+    width: 30%;
+    position: relative;
+    h1 {
+        margin-top: 0;
+        margin-bottom: 0px;
+        color: #fff;
+        text-align: center;
+        letter-spacing: 1px;
+    }
+    h2 {
+        padding-top: 10px;
+    }
+    hr {
+        width: 40%;
+        margin-bottom: 20px;
+    }
+    .close {
+        position: absolute;
+        top: 12px;
+        right: 20px;
+        font-size: 30px;
+        font-weight: bold;
+        text-decoration: none;
+        color: rgba(255, 255, 255, 0.8);
+        &:hover {
+            color: #fff;
+            cursor: pointer;
+        }
+    }
+    .content {
+        max-height: 30%;
+        color: #fff;
+        letter-spacing: 1px;
+        overflow: auto;
+    }
+    input[type='number'] {
+        display: block;
+        width: 80%;
+        height: 20px;
+        margin-bottom: 15px;
+        border-radius: 5px;
+        padding: 2px;
+    }
+}
+
+.control-section {
+    margin-bottom: 15px;
+    padding-bottom: 15px;
+    border-bottom: 1px solid white;
+}
+
+@media screen and (max-width: 700px) {
+    .box,
+    .popup {
+        width: 70%;
+    }
+}

--- a/react/src/core/usePageviewTracking.ts
+++ b/react/src/core/usePageviewTracking.ts
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+declare global {
+    interface Window {
+        ga?: (...args: string[]) => void;
+    }
+}
+
+export function usePageviewTracking(): void {
+    const { pathname } = useLocation();
+
+    useEffect(() => {
+        if (window.ga) {
+            window.ga('set', 'page', pathname);
+            window.ga('send', 'pageview');
+        }
+    }, [pathname]);
+}


### PR DESCRIPTION
## Summary

Phase 2D of the Angular → React migration: ports the app shell (`AppComponent`), `CoreModule` components (`Header`, `Footer`, `Settings`) and the Google Analytics pageview tracking into `react/src/core/`. Only files under `react/src/core/` are added; no existing file (Angular or React) is modified. Phase 3 will swap `AppLayout` into `App.tsx`.

Key points:
- `usePageviewTracking()` replaces the `router.events` / `NavigationEnd` subscription: on every `useLocation().pathname` change it calls `ga('set','page', pathname)` then `ga('send','pageview')`, skipping silently when `window.ga` is undefined (the GA loader lives in `index.html`, so the hook only consumes the global; `ga` is declared on `Window` via `declare global`).
- `AppLayout` = `app.component.html`: `<div className={settings.theme}>` → `.body-cover` + `.wrapper` → `<Header/> {children} <Footer/>`.
- `Header` uses `NavLink` so `routerLinkActive="active"` is preserved (`.active` class on the current feed link and home link). Every link calls `window.scrollTo(0, 0)`; the cog calls `toggleSettings()`; `<Settings/>` renders inside `<header>` only when `settings.showSettings`.
- `Settings`: the Angular `[value] + (keyup)` number inputs become controlled inputs (`value={settings.titleFontSize}` / `onChange → setFont`), so the store is updated on each keystroke exactly as before; radios use `checked={settings.theme === t}` / `onChange → setTheme(t)`. Markup, ids, names, `min` attributes and labels are identical.
- SCSS copied 1:1 from the component `.scss` files with `@import` converted to `@use '../styles/...' as *`.

## Angular → React mapping

| Angular file | React file(s) |
| --- | --- |
| `src/app/app.component.ts` (router GA subscription) | `react/src/core/usePageviewTracking.ts` |
| `src/app/app.component.ts` / `app.component.html` | `react/src/core/AppLayout.tsx` |
| `src/app/app.component.scss` | `react/src/core/app.scss` |
| `src/app/core/header/header.component.{ts,html}` | `react/src/core/Header.tsx` |
| `src/app/core/header/header.component.scss` | `react/src/core/header.scss` |
| `src/app/core/footer/footer.component.{ts,html}` | `react/src/core/Footer.tsx` |
| `src/app/core/footer/footer.component.scss` | `react/src/core/footer.scss` |
| `src/app/core/settings/settings.component.{ts,html}` | `react/src/core/Settings.tsx` |
| `src/app/core/settings/settings.component.scss` | `react/src/core/settings.scss` |
| `src/app/core/core.module.ts` | `react/src/core/index.ts` |
| `src/index.html` (GA `ga(...)` consumer) | `react/src/core/usePageviewTracking.ts` |

Tests: `AppLayout.test.tsx`, `Header.test.tsx`, `Footer.test.tsx`, `Settings.test.tsx`, `index.test.ts`.

## Verification (run in `react/`)

- `npm run lint` — 0 errors, 0 warnings (ESLint + Prettier)
- `npm run typecheck` — passes
- `npm test` — 12 files / 50 tests pass
- `npm run test:coverage` — `src/core` 100% statements / branches / functions / lines
- `npm run build` — succeeds

## Screenshots (temporary Vite harness, not committed)

Default theme, layout with sample child content:

![layout](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfNjlJWEpGTHJsang4elNBdyIsInVzZXJfaWQiOm51bGwsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZ182OUlYSkZMcmxqeDh6U0F3LzZjODk4MGU2LTcxNzUtNGZiOC04MTg1LTRlZGNhMDIzODgzZCIsImlhdCI6MTc4ODM2MzA4MywiZXhwIjoxNzg4OTY3ODgzLCJmaWxlbmFtZSI6InNob3QtbGF5b3V0LnBuZyJ9.Ut2J15nzJ_B-l5nldVaFXL3t0YM5fJYpvveuzSwgFL8)

Settings panel open, Night theme selected:

![settings](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfNjlJWEpGTHJsang4elNBdyIsInVzZXJfaWQiOm51bGwsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZ182OUlYSkZMcmxqeDh6U0F3LzA4MWZmY2U2LWU1NDktNGNiNS04MmY5LWJjYzZlMDE3Y2MxMCIsImlhdCI6MTc4ODM2MzA4MywiZXhwIjoxNzg4OTY3ODgzLCJmaWxlbmFtZSI6InNob3Qtc2V0dGluZ3MucG5nIn0.ToXRnuh1wK9sG1XPEjSeV98gr2okhiVSylr7YnTyPIg)

Devin-Org: engineering


Link to Devin session: https://app.devin.ai/sessions/1737accca6d64dfab6da65dd69bcf431
Open in Devin Desktop: https://app.devin.ai/desktop/session/1737accca6d64dfab6da65dd69bcf431?variant=devin
Requested by: @vibhaseshadri-cognition