### PR TITLE
[2/8] Port models, API layer, and settings context to React

### DIFF
--- a/react/src/api/hackernews.ts
+++ b/react/src/api/hackernews.ts
@@ -1,0 +1,41 @@
+import type { FeedType } from '../models/feed-type'
+import type { PollResult } from '../models/poll-result'
+import type { Story } from '../models/story'
+import type { User } from '../models/user'
+
+const BASE_URL = 'https://node-hnapi.herokuapp.com'
+
+async function getJson<T>(url: string): Promise<T> {
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new Error(`Request failed with status ${response.status}`)
+  }
+  return response.json() as Promise<T>
+}
+
+export function fetchFeed(feedType: FeedType, page: number): Promise<Story[]> {
+  return getJson<Story[]>(`${BASE_URL}/${feedType}?page=${page}`)
+}
+
+export function fetchPollContent(id: number): Promise<PollResult> {
+  return getJson<PollResult>(`${BASE_URL}/item/${id}`)
+}
+
+export function fetchUser(id: string): Promise<User> {
+  return getJson<User>(`${BASE_URL}/user/${id}`)
+}
+
+export async function fetchItemContent(id: number): Promise<Story> {
+  const story = await getJson<Story>(`${BASE_URL}/item/${id}`)
+  if (story.type === 'poll') {
+    const pollResults = await Promise.all(
+      story.poll.map((_, index) => fetchPollContent(story.id + index + 1)),
+    )
+    story.poll = pollResults
+    story.poll_votes_count = pollResults.reduce(
+      (total, pollResult) => total + pollResult.points,
+      0,
+    )
+  }
+  return story
+}

--- a/react/src/context/SettingsContext.tsx
+++ b/react/src/context/SettingsContext.tsx
@@ -1,0 +1,108 @@
+import {
+  createContext,
+  type PropsWithChildren,
+  useContext,
+  useEffect,
+  useState,
+} from 'react'
+import type { Settings, Theme } from '../models/settings'
+
+interface SettingsContextValue {
+  settings: Settings
+  toggleSettings: () => void
+  toggleOpenLinksInNewTab: () => void
+  setTheme: (theme: Theme) => void
+  setFont: (fontSize: string) => void
+  setSpacing: (listSpacing: string) => void
+}
+
+const SettingsContext = createContext<SettingsContextValue | undefined>(
+  undefined,
+)
+
+function getInitialSettings(): Settings {
+  const darkColorScheme = window.matchMedia('(prefers-color-scheme: dark)')
+  const savedTheme = localStorage.getItem('theme') as Theme | null
+  const theme = savedTheme ?? (darkColorScheme.matches ? 'night' : 'default')
+  if (!savedTheme) {
+    localStorage.setItem('theme', theme)
+  }
+
+  const savedOpenLinks = localStorage.getItem('openLinkInNewTab')
+  return {
+    showSettings: false,
+    openLinkInNewTab: savedOpenLinks ? JSON.parse(savedOpenLinks) : false,
+    theme,
+    titleFontSize: localStorage.getItem('titleFontSize') ?? '16',
+    listSpacing: localStorage.getItem('listSpacing') ?? '0',
+  }
+}
+
+export function SettingsProvider({ children }: PropsWithChildren) {
+  const [settings, setSettings] = useState<Settings>(getInitialSettings)
+
+  const toggleSettings = () => {
+    setSettings((current) => ({
+      ...current,
+      showSettings: !current.showSettings,
+    }))
+  }
+
+  const toggleOpenLinksInNewTab = () => {
+    setSettings((current) => {
+      const openLinkInNewTab = !current.openLinkInNewTab
+      localStorage.setItem(
+        'openLinkInNewTab',
+        JSON.stringify(openLinkInNewTab),
+      )
+      return { ...current, openLinkInNewTab }
+    })
+  }
+
+  const setTheme = (theme: Theme) => {
+    localStorage.setItem('theme', theme)
+    setSettings((current) => ({ ...current, theme }))
+  }
+
+  const setFont = (titleFontSize: string) => {
+    localStorage.setItem('titleFontSize', titleFontSize)
+    setSettings((current) => ({ ...current, titleFontSize }))
+  }
+
+  const setSpacing = (listSpacing: string) => {
+    localStorage.setItem('listSpacing', listSpacing)
+    setSettings((current) => ({ ...current, listSpacing }))
+  }
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
+    const handleChange = (event: MediaQueryListEvent) => {
+      setTheme(event.matches ? 'night' : 'default')
+    }
+    mediaQuery.addEventListener('change', handleChange)
+    return () => mediaQuery.removeEventListener('change', handleChange)
+  }, [])
+
+  return (
+    <SettingsContext.Provider
+      value={{
+        settings,
+        toggleSettings,
+        toggleOpenLinksInNewTab,
+        setTheme,
+        setFont,
+        setSpacing,
+      }}
+    >
+      {children}
+    </SettingsContext.Provider>
+  )
+}
+
+export function useSettings(): SettingsContextValue {
+  const context = useContext(SettingsContext)
+  if (!context) {
+    throw new Error('useSettings must be used within a SettingsProvider')
+  }
+  return context
+}

