### PR TITLE
Phase 2A: React Feed + StoryItem (PR 3)

### DIFF
--- a/react/src/feed/Feed.test.tsx
+++ b/react/src/feed/Feed.test.tsx
@@ -1,0 +1,195 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { fetchFeed } from '../api/hackernews-api';
+import type { Story } from '../models';
+import { SettingsProvider } from '../settings';
+import { mockMatchMedia } from '../test/matchMedia';
+import { Feed } from './index';
+
+vi.mock('../api/hackernews-api');
+
+const mockedFetchFeed = vi.mocked(fetchFeed);
+
+function makeStory(id: number): Story {
+    return {
+        id,
+        title: `Story ${id}`,
+        points: id,
+        user: 'pg',
+        time: 0,
+        time_ago: '1 hour ago',
+        type: 'story',
+        url: `https://example.com/${id}`,
+        domain: 'example.com',
+        comments: [],
+        comments_count: id,
+        poll: [],
+        poll_votes_count: 0,
+        deleted: false,
+        dead: false,
+    } as unknown as Story;
+}
+
+function makeStories(count: number): Story[] {
+    return Array.from({ length: count }, (_, i) => makeStory(i + 1));
+}
+
+function renderFeed(feedType: 'news' | 'jobs' = 'news', page = '1') {
+    return render(
+        <MemoryRouter initialEntries={[`/${feedType}/${page}`]}>
+            <SettingsProvider>
+                <Routes>
+                    <Route path={`/${feedType}/:page`} element={<Feed feedType={feedType} />} />
+                </Routes>
+            </SettingsProvider>
+        </MemoryRouter>
+    );
+}
+
+describe('Feed', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        localStorage.clear();
+        mockMatchMedia(false);
+        vi.spyOn(window, 'scrollTo').mockImplementation(() => {});
+    });
+
+    it('shows the loader while the feed is loading', () => {
+        mockedFetchFeed.mockReturnValue(new Promise(() => {}));
+        const { container } = renderFeed();
+
+        expect(screen.getByText('Loading...')).toBeInTheDocument();
+        expect(container.querySelector('ol')).toBeNull();
+    });
+
+    it('shows an error message naming the feed type when loading fails', async () => {
+        mockedFetchFeed.mockRejectedValue(new Error('boom'));
+        const { container } = renderFeed();
+
+        expect(await screen.findByText('Could not load news stories.')).toBeInTheDocument();
+        expect(container.querySelector('ol')).toBeNull();
+    });
+
+    it('renders the stories with start=1 and scrolls to the top on page 1', async () => {
+        mockedFetchFeed.mockResolvedValue(makeStories(3));
+        const { container } = renderFeed();
+
+        await waitFor(() => expect(container.querySelector('ol')).not.toBeNull());
+        expect(mockedFetchFeed).toHaveBeenCalledWith('news', 1, expect.any(AbortSignal));
+        expect(container.querySelector('ol')).toHaveAttribute('start', '1');
+        expect(container.querySelector('ol')).toHaveClass('list-margin');
+        expect(container.querySelectorAll('li.post')).toHaveLength(3);
+        expect(screen.getByRole('link', { name: 'Story 1' })).toBeInTheDocument();
+        expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
+        expect(container.querySelector('.prev')).toBeNull();
+        expect(container.querySelector('.more')).toBeNull();
+    });
+
+    it('offsets the list start and shows Prev on later pages', async () => {
+        mockedFetchFeed.mockResolvedValue(makeStories(3));
+        const { container } = renderFeed('news', '3');
+
+        await waitFor(() => expect(container.querySelector('ol')).not.toBeNull());
+        expect(mockedFetchFeed).toHaveBeenCalledWith('news', 3, expect.any(AbortSignal));
+        expect(container.querySelector('ol')).toHaveAttribute('start', '61');
+        expect(screen.getByRole('link', { name: '‹ Prev' })).toHaveAttribute('href', '/news/2');
+    });
+
+    it('shows the More link only when the page is full with 30 items', async () => {
+        mockedFetchFeed.mockResolvedValue(makeStories(30));
+        const { container } = renderFeed('news', '2');
+
+        await waitFor(() => expect(container.querySelector('ol')).not.toBeNull());
+        expect(screen.getByRole('link', { name: 'More ›' })).toHaveAttribute('href', '/news/3');
+        expect(screen.getByRole('link', { name: '‹ Prev' })).toHaveAttribute('href', '/news/1');
+        expect(container.querySelectorAll('li.post')).toHaveLength(30);
+    });
+
+    it('hides the More link when the page has 29 items', async () => {
+        mockedFetchFeed.mockResolvedValue(makeStories(29));
+        const { container } = renderFeed('news', '2');
+
+        await waitFor(() => expect(container.querySelector('ol')).not.toBeNull());
+        expect(container.querySelector('.more')).toBeNull();
+    });
+
+    it('renders the jobs header and drops the list margin for the jobs feed', async () => {
+        mockedFetchFeed.mockResolvedValue(makeStories(1));
+        const { container } = renderFeed('jobs');
+
+        await waitFor(() => expect(container.querySelector('ol')).not.toBeNull());
+        const header = container.querySelector('.job-header');
+        expect(header?.textContent).toContain('These are jobs at startups that were funded by Y Combinator.');
+        expect(screen.getByRole('link', { name: 'Triplebyte' })).toHaveAttribute(
+            'href',
+            'https://triplebyte.com/?ref=yc_jobs'
+        );
+        expect(container.querySelector('ol')).not.toHaveClass('list-margin');
+    });
+
+    it('does not render the jobs header for other feeds', async () => {
+        mockedFetchFeed.mockResolvedValue(makeStories(1));
+        const { container } = renderFeed();
+
+        await waitFor(() => expect(container.querySelector('ol')).not.toBeNull());
+        expect(container.querySelector('.job-header')).toBeNull();
+    });
+
+    it('re-fetches when the route page changes', async () => {
+        mockedFetchFeed.mockResolvedValue(makeStories(30));
+        const { container } = renderFeed('news', '1');
+
+        await waitFor(() => expect(container.querySelector('ol')).not.toBeNull());
+        await userEvent.click(screen.getByRole('link', { name: 'More ›' }));
+
+        await waitFor(() => expect(mockedFetchFeed).toHaveBeenCalledWith('news', 2, expect.any(AbortSignal)));
+        await waitFor(() => expect(container.querySelector('ol')).toHaveAttribute('start', '31'));
+    });
+
+    it('defaults to page 1 when the route has no page param', async () => {
+        mockedFetchFeed.mockResolvedValue(makeStories(1));
+        render(
+            <MemoryRouter initialEntries={['/news']}>
+                <SettingsProvider>
+                    <Routes>
+                        <Route path="/news" element={<Feed feedType="news" />} />
+                    </Routes>
+                </SettingsProvider>
+            </MemoryRouter>
+        );
+
+        await waitFor(() => expect(mockedFetchFeed).toHaveBeenCalledWith('news', 1, expect.any(AbortSignal)));
+    });
+
+    it('ignores a resolved response after unmount', async () => {
+        let resolveFeed: (stories: Story[]) => void = () => {};
+        mockedFetchFeed.mockReturnValue(
+            new Promise<Story[]>((resolve) => {
+                resolveFeed = resolve;
+            })
+        );
+        const { unmount } = renderFeed();
+        unmount();
+        resolveFeed(makeStories(3));
+
+        await waitFor(() => expect(window.scrollTo).not.toHaveBeenCalled());
+        expect(screen.queryByRole('link', { name: 'Story 1' })).toBeNull();
+    });
+
+    it('ignores a rejected request after unmount', async () => {
+        let rejectFeed: (reason: Error) => void = () => {};
+        mockedFetchFeed.mockReturnValue(
+            new Promise<Story[]>((_, reject) => {
+                rejectFeed = reject;
+            })
+        );
+        const { unmount } = renderFeed();
+        unmount();
+        rejectFeed(new Error('aborted'));
+
+        await waitFor(() => expect(screen.queryByText('Could not load news stories.')).toBeNull());
+    });
+});

--- a/react/src/feed/Feed.tsx
+++ b/react/src/feed/Feed.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+
+import { fetchFeed, type FeedName } from '../api/hackernews-api';
+import type { Story } from '../models';
+import { ErrorMessage, Loader } from '../shared/components';
+import { StoryItem } from './StoryItem';
+import './feed.scss';
+
+export interface FeedProps {
+    feedType: FeedName;
+}
+
+interface FeedState {
+    key: string;
+    items: Story[] | null;
+    errorMessage: string;
+    listStart: number;
+}
+
+const PENDING: Omit<FeedState, 'key'> = { items: null, errorMessage: '', listStart: 1 };
+
+export function Feed({ feedType }: FeedProps) {
+    const { page } = useParams<{ page: string }>();
+    const pageNum = page ? Number(page) : 1;
+    const feedKey = `${feedType}/${pageNum}`;
+    const [state, setState] = useState<FeedState>({ key: feedKey, ...PENDING });
+
+    useEffect(() => {
+        const controller = new AbortController();
+
+        fetchFeed(feedType, pageNum, controller.signal).then(
+            (stories) => {
+                if (controller.signal.aborted) {
+                    return;
+                }
+                setState({
+                    key: `${feedType}/${pageNum}`,
+                    items: stories,
+                    errorMessage: '',
+                    listStart: (pageNum - 1) * 30 + 1,
+                });
+                window.scrollTo(0, 0);
+            },
+            () => {
+                if (controller.signal.aborted) {
+                    return;
+                }
+                setState({
+                    key: `${feedType}/${pageNum}`,
+                    items: null,
+                    errorMessage: `Could not load ${feedType} stories.`,
+                    listStart: 1,
+                });
+            }
+        );
+
+        return () => controller.abort();
+    }, [feedType, pageNum]);
+
+    const current: FeedState = state.key === feedKey ? state : { key: feedKey, ...PENDING };
+    const { items, errorMessage, listStart } = current;
+
+    return (
+        <div className="main-content">
+            {!items && !errorMessage && <Loader />}
+            {!items && errorMessage !== '' && <ErrorMessage message={errorMessage} />}
+
+            {items && (
+                <div>
+                    {feedType === 'jobs' && (
+                        <p className="job-header">
+                            These are jobs at startups that were funded by Y Combinator. You can also get a job at a YC
+                            startup through <a href="https://triplebyte.com/?ref=yc_jobs">Triplebyte</a>.
+                        </p>
+                    )}
+                    <ol className={feedType !== 'jobs' ? 'list-margin' : undefined} start={listStart}>
+                        {items.map((item) => (
+                            <li key={item.id} className="post">
+                                <StoryItem item={item} />
+                            </li>
+                        ))}
+                    </ol>
+                    <div className="nav">
+                        {listStart !== 1 && (
+                            <Link to={`/${feedType}/${pageNum - 1}`} className="prev">
+                                ‹ Prev
+                            </Link>
+                        )}
+                        {items.length === 30 && (
+                            <Link to={`/${feedType}/${pageNum + 1}`} className="more">
+                                More ›
+                            </Link>
+                        )}
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/react/src/feed/StoryItem.test.tsx
+++ b/react/src/feed/StoryItem.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import type { Story } from '../models';
+import { SettingsProvider, useSettings } from '../settings';
+import { mockMatchMedia } from '../test/matchMedia';
+import { StoryItem } from './index';
+
+const externalStory: Story = {
+    id: 1,
+    title: 'A great external story',
+    points: 42,
+    user: 'pg',
+    time: 1234,
+    time_ago: '2 hours ago',
+    type: 'story',
+    url: 'https://example.com/great',
+    domain: 'example.com',
+    comments: [],
+    comments_count: 5,
+    poll: [],
+    poll_votes_count: 0,
+    deleted: false,
+    dead: false,
+} as unknown as Story;
+
+function renderStoryItem(item: Story) {
+    return render(
+        <MemoryRouter>
+            <SettingsProvider>
+                <StoryItem item={item} />
+            </SettingsProvider>
+        </MemoryRouter>
+    );
+}
+
+function SettingsControls() {
+    const { toggleOpenLinksInNewTab, setFont, setSpacing } = useSettings();
+    return (
+        <div>
+            <button onClick={toggleOpenLinksInNewTab}>new tab</button>
+            <button onClick={() => setFont('20')}>font</button>
+            <button onClick={() => setSpacing('12')}>spacing</button>
+        </div>
+    );
+}
+
+describe('StoryItem', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        mockMatchMedia(false);
+    });
+
+    it('renders an external story with domain, points, user, time and comment count in both layouts', () => {
+        const { container } = renderStoryItem(externalStory);
+
+        const titleLink = screen.getByRole('link', { name: 'A great external story' });
+        expect(titleLink).toHaveAttribute('href', 'https://example.com/great');
+        expect(titleLink).toHaveClass('title');
+        expect(titleLink).not.toHaveAttribute('target');
+        expect(titleLink).not.toHaveAttribute('rel');
+        expect(screen.getByText('(example.com)')).toHaveClass('domain');
+
+        const palm = container.querySelector('.subtext-palm');
+        expect(palm).not.toBeNull();
+        expect(palm?.querySelector('.name a')).toHaveAttribute('href', '/user/pg');
+        expect(palm?.querySelector('.right')?.textContent).toBe('42 ★');
+        expect(palm?.querySelector('.comment-number')).toHaveAttribute('href', '/item/1');
+        expect(palm?.querySelector('.comment-number')?.textContent).toContain('5 comments');
+        expect(palm?.textContent).toContain('2 hours ago');
+
+        const laptop = container.querySelector('.subtext-laptop');
+        expect(laptop?.textContent).toContain('42 points by');
+        expect(laptop?.textContent).toContain('pg');
+        expect(laptop?.textContent).toContain('2 hours ago');
+        expect(laptop?.textContent).toContain('5 comments');
+        expect(laptop?.querySelector('.item-details')).not.toBeNull();
+    });
+
+    it('hides the domain span when the story has no domain', () => {
+        const { container } = renderStoryItem({ ...externalStory, domain: '' });
+        expect(container.querySelector('.domain')).toBeNull();
+    });
+
+    it('links internally when the story has no external url', () => {
+        renderStoryItem({ ...externalStory, url: 'item?id=1', domain: '' });
+        const titleLink = screen.getByRole('link', { name: 'A great external story' });
+        expect(titleLink).toHaveAttribute('href', '/item/1');
+        expect(titleLink).toHaveClass('title');
+    });
+
+    it('hides points, user and comments for job items', () => {
+        const { container } = renderStoryItem({ ...externalStory, type: 'job', comments_count: 0 });
+
+        expect(container.querySelector('.subtext-palm .name')).toBeNull();
+        expect(container.querySelector('.subtext-palm .comment-number')).toBeNull();
+        expect(container.querySelector('.subtext-laptop .item-details')).toBeNull();
+        expect(container.querySelector('.subtext-palm')?.textContent).toBe('2 hours ago');
+        expect(container.querySelector('.subtext-laptop')?.textContent).toBe('2 hours ago');
+    });
+
+    it('renders "discuss" with no comments and singular "comment" for one', () => {
+        const { container: none } = renderStoryItem({ ...externalStory, comments_count: 0 });
+        expect(none.querySelector('.comment-number')?.textContent).toContain('discuss');
+
+        const { container: one } = renderStoryItem({ ...externalStory, comments_count: 1 });
+        expect(one.querySelector('.comment-number')?.textContent).toContain('1 comment');
+    });
+
+    it('applies the settings-driven new tab attributes, font size and list spacing', async () => {
+        const user = userEvent.setup();
+        const { container } = render(
+            <MemoryRouter>
+                <SettingsProvider>
+                    <SettingsControls />
+                    <StoryItem item={externalStory} />
+                </SettingsProvider>
+            </MemoryRouter>
+        );
+
+        const block = container.querySelector('.item-block');
+        expect(block).toHaveStyle({ marginBottom: '0px' });
+        expect(screen.getByRole('link', { name: 'A great external story' })).toHaveStyle({ fontSize: '16px' });
+
+        await user.click(screen.getByRole('button', { name: 'new tab' }));
+        await user.click(screen.getByRole('button', { name: 'font' }));
+        await user.click(screen.getByRole('button', { name: 'spacing' }));
+
+        const titleLink = screen.getByRole('link', { name: 'A great external story' });
+        expect(titleLink).toHaveAttribute('target', '_blank');
+        expect(titleLink).toHaveAttribute('rel', 'noopener');
+        expect(titleLink).toHaveStyle({ fontSize: '20px' });
+        expect(container.querySelector('.item-block')).toHaveStyle({ marginBottom: '12px' });
+    });
+});

--- a/react/src/feed/StoryItem.tsx
+++ b/react/src/feed/StoryItem.tsx
@@ -1,0 +1,76 @@
+import { Link } from 'react-router-dom';
+
+import type { Story } from '../models';
+import { useSettings } from '../settings';
+import { formatCommentCount } from '../utils/comment-format';
+import './story-item.scss';
+
+export interface StoryItemProps {
+    item: Story;
+}
+
+export function StoryItem({ item }: StoryItemProps) {
+    const { settings } = useSettings();
+    const hasUrl = item.url.indexOf('http') === 0;
+    const isJob = item.type === 'job';
+
+    return (
+        <div className="item-block" style={{ marginBottom: settings.listSpacing + 'px' }}>
+            {hasUrl ? (
+                <p>
+                    <a
+                        className="title"
+                        style={{ fontSize: settings.titleFontSize + 'px' }}
+                        href={item.url}
+                        target={settings.openLinkInNewTab ? '_blank' : undefined}
+                        rel={settings.openLinkInNewTab ? 'noopener' : undefined}
+                    >
+                        {item.title}
+                    </a>
+                    {item.domain && <span className="domain">({item.domain})</span>}
+                </p>
+            ) : (
+                <p>
+                    <Link className="title" style={{ fontSize: settings.titleFontSize + 'px' }} to={`/item/${item.id}`}>
+                        {item.title}
+                    </Link>
+                </p>
+            )}
+            <div className="subtext-palm">
+                {!isJob && (
+                    <div className="details">
+                        <span className="name">
+                            <Link to={`/user/${item.user}`}>{item.user}</Link>
+                        </span>
+                        <span className="right">{item.points} ★</span>
+                    </div>
+                )}
+                <div className="details">
+                    {item.time_ago}
+                    {!isJob && (
+                        <Link to={`/item/${item.id}`} className="comment-number">
+                            {' '}
+                            • {formatCommentCount(item.comments_count)}
+                        </Link>
+                    )}
+                </div>
+            </div>
+            <div className="subtext-laptop">
+                {!isJob && (
+                    <span>
+                        {item.points} points by <Link to={`/user/${item.user}`}>{item.user}</Link>
+                    </span>
+                )}
+                <span className={!isJob ? 'item-details' : undefined}>
+                    {item.time_ago}
+                    {!isJob && (
+                        <span>
+                            {' | '}
+                            <Link to={`/item/${item.id}`}>{formatCommentCount(item.comments_count)}</Link>
+                        </span>
+                    )}
+                </span>
+            </div>
+        </div>
+    );
+}

--- a/react/src/feed/feed.scss
+++ b/react/src/feed/feed.scss
@@ -1,0 +1,107 @@
+@use '../styles/media' as *;
+@use '../styles/theme_variables' as *;
+
+.main-content {
+    position: relative;
+    width: 100%;
+    min-height: 100vh;
+    -webkit-transition: opacity 0.2s ease;
+    transition: opacity 0.2s ease;
+    box-sizing: border-box;
+    padding: 8px 0;
+    z-index: 0;
+
+    a {
+        text-decoration: none;
+        font-weight: bold;
+
+        &:hover {
+            text-decoration: underline;
+        }
+    }
+
+    ol {
+        padding: 0 40px;
+        margin: 0;
+
+        @media #{$mobile-only} {
+            box-sizing: border-box;
+            list-style: none;
+            padding: 0 10px;
+        }
+
+        li {
+            position: relative;
+            -webkit-transition: background-color 0.2s ease;
+            transition: background-color 0.2s ease;
+        }
+    }
+
+    .list-margin {
+        @media #{$mobile-only} {
+            margin-top: 55px;
+        }
+    }
+
+    .post {
+        padding: 10px 0 10px 5px;
+        transition: background-color 0.2s ease;
+        border-bottom: 1px solid #cececb;
+
+        .itemNum {
+            color: #696969;
+            position: absolute;
+            width: 30px;
+            text-align: right;
+            left: 0;
+            top: 4px;
+        }
+    }
+
+    .item-block {
+        display: block;
+    }
+
+    .nav {
+        padding: 10px 40px;
+        margin-top: 10px;
+        font-size: 17px;
+
+        a {
+            @media #{$mobile-only} {
+                text-decoration: none;
+            }
+        }
+
+        @media #{$mobile-only} {
+            margin: 20px 0;
+            text-align: center;
+            padding: 10px 80px;
+            height: 20px;
+        }
+
+        .prev {
+            padding-right: 20px;
+
+            @media #{$mobile-only} {
+                float: left;
+                padding-right: 0;
+            }
+        }
+
+        .more {
+            @media #{$mobile-only} {
+                float: right;
+            }
+        }
+    }
+
+    .job-header {
+        font-size: 15px;
+        padding: 0 40px 10px;
+
+        @media #{$mobile-only} {
+            padding: 60px 15px 25px 15px;
+        }
+    }
+}

--- a/react/src/feed/index.ts
+++ b/react/src/feed/index.ts
@@ -1,0 +1,4 @@
+export { Feed } from './Feed';
+export type { FeedProps } from './Feed';
+export { StoryItem } from './StoryItem';
+export type { StoryItemProps } from './StoryItem';

--- a/react/src/feed/story-item.scss
+++ b/react/src/feed/story-item.scss
@@ -1,0 +1,72 @@
+@use '../styles/media' as *;
+@use '../styles/theme_variables' as *;
+
+.item-block {
+    p {
+        margin: 2px 0;
+
+        @media #{$mobile-only} {
+            margin-bottom: 5px;
+            margin-top: 0;
+        }
+    }
+
+    a {
+        cursor: pointer;
+        text-decoration: none;
+    }
+
+    .title {
+        font-size: 16px;
+        font-family: Verdana, Geneva, sans-serif;
+    }
+
+    .subtext-laptop {
+        font-size: 12px;
+        font-weight: bold;
+        letter-spacing: 0.5px;
+
+        a {
+            &:hover {
+                text-decoration: underline;
+            }
+        }
+
+        @media #{$mobile-only} {
+            display: none;
+        }
+    }
+
+    .subtext-palm {
+        font-size: 13px;
+        font-weight: bold;
+        letter-spacing: 0.5px;
+
+        a {
+            &:hover {
+                text-decoration: underline;
+            }
+        }
+
+        .details {
+            margin-top: 5px;
+
+            .right {
+                float: right;
+            }
+        }
+
+        @media #{$laptop-only} {
+            display: none;
+        }
+    }
+
+    .domain {
+        color: #696969;
+        letter-spacing: 0.5px;
+    }
+
+    .item-details {
+        padding: 10px;
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2A of the Angular -> React migration: ports the Angular `feeds` module (feed list + story row) to React in a new, self-contained `react/src/feed/` directory. Nothing outside that directory is touched, and the Angular app is untouched so parity can still be diffed.

`Feed` mirrors `FeedComponent`'s route-driven fetch: it reads `:page` from `useParams`, fetches on every `feedType`/`page` change with an `AbortController`, computes `listStart = (pageNum - 1) * 30 + 1`, and calls `window.scrollTo(0, 0)` after a successful load (Angular does this in the subscribe completion callback). The Angular error string is reproduced verbatim, including the feed name: `Could not load ${feedType} stories.`

Because Phase 1's ESLint config enables `react-hooks/set-state-in-effect`, the "reset to loading when the route changes" behaviour is derived rather than written with a synchronous `setState` in the effect. State carries the request it belongs to:

```ts
const feedKey = `${feedType}/${pageNum}`;
const [state, setState] = useState<FeedState>({ key: feedKey, ...PENDING });
// only the promise callbacks call setState (guarded by controller.signal.aborted)
const current: FeedState = state.key === feedKey ? state : { key: feedKey, ...PENDING };
```

so a page change renders the `<Loader/>` immediately without an extra render pass.

`StoryItem` reproduces both templates from `item.component.html` — the `.subtext-palm` (mobile) and `.subtext-laptop` layouts, `hasUrl = item.url.indexOf('http') === 0` deciding between an external `<a href>` (with `target="_blank" rel="noopener"` only when `settings.openLinkInNewTab`) and an internal `<Link to="/item/:id">`, the `(domain)` span, and the `item.type !== 'job'` guards that hide points/user/comments for job posts.

Notes / deliberate deviations from the task brief, in favour of matching the Angular source:
- Spacing style is `marginBottom: settings.listSpacing + 'px'` on the item wrapper, because that is what `[ngStyle]` applies in `item.component.html` (not `paddingTop`/`paddingBottom`).
- `feedType` is typed as `FeedName` (from `api/hackernews-api`), not `FeedType` from `models` — `FeedType` is the item type (`'poll' | 'story' | 'job'`), and `FeedName` is what Phase 1's `AppRoutes`/`FeedPageProps` pass in, so `Feed` drops straight into the route shell in Phase 3.
- Angular's `<ol *ngIf="feedType !== 'new'">` is omitted: no feed is named `new` (the route is `newest`), so the list always rendered in Angular; keeping the comparison would be a TS type error.
- Component SCSS is nested under `.main-content` / `.item-block` since React has no Angular-style view encapsulation, which keeps the bare `a`/`p`/`ol` rules from Angular's component styles from leaking globally. All class names are unchanged.

### Angular -> React file mapping

| Angular file | React replacement |
| --- | --- |
| `src/app/feeds/feed/feed.component.ts` | `react/src/feed/Feed.tsx` |
| `src/app/feeds/feed/feed.component.html` | `react/src/feed/Feed.tsx` (JSX) |
| `src/app/feeds/feed/feed.component.scss` | `react/src/feed/feed.scss` |
| `src/app/feeds/item/item.component.ts` | `react/src/feed/StoryItem.tsx` |
| `src/app/feeds/item/item.component.html` | `react/src/feed/StoryItem.tsx` (JSX) |
| `src/app/feeds/item/item.component.scss` | `react/src/feed/story-item.scss` |
| Angular feeds module declarations/exports | `react/src/feed/index.ts` |
| `src/app/shared/pipes/comment.pipe.ts` | `utils/comment-format.ts` (`formatCommentCount`, already in Phase 1) |

### Verification

Run in `react/`:
- `npm run lint` — 0 errors, 0 warnings (ESLint + Prettier check).
- `npm run typecheck` — clean.
- `npm test` — 51 tests passing (18 new: 12 `Feed`, 6 `StoryItem`).
- `npm run test:coverage` — 100% statements/branches/functions/lines for `src/feed` (and 100% overall).
- `npm run build` — succeeds (Vite + PWA precache).

`Feed` tests cover loading, error, `start` attribute on page 1 and page 3, Prev hidden/shown with correct hrefs, More shown at exactly 30 items and hidden at 29, jobs header presence, `scrollTo(0, 0)`, re-fetch on route page change, missing `:page` defaulting to page 1, and ignored resolve/reject after unmount. `StoryItem` tests cover external vs internal links, new-tab attributes toggled through the settings store, font-size/spacing styles, comment counts (0/1/many), domain presence, and the job variant.

### Screenshot

Rendered through the Vite dev server with a temporary (uncommitted) harness feeding sample stories:

![React Feed with StoryItem rows](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfNjlJWEpGTHJsang4elNBdyIsInVzZXJfaWQiOm51bGwsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZ182OUlYSkZMcmxqeDh6U0F3LzMxYmRhMTBmLTgyMGYtNDk0Ny1hYjkxLWVkNGJlNWQzNGNlZSIsImlhdCI6MTc4ODM2MzEyNywiZXhwIjoxNzg4OTY3OTI3LCJmaWxlbmFtZSI6ImZlZWQtc2NyZWVuc2hvdC5wbmcifQ.uuZYSj4z10_RjMytn3F4DiNm9Xz9wr9saAmlPVOXbLE)

Devin-Org: engineering

Link to Devin session: https://app.devin.ai/sessions/755d8b00a6374e16acba92fd73ac9dd4
Open in Devin Desktop: https://app.devin.ai/desktop/session/755d8b00a6374e16acba92fd73ac9dd4?variant=devin
Requested by: @vibhaseshadri-cognition