### PR TITLE
Phase 2B: React ItemDetails + recursive Comment (PR 4)

### DIFF
--- a/react/src/item-details/Comment.test.tsx
+++ b/react/src/item-details/Comment.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+
+import type { Comment as CommentModel } from '../models';
+import { Comment } from '.';
+
+function makeComment(overrides: Partial<CommentModel> = {}): CommentModel {
+    return {
+        id: 1,
+        level: 0,
+        user: 'alice',
+        time: 0,
+        time_ago: '2 hours ago',
+        content: '<p>root comment</p>',
+        deleted: false,
+        comments: [],
+        ...overrides,
+    };
+}
+
+function renderComment(comment: CommentModel) {
+    return render(
+        <MemoryRouter>
+            <Comment comment={comment} />
+        </MemoryRouter>
+    );
+}
+
+describe('Comment', () => {
+    it('renders a comment with no children', () => {
+        const { container } = renderComment(makeComment());
+        expect(screen.getByText('[-]')).toHaveClass('collapse');
+        expect(screen.getByText('alice')).toHaveAttribute('href', '/user/alice');
+        expect(screen.getByText('2 hours ago')).toHaveClass('time');
+        expect(container.querySelector('.comment-text')?.innerHTML).toBe('<p>root comment</p>');
+        expect(container.querySelector('.subtree')?.children).toHaveLength(0);
+        expect(container.querySelector('.meta')).not.toHaveClass('meta-collapse');
+    });
+
+    it('renders a nested three-level tree recursively', () => {
+        const tree = makeComment({
+            comments: [
+                makeComment({
+                    id: 2,
+                    user: 'bob',
+                    content: 'level two',
+                    comments: [makeComment({ id: 3, user: 'carol', content: 'level three' })],
+                }),
+            ],
+        });
+        const { container } = renderComment(tree);
+        expect(screen.getByText('level two')).toBeInTheDocument();
+        expect(screen.getByText('level three')).toBeInTheDocument();
+        expect(container.querySelectorAll('.comment-text')).toHaveLength(3);
+        expect(container.querySelector('.subtree .subtree .comment-text')?.textContent).toBe('level three');
+        expect(screen.getByText('carol')).toHaveAttribute('href', '/user/carol');
+    });
+
+    it('collapses and expands the subtree via the [-]/[+] control', async () => {
+        const user = userEvent.setup();
+        const tree = makeComment({ comments: [makeComment({ id: 2, user: 'bob', content: 'child' })] });
+        const { container } = renderComment(tree);
+        const commentTree = container.querySelector('.comment-tree > div') as HTMLElement;
+        expect(commentTree).not.toHaveAttribute('hidden');
+
+        await user.click(screen.getAllByText('[-]')[0]);
+        expect(screen.getByText('[+]')).toBeInTheDocument();
+        expect(commentTree).toHaveAttribute('hidden');
+        expect(container.querySelector('.meta')).toHaveClass('meta-collapse');
+        expect(screen.getByText('child')).not.toBeVisible();
+
+        await user.click(screen.getByText('[+]'));
+        expect(screen.queryByText('[+]')).toBeNull();
+        expect(commentTree).not.toHaveAttribute('hidden');
+        expect(container.querySelector('.meta')).not.toHaveClass('meta-collapse');
+        expect(screen.getByText('child')).toBeVisible();
+    });
+
+    it('renders the deleted markup for a deleted comment', () => {
+        const { container } = renderComment(makeComment({ deleted: true, user: 'ghost' }));
+        expect(container.querySelector('.deleted-meta')).toHaveTextContent('[deleted] | Comment Deleted');
+        expect(screen.getByText('[deleted]')).toHaveClass('collapse');
+        expect(screen.queryByText('ghost')).toBeNull();
+        expect(container.querySelector('.comment-text')).toBeNull();
+    });
+});

--- a/react/src/item-details/Comment.tsx
+++ b/react/src/item-details/Comment.tsx
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+
+import type { Comment as CommentModel } from '../models';
+
+import './comment.scss';
+
+export interface CommentProps {
+    comment: CommentModel;
+}
+
+export function Comment({ comment }: CommentProps) {
+    const [collapse, setCollapse] = useState(false);
+
+    if (comment.deleted) {
+        return (
+            <div className="comment">
+                <div className="deleted-meta">
+                    <span className="collapse">[deleted]</span> | Comment Deleted
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="comment">
+            <div className={collapse ? 'meta meta-collapse' : 'meta'}>
+                <span className="collapse" onClick={() => setCollapse(!collapse)}>
+                    [{collapse ? '+' : '-'}]
+                </span>{' '}
+                <Link to={`/user/${comment.user}`}>{comment.user}</Link>
+                <span className="time">{comment.time_ago}</span>
+            </div>
+            <div className="comment-tree">
+                <div hidden={collapse}>
+                    <p className="comment-text" dangerouslySetInnerHTML={{ __html: comment.content }}></p>
+                    <ul className="subtree">
+                        {comment.comments.map((subComment) => (
+                            <li key={subComment.id}>
+                                <Comment comment={subComment} />
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/react/src/item-details/ItemDetails.test.tsx
+++ b/react/src/item-details/ItemDetails.test.tsx
@@ -1,0 +1,264 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { mockMatchMedia } from '../test/matchMedia';
+import { fetchItemContent } from '../api/hackernews-api';
+import type { Story } from '../models';
+import { SettingsProvider } from '../settings';
+import { ItemDetails } from '.';
+
+vi.mock('../api/hackernews-api');
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+    const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+    return { ...actual, useNavigate: () => mockNavigate };
+});
+
+type Item = Story & { content?: string; text?: string };
+
+function makeStory(overrides: Partial<Item> = {}): Item {
+    return {
+        id: 100,
+        title: 'A story',
+        points: 42,
+        user: 'pg',
+        time: 0,
+        time_ago: 0,
+        type: 'story',
+        url: 'https://example.com/post',
+        domain: 'example.com',
+        comments: [],
+        comments_count: 3,
+        poll: [],
+        poll_votes_count: 0,
+        deleted: false,
+        dead: false,
+        ...overrides,
+    };
+}
+
+function renderItem(id = '100') {
+    return render(
+        <SettingsProvider>
+            <MemoryRouter initialEntries={[`/item/${id}`]}>
+                <Routes>
+                    <Route path="/item/:id" element={<ItemDetails />} />
+                </Routes>
+            </MemoryRouter>
+        </SettingsProvider>
+    );
+}
+
+describe('ItemDetails', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        mockMatchMedia();
+        window.scrollTo = vi.fn();
+        mockNavigate.mockReset();
+        vi.mocked(fetchItemContent).mockReset();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('shows the loader while loading and fetches the numeric id', () => {
+        vi.mocked(fetchItemContent).mockReturnValue(new Promise(() => {}));
+        renderItem('123');
+        expect(screen.getByText('Loading...')).toBeInTheDocument();
+        expect(fetchItemContent).toHaveBeenCalledWith(123, expect.any(AbortSignal));
+        expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
+    });
+
+    it('shows the error message when the request fails', async () => {
+        vi.mocked(fetchItemContent).mockRejectedValue(new Error('boom'));
+        renderItem();
+        expect(await screen.findByText('Could not load item comments.')).toBeInTheDocument();
+        expect(screen.queryByText('Loading...')).toBeNull();
+    });
+
+    it('ignores results and errors after unmount (abort)', async () => {
+        let reject: (reason: Error) => void = () => {};
+        vi.mocked(fetchItemContent).mockImplementation(
+            () =>
+                new Promise<Story>((_, rej) => {
+                    reject = rej;
+                })
+        );
+        const { unmount } = renderItem();
+        const signal = vi.mocked(fetchItemContent).mock.calls[0][1] as AbortSignal;
+        unmount();
+        expect(signal.aborted).toBe(true);
+        reject(new Error('late'));
+        await Promise.resolve();
+        expect(screen.queryByText('Could not load item comments.')).toBeNull();
+    });
+
+    it('ignores a resolved story after abort', async () => {
+        let resolve: (story: Story) => void = () => {};
+        vi.mocked(fetchItemContent).mockImplementation(
+            () =>
+                new Promise<Story>((res) => {
+                    resolve = res;
+                })
+        );
+        const { unmount } = renderItem();
+        unmount();
+        resolve(makeStory());
+        await Promise.resolve();
+        expect(screen.queryByText('A story')).toBeNull();
+    });
+
+    it('renders a story with url in the same tab by default', async () => {
+        vi.mocked(fetchItemContent).mockResolvedValue(makeStory({ text: 'has text' }));
+        const { container } = renderItem();
+        const titles = await screen.findAllByText('A story');
+        expect(titles).toHaveLength(2);
+        for (const title of titles) {
+            expect(title).toHaveAttribute('href', 'https://example.com/post');
+            expect(title).not.toHaveAttribute('target');
+            expect(title).not.toHaveAttribute('rel');
+        }
+        expect(screen.getByText('(example.com)')).toHaveClass('domain');
+        expect(screen.getByText('pg')).toHaveAttribute('href', '/user/pg');
+        expect(screen.getByText('3 comments')).toHaveAttribute('href', '/item/100');
+        expect(container.querySelector('.laptop')).toHaveClass('item-header');
+        expect(container.querySelector('.laptop')).toHaveClass('head-margin');
+        expect(container.querySelector('.subtext > span:last-child')).toHaveClass('item-details');
+        expect(container.querySelector('.subject')?.innerHTML).toBe('');
+    });
+
+    it('opens external links in a new tab when the setting is enabled', async () => {
+        localStorage.setItem('openLinkInNewTab', 'true');
+        vi.mocked(fetchItemContent).mockResolvedValue(makeStory());
+        renderItem();
+        const titles = await screen.findAllByText('A story');
+        for (const title of titles) {
+            expect(title).toHaveAttribute('target', '_blank');
+            expect(title).toHaveAttribute('rel', 'noopener');
+        }
+    });
+
+    it('renders a story without url as internal links and renders content html', async () => {
+        vi.mocked(fetchItemContent).mockResolvedValue(
+            makeStory({
+                url: 'item?id=100',
+                domain: '',
+                comments_count: 0,
+                content: '<b>Ask HN body</b>',
+            })
+        );
+        const { container } = renderItem();
+        const titles = await screen.findAllByText('A story');
+        expect(titles).toHaveLength(2);
+        for (const title of titles) {
+            expect(title).toHaveAttribute('href', '/item/100');
+        }
+        expect(screen.queryByText(/\(/)).toBeNull();
+        expect(screen.getByText('discuss')).toHaveAttribute('href', '/item/100');
+        expect(container.querySelector('.laptop')).not.toHaveClass('item-header');
+        expect(container.querySelector('.laptop')).not.toHaveClass('head-margin');
+        expect(container.querySelector('.subject')?.innerHTML).toBe('<b>Ask HN body</b>');
+    });
+
+    it('hides the domain when the story has a url but no domain', async () => {
+        vi.mocked(fetchItemContent).mockResolvedValue(makeStory({ domain: '' }));
+        const { container } = renderItem();
+        await screen.findAllByText('A story');
+        expect(container.querySelector('.domain')).toBeNull();
+    });
+
+    it('renders a job without points, user or comment link', async () => {
+        vi.mocked(fetchItemContent).mockResolvedValue(
+            makeStory({ type: 'job', comments_count: 0, time_ago: 5, user: 'hiring' })
+        );
+        const { container } = renderItem();
+        await screen.findAllByText('A story');
+        expect(screen.queryByText(/points by/)).toBeNull();
+        expect(screen.queryByText('hiring')).toBeNull();
+        expect(screen.queryByText('discuss')).toBeNull();
+        expect(container.querySelector('.laptop')).toHaveClass('item-header');
+        const timeSpan = container.querySelector('.subtext > span') as HTMLElement;
+        expect(timeSpan).not.toHaveClass('item-details');
+        expect(timeSpan.textContent).toBe('5');
+    });
+
+    it('renders poll results with bar widths computed from votes', async () => {
+        vi.mocked(fetchItemContent).mockResolvedValue(
+            makeStory({
+                type: 'poll',
+                url: 'item?id=100',
+                poll: [
+                    { points: 5, content: '<p>Option A</p>' },
+                    { points: 8, content: '<p>Option B</p>' },
+                ],
+                poll_votes_count: 13,
+            })
+        );
+        const { container } = renderItem();
+        await screen.findAllByText('A story');
+        const options = container.querySelectorAll('.pollResults .pollContent');
+        expect(options).toHaveLength(2);
+        expect(options[0].querySelector('div')?.innerHTML).toBe('<p>Option A</p>');
+        expect(options[0].querySelector('.subtext')).toHaveTextContent('5 points');
+        expect((options[0].querySelector('.pollBar') as HTMLElement).style.width).toBe(`${(5 / 13) * 100}%`);
+        expect((options[1].querySelector('.pollBar') as HTMLElement).style.width).toBe(`${(8 / 13) * 100}%`);
+        expect((options[0].querySelector('.pollBar') as HTMLElement).style.width).toMatch(/^38\.46/);
+    });
+
+    it('does not render poll results for non-poll items', async () => {
+        vi.mocked(fetchItemContent).mockResolvedValue(makeStory());
+        const { container } = renderItem();
+        await screen.findAllByText('A story');
+        expect(container.querySelector('.pollResults')).toBeNull();
+    });
+
+    it('navigates back when the back button is clicked', async () => {
+        const user = userEvent.setup();
+        vi.mocked(fetchItemContent).mockResolvedValue(makeStory());
+        const { container } = renderItem();
+        await screen.findAllByText('A story');
+        await user.click(container.querySelector('.back-button') as HTMLElement);
+        expect(mockNavigate).toHaveBeenCalledWith(-1);
+    });
+
+    it('renders the comment tree', async () => {
+        vi.mocked(fetchItemContent).mockResolvedValue(
+            makeStory({
+                comments: [
+                    {
+                        id: 1,
+                        level: 0,
+                        user: 'alice',
+                        time: 0,
+                        time_ago: '1 hour ago',
+                        content: 'first',
+                        deleted: false,
+                        comments: [
+                            {
+                                id: 2,
+                                level: 1,
+                                user: 'bob',
+                                time: 0,
+                                time_ago: '30 minutes ago',
+                                content: 'reply',
+                                deleted: false,
+                                comments: [],
+                            },
+                        ],
+                    },
+                    { id: 3, level: 0, user: '', time: 0, time_ago: '', content: '', deleted: true, comments: [] },
+                ],
+            })
+        );
+        const { container } = renderItem();
+        await screen.findAllByText('A story');
+        await waitFor(() => expect(screen.getByText('first')).toBeInTheDocument());
+        expect(screen.getByText('reply')).toBeInTheDocument();
+        expect(container.querySelectorAll('.comment-list > li')).toHaveLength(2);
+        expect(screen.getByText('[deleted]')).toBeInTheDocument();
+    });
+});

--- a/react/src/item-details/ItemDetails.tsx
+++ b/react/src/item-details/ItemDetails.tsx
@@ -1,0 +1,142 @@
+import { useEffect, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+
+import { fetchItemContent } from '../api/hackernews-api';
+import type { Story } from '../models';
+import { useSettings } from '../settings';
+import { ErrorMessage, Loader } from '../shared/components';
+import { formatCommentCount } from '../utils/comment-format';
+import { Comment } from './Comment';
+
+import './item-details.scss';
+
+const ERROR_MESSAGE = 'Could not load item comments.';
+
+type Item = Story & { content?: string; text?: string };
+
+interface LoadResult {
+    id: string | undefined;
+    item: Item | null;
+    errorMessage: string;
+}
+
+export function ItemDetails() {
+    const { id } = useParams<{ id: string }>();
+    const navigate = useNavigate();
+    const { settings } = useSettings();
+    const [result, setResult] = useState<LoadResult>({ id: undefined, item: null, errorMessage: '' });
+
+    useEffect(() => {
+        const controller = new AbortController();
+        fetchItemContent(Number(id), controller.signal)
+            .then((story) => {
+                if (!controller.signal.aborted) {
+                    setResult({ id, item: story, errorMessage: '' });
+                }
+            })
+            .catch(() => {
+                if (!controller.signal.aborted) {
+                    setResult({ id, item: null, errorMessage: ERROR_MESSAGE });
+                }
+            });
+        window.scrollTo(0, 0);
+        return () => controller.abort();
+    }, [id]);
+
+    const { item, errorMessage } = result.id === id ? result : { item: null, errorMessage: '' };
+
+    const target = settings.openLinkInNewTab ? '_blank' : undefined;
+    const rel = settings.openLinkInNewTab ? 'noopener' : undefined;
+
+    return (
+        <div className="main-content">
+            {!item && !errorMessage && <Loader />}
+            {!item && errorMessage !== '' && <ErrorMessage message={errorMessage} />}
+
+            {item && (
+                <div className="item">
+                    <div className="mobile item-header">
+                        <p className="title-block">
+                            <span className="back-button" onClick={() => navigate(-1)}></span>
+                            {hasUrl(item) ? (
+                                <a className="title" href={item.url} target={target} rel={rel}>
+                                    {item.title}
+                                </a>
+                            ) : (
+                                <Link className="title" to={`/item/${item.id}`}>
+                                    {item.title}
+                                </Link>
+                            )}
+                        </p>
+                    </div>
+                    <div
+                        className={[
+                            'laptop',
+                            item.comments_count > 0 || item.type === 'job' ? 'item-header' : '',
+                            item.text ? 'head-margin' : '',
+                        ]
+                            .filter(Boolean)
+                            .join(' ')}
+                    >
+                        {hasUrl(item) ? (
+                            <p>
+                                <a className="title" href={item.url} target={target} rel={rel}>
+                                    {item.title}
+                                </a>
+                                {item.domain && <span className="domain">({item.domain})</span>}
+                            </p>
+                        ) : (
+                            <p>
+                                <Link className="title" to={`/item/${item.id}`}>
+                                    {item.title}
+                                </Link>
+                            </p>
+                        )}
+                        <div className="subtext">
+                            {item.type !== 'job' && (
+                                <span>
+                                    {item.points} points by <Link to={`/user/${item.user}`}>{item.user}</Link>
+                                </span>
+                            )}
+                            <span className={item.type !== 'job' ? 'item-details' : undefined}>
+                                {item.time_ago}
+                                {item.type !== 'job' && (
+                                    <span>
+                                        {' '}
+                                        | <Link to={`/item/${item.id}`}>{formatCommentCount(item.comments_count)}</Link>
+                                    </span>
+                                )}
+                            </span>
+                        </div>
+                    </div>
+                    {item.type === 'poll' && (
+                        <div className="pollResults">
+                            {item.poll.map((pollResult, index) => (
+                                <div key={index} className="pollContent">
+                                    <div dangerouslySetInnerHTML={{ __html: pollResult.content }}></div>
+                                    <div className="subtext">{pollResult.points} points</div>
+                                    <div
+                                        className="pollBar"
+                                        style={{ width: `${(pollResult.points / item.poll_votes_count) * 100}%` }}
+                                    ></div>
+                                </div>
+                            ))}
+                        </div>
+                    )}
+                    <p className="subject" dangerouslySetInnerHTML={{ __html: item.content ?? '' }}></p>
+                    <ul className="comment-list">
+                        {item.comments.map((comment) => (
+                            <li key={comment.id}>
+                                <Comment comment={comment} />
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            )}
+        </div>
+    );
+}
+
+function hasUrl(item: Item): boolean {
+    return item.url.indexOf('http') === 0;
+}

--- a/react/src/item-details/comment.scss
+++ b/react/src/item-details/comment.scss
@@ -1,0 +1,83 @@
+@use '../styles/media' as *;
+@use '../styles/theme_variables' as *;
+
+.comment a {
+    font-weight: bold;
+    text-decoration: none;
+    &:hover {
+        text-decoration: underline;
+    }
+}
+
+.meta {
+    font-size: 13px;
+    color: #696969;
+    font-weight: bold;
+    letter-spacing: 0.5px;
+    margin-bottom: 8px;
+    a {
+        text-decoration: none;
+
+        &:hover {
+            text-decoration: underline;
+        }
+    }
+    .time {
+        padding-left: 5px;
+    }
+}
+
+@media #{$mobile-only} {
+    .meta {
+        font-size: 14px;
+        margin-bottom: 10px;
+        .time {
+            padding: 0;
+            float: right;
+        }
+    }
+}
+
+.meta-collapse {
+    margin-bottom: 20px;
+}
+
+.deleted-meta {
+    font-size: 12px;
+    font-weight: bold;
+    letter-spacing: 0.5px;
+    margin: 30px 0;
+    a {
+        text-decoration: none;
+    }
+}
+
+.collapse {
+    font-size: 13px;
+    letter-spacing: 2px;
+    cursor: pointer;
+}
+
+.comment-tree {
+    margin-left: 24px;
+}
+
+@media #{$tablet-only} {
+    .comment-tree {
+        margin-left: 8px;
+    }
+}
+
+.comment-text {
+    font-size: 15px;
+    margin-top: 0;
+    margin-bottom: 20px;
+    word-wrap: break-word;
+    line-height: 1.5em;
+}
+
+.subtree {
+    margin-left: 0;
+    padding: 0;
+    list-style-type: none;
+}

--- a/react/src/item-details/index.ts
+++ b/react/src/item-details/index.ts
@@ -1,0 +1,3 @@
+export { Comment } from './Comment';
+export type { CommentProps } from './Comment';
+export { ItemDetails } from './ItemDetails';

--- a/react/src/item-details/item-details.scss
+++ b/react/src/item-details/item-details.scss
@@ -1,0 +1,151 @@
+@use '../styles/media' as *;
+@use '../styles/theme_variables' as *;
+
+.main-content {
+    position: relative;
+    width: 100%;
+    min-height: 100vh;
+    -webkit-transition: opacity 0.2s ease;
+    transition: opacity 0.2s ease;
+    box-sizing: border-box;
+    padding: 8px 0;
+    z-index: 0;
+}
+
+.item {
+    box-sizing: border-box;
+    padding: 10px 40px 0 40px;
+    z-index: 0;
+}
+
+@media #{$tablet-only} {
+    .item {
+        padding: 10px 20px 0 40px;
+    }
+}
+
+@media #{$mobile-only} {
+    .item {
+        box-sizing: border-box;
+        padding: 110px 15px 0 15px;
+    }
+}
+
+.head-margin {
+    margin-bottom: 15px;
+}
+
+p {
+    margin: 2px 0;
+}
+
+.subject {
+    word-wrap: break-word;
+    margin-top: 20px;
+}
+
+a {
+    cursor: pointer;
+    text-decoration: none;
+}
+
+@media #{$mobile-only} {
+    .laptop {
+        display: none;
+    }
+}
+
+@media #{$laptop-only} {
+    .mobile {
+        display: none;
+    }
+}
+
+.title {
+    font-size: 16px;
+    font-family: Verdana, Geneva, sans-serif;
+}
+
+.title-block {
+    text-align: center;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    margin: 0 75px;
+}
+
+@media #{$mobile-only} {
+    .title {
+        font-size: 15px;
+    }
+    .back-button {
+        position: absolute;
+        top: 52%;
+        width: 0.6rem;
+        height: 0.6rem;
+        background: transparent;
+        box-shadow: 0 0 0 lightgray;
+        transition: all 200ms ease;
+        left: 4%;
+        transform: translate3d(0, -50%, 0) rotate(-135deg);
+    }
+}
+
+.subtext {
+    font-size: 12px;
+    font-weight: bold;
+    letter-spacing: 0.5px;
+}
+
+.domain {
+    letter-spacing: 0.5px;
+}
+
+.subtext a {
+    &:hover {
+        text-decoration: underline;
+    }
+}
+
+.item-details {
+    padding: 10px;
+}
+
+.item-header {
+    padding-bottom: 10px;
+}
+
+@media #{$mobile-only} {
+    .item-header {
+        padding: 10px 0 10px 0;
+        position: fixed;
+        width: 100%;
+        left: 0;
+        top: 62px;
+    }
+}
+
+.pollResults {
+    margin-bottom: 1em;
+}
+
+.pollContent {
+    * {
+        padding-bottom: 0;
+        margin-bottom: -1em;
+        margin-top: 1em;
+    }
+    .pollBar {
+        height: 10px;
+        margin-bottom: 1em;
+    }
+}
+
+ul {
+    list-style-type: none;
+    padding: 10px 0;
+}
+
+li {
+    display: list-item;
+}


### PR DESCRIPTION
## Summary
Phase 2B of the Angular -> React migration: ports the item-details feature (story/poll page + recursive comment tree) into `react/src/item-details/`, on top of the Phase 1 core (#721). No Angular sources and no existing React files are touched.

- `ItemDetails()` reads `:id` via `useParams`, calls `fetchItemContent(Number(id), signal)` inside a `useEffect` with an `AbortController`, and renders `<Loader/>` / `<ErrorMessage message="Could not load item comments."/>` / the item markup 1:1 with `item-details.component.html` (`.mobile .item-header` + `.laptop` blocks, `item-header`/`head-margin` class toggles, external `href` honoring `settings.openLinkInNewTab` -> `target="_blank" rel="noopener"`, internal `<Link to="/item/:id">`, `(domain)`, `points by <Link to="/user/:user">`, `time_ago | formatCommentCount(...)`, `.pollResults > .pollContent` with `.pollBar` width `points / poll_votes_count * 100 %`, `.subject` innerHTML, `.comment-list`). The back button calls `useNavigate()(-1)` (Angular `Location.back()`).
  - The load result is stored together with the `id` it was fetched for (`{ id, item, errorMessage }`), so a route change shows the loader again without a synchronous `setState` in the effect (which the `react-hooks/set-state-in-effect` lint rule forbids).
  - `Story` has no `content`/`text` fields (neither does the Angular model, which is untyped at the template level), so the component uses a local `type Item = Story & { content?: string; text?: string }` rather than modifying `models/`.
- `Comment({ comment })` is recursive; `collapse` is `useState(false)`, toggled by the `[-]`/`[+]` span, adds `meta-collapse` to `.meta` and hides the `.comment-tree > div` with the `hidden` attribute (same as Angular `[hidden]="collapse"`). Deleted comments render `.deleted-meta` with `[deleted] | Comment Deleted`. A `.comment` wrapper div stands in for the Angular `app-comment` host element so the `:host >>> a` styles have a target.
- SCSS is copied verbatim with `@import` -> `@use '../styles/media' as *`.

### Angular -> React mapping
| Angular file | React file(s) |
| --- | --- |
| `src/app/item-details/item-details.component.ts` | `react/src/item-details/ItemDetails.tsx` |
| `src/app/item-details/item-details.component.html` | `react/src/item-details/ItemDetails.tsx` |
| `src/app/item-details/item-details.component.scss` | `react/src/item-details/item-details.scss` |
| `src/app/item-details/comment/comment.component.ts` | `react/src/item-details/Comment.tsx` |
| `src/app/item-details/comment/comment.component.html` | `react/src/item-details/Comment.tsx` |
| `src/app/item-details/comment/comment.component.scss` | `react/src/item-details/comment.scss` |
| `src/app/item-details/item-details.module.ts` | `react/src/item-details/index.ts` (barrel; routing is wired in Phase 3) |
| `src/app/item-details/item-details.component.spec.ts`, `comment/comment.component.spec.ts` | `react/src/item-details/ItemDetails.test.tsx`, `Comment.test.tsx` |

### Verification (in `react/`)
- `npm run lint`: 0 errors, 0 warnings (eslint + prettier)
- `npm run typecheck`: pass
- `npm test`: 9 files / 50 tests pass (17 new)
- `npm run test:coverage`: `src/item-details` 100% statements / branches / functions / lines
- `npm run build`: pass

### Screenshot
`ItemDetails` rendered against the live HNPWA API for poll item 126809 via a temporary Vite harness (not committed). Poll bars have no colour here because the theme class that colours `.pollBar` is applied by the app shell (Phase 3), not by this component.

![ItemDetails with poll and comment tree](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfNjlJWEpGTHJsang4elNBdyIsInVzZXJfaWQiOm51bGwsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZ182OUlYSkZMcmxqeDh6U0F3L2E0OTlkMWEyLTA4ZTctNDMyOC1hMzU2LWM4ZmY1YjEzMTA3MiIsImlhdCI6MTc4ODM2MzExMCwiZXhwIjoxNzg4OTY3OTEwLCJmaWxlbmFtZSI6Iml0ZW0tZGV0YWlscy5wbmcifQ.3KfcWuF-i3FXxP4mueJv845IA68WcdtW4ogAgUj5SDc)

Devin-Org: engineering


Link to Devin session: https://app.devin.ai/sessions/8d75c47209cf457ea70098e5ce4a2628
Open in Devin Desktop: https://app.devin.ai/desktop/session/8d75c47209cf457ea70098e5ce4a2628?variant=devin
Requested by: @vibhaseshadri-cognition