--- a/react/src/main.tsx
+++ b/react/src/main.tsx
@@ -1,9 +1,12 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App'
+import { SettingsProvider } from './context/SettingsContext'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <SettingsProvider>
+      <App />
+    </SettingsProvider>
   </StrictMode>,
 )

--- a/react/src/models/comment.ts
+++ b/react/src/models/comment.ts
@@ -1,0 +1,10 @@
+export interface Comment {
+  id: number
+  level: number
+  user: string
+  time: number
+  time_ago: string
+  content: string
+  deleted: boolean
+  comments: Comment[]
+}

--- a/react/src/models/feed-type.ts
+++ b/react/src/models/feed-type.ts
@@ -1,1 +1,1 @@
-export type FeedType = 'poll' | 'story' | 'job'
+export type FeedType = 'news' | 'newest' | 'show' | 'ask' | 'jobs'

--- a/react/src/models/feed-type.ts
+++ b/react/src/models/feed-type.ts
@@ -1,0 +1,1 @@
+export type FeedType = 'poll' | 'story' | 'job'

--- a/react/src/models/item-type.ts
+++ b/react/src/models/item-type.ts
@@ -1,0 +1,1 @@
+export type ItemType = 'poll' | 'story' | 'job'

--- a/react/src/models/poll-result.ts
+++ b/react/src/models/poll-result.ts
@@ -1,0 +1,4 @@
+export interface PollResult {
+  points: number
+  content: string
+}

--- a/react/src/models/settings.ts
+++ b/react/src/models/settings.ts
@@ -1,0 +1,9 @@
+export type Theme = 'default' | 'night' | 'amoledblack'
+
+export interface Settings {
+  showSettings: boolean
+  openLinkInNewTab: boolean
+  theme: Theme
+  titleFontSize: string
+  listSpacing: string
+}

--- a/react/src/models/story.ts
+++ b/react/src/models/story.ts
@@ -1,5 +1,5 @@
 import type { Comment } from './comment'
-import type { FeedType } from './feed-type'
+import type { ItemType } from './item-type'
 import type { PollResult } from './poll-result'
 
 export interface Story {
@@ -9,7 +9,7 @@ export interface Story {
   user: string
   time: number
   time_ago: number
-  type: FeedType
+  type: ItemType
   url: string
   domain: string
   content: string

--- a/react/src/models/story.ts
+++ b/react/src/models/story.ts
@@ -1,0 +1,22 @@
+import type { Comment } from './comment'
+import type { FeedType } from './feed-type'
+import type { PollResult } from './poll-result'
+
+export interface Story {
+  id: number
+  title: string
+  points: number
+  user: string
+  time: number
+  time_ago: number
+  type: FeedType
+  url: string
+  domain: string
+  content: string
+  comments: Comment[]
+  comments_count: number
+  poll: PollResult[]
+  poll_votes_count: number
+  deleted: boolean
+  dead: boolean
+}

--- a/react/src/models/user.ts
+++ b/react/src/models/user.ts
@@ -1,0 +1,8 @@
+export interface User {
+  id: string
+  crated_time: number
+  created: string
+  karma: number
+  avg: number
+  about: string
+}


### PR DESCRIPTION
## Summary
Stacked on [1/8]. Ports the framework-agnostic layer of the Angular app.

- `react/src/models/*` — TS interfaces copied from `src/app/shared/models/` (`Theme` union added to `settings.ts`).
- `react/src/api/hackernews.ts` — `fetchFeed`, `fetchItemContent`, `fetchPollContent`, `fetchUser` as plain `async` functions over `fetch` against `https://node-hnapi.herokuapp.com`. `fetchItemContent` now *awaits* the poll option fetches (`Promise.all` over `story.id + i`) and sets `poll_votes_count` before resolving, instead of Angular's fire-and-forget subscriptions.
- `react/src/context/SettingsContext.tsx` — `SettingsProvider` + `useSettings()` replicating `SettingsService`: same localStorage keys (`theme`, `openLinkInNewTab`, `titleFontSize`, `listSpacing`), `prefers-color-scheme: dark` listener → `night`/`default`, `showSettings` toggle.

Devin-Org: engineering

Link to Devin session: https://app.devin.ai/sessions/43958fcfde3c4663bde63cbf894f9e7a
Open in Devin Desktop: https://app.devin.ai/desktop/session/43958fcfde3c4663bde63cbf894f9e7a?variant=devin
Requested by: @charityquinn-cognition
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/angular2-hn/pull/728" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->