### PR TITLE
[4/8] Port feed pages and set up routing

### DIFF
--- a/react/src/App.tsx
+++ b/react/src/App.tsx
@@ -1,18 +1,5 @@
-import { createBrowserRouter, RouterProvider } from 'react-router-dom'
-import { Layout } from './components/Layout'
-
-const router = createBrowserRouter([
-  {
-    path: '/',
-    element: <Layout />,
-    children: [
-      {
-        path: '*',
-        element: <div>Hello World</div>,
-      },
-    ],
-  },
-])
+import { RouterProvider } from 'react-router-dom'
+import { router } from './router'
 
 function App() {
   return <RouterProvider router={router} />

--- a/react/src/components/Item.tsx
+++ b/react/src/components/Item.tsx
@@ -1,0 +1,80 @@
+import { Link } from 'react-router-dom'
+import { useSettings } from '../context/SettingsContext'
+import type { Story } from '../models/story'
+import { formatCommentCount } from '../utils/format-comments'
+
+interface ItemProps {
+  item: Story
+}
+
+export function Item({ item }: ItemProps) {
+  const { settings } = useSettings()
+  const hasUrl = item.url?.startsWith('http') ?? false
+  const titleStyle = { fontSize: `${settings.titleFontSize}px` }
+  const externalLinkProps = settings.openLinkInNewTab
+    ? { target: '_blank', rel: 'noopener' }
+    : {}
+
+  return (
+    <div
+      className="item-block"
+      style={{ marginBottom: `${settings.listSpacing}px` }}
+    >
+      {hasUrl ? (
+        <p>
+          <a className="title" style={titleStyle} href={item.url} {...externalLinkProps}>
+            {item.title}
+          </a>
+          {item.domain && <span className="domain">({item.domain})</span>}
+        </p>
+      ) : (
+        <p>
+          <Link className="title" style={titleStyle} to={`/item/${item.id}`}>
+            {item.title}
+          </Link>
+        </p>
+      )}
+      <div className="subtext-palm">
+        <div className="details">
+          {item.type !== 'job' && (
+            <>
+              <span className="name">
+                <Link to={`/user/${item.user}`}>{item.user}</Link>
+              </span>
+              <span className="right">{item.points} ★</span>
+            </>
+          )}
+        </div>
+        <div className="details">
+          {item.time_ago}
+          {item.type !== 'job' && (
+            <Link to={`/item/${item.id}`} className="comment-number">
+              {' • '}
+              {formatCommentCount(item.comments_count)}
+            </Link>
+          )}
+        </div>
+      </div>
+      <div className="subtext-laptop">
+        <span>
+          {item.type !== 'job' && (
+            <>
+              {item.points} points by <Link to={`/user/${item.user}`}>{item.user}</Link>
+            </>
+          )}
+        </span>
+        <span className={item.type !== 'job' ? 'item-details' : ''}>
+          {item.time_ago}
+          {item.type !== 'job' && (
+            <>
+              {' | '}
+              <Link to={`/item/${item.id}`}>
+                {formatCommentCount(item.comments_count)}
+              </Link>
+            </>
+          )}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/react/src/pages/Feed.tsx
+++ b/react/src/pages/Feed.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useState } from 'react'
+import { Link, useParams } from 'react-router-dom'
+import { fetchFeed } from '../api/hackernews'
+import { ErrorMessage } from '../components/ErrorMessage'
+import { Item } from '../components/Item'
+import { Loader } from '../components/Loader'
+import type { FeedType } from '../models/feed-type'
+import type { Story } from '../models/story'
+
+interface FeedProps {
+  feedType: FeedType
+}
+
+export function Feed({ feedType }: FeedProps) {
+  const { page: pageParam } = useParams()
+  const page = Number(pageParam) || 1
+  const [items, setItems] = useState<Story[] | undefined>()
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    let cancelled = false
+    setItems(undefined)
+    setError('')
+    fetchFeed(feedType, page)
+      .then((nextItems) => {
+        if (!cancelled) {
+          setItems(nextItems)
+          window.scrollTo(0, 0)
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setError(`Could not load ${feedType} stories.`)
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [feedType, page])
+
+  const listStart = (page - 1) * 30 + 1
+
+  return (
+    <div className="main-content">
+      {!items && !error && <Loader />}
+      {!items && error && <ErrorMessage message={error} />}
+      {items && (
+        <>
+          {feedType === 'jobs' && (
+            <p className="job-header">
+              These are jobs at startups that were funded by Y Combinator. You
+              can also get a job at a YC startup through{' '}
+              <a href="https://triplebyte.com/?ref=yc_jobs">Triplebyte</a>.
+            </p>
+          )}
+          <ol
+            className={feedType !== 'jobs' ? 'list-margin' : ''}
+            start={listStart}
+          >
+            {items.map((item) => (
+              <li key={item.id} className="post">
+                <Item item={item} />
+              </li>
+            ))}
+          </ol>
+          <div className="nav">
+            {listStart !== 1 && (
+              <Link className="prev" to={`/${feedType}/${page - 1}`}>
+                ‹ Prev
+              </Link>
+            )}
+            {items.length === 30 && (
+              <Link className="more" to={`/${feedType}/${page + 1}`}>
+                More ›
+              </Link>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/react/src/pages/Feed.tsx
+++ b/react/src/pages/Feed.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { Link, useParams } from 'react-router-dom'
+import { Link, Navigate, useParams } from 'react-router-dom'
 import { fetchFeed } from '../api/hackernews'
 import { ErrorMessage } from '../components/ErrorMessage'
 import { Item } from '../components/Item'
@@ -13,31 +13,48 @@ interface FeedProps {
 
 export function Feed({ feedType }: FeedProps) {
   const { page: pageParam } = useParams()
-  const page = Number(pageParam) || 1
-  const [items, setItems] = useState<Story[] | undefined>()
-  const [error, setError] = useState('')
+  const page = /^[1-9]\d*$/.test(pageParam ?? '') ? Number(pageParam) : null
+  const routeKey = `${feedType}/${page}`
+  const [state, setState] = useState<{
+    key: string
+    items?: Story[]
+    error?: string
+  }>({ key: '' })
 
   useEffect(() => {
+    if (page === null) {
+      return
+    }
+
     let cancelled = false
-    setItems(undefined)
-    setError('')
+    setState({ key: routeKey })
     fetchFeed(feedType, page)
       .then((nextItems) => {
         if (!cancelled) {
-          setItems(nextItems)
+          setState({ key: routeKey, items: nextItems })
           window.scrollTo(0, 0)
         }
       })
       .catch(() => {
         if (!cancelled) {
-          setError(`Could not load ${feedType} stories.`)
+          setState({
+            key: routeKey,
+            error: `Could not load ${feedType} stories.`,
+          })
         }
       })
 
     return () => {
       cancelled = true
     }
-  }, [feedType, page])
+  }, [feedType, page, routeKey])
+
+  if (page === null) {
+    return <Navigate to={`/${feedType}/1`} replace />
+  }
+
+  const current = state.key === routeKey ? state : { key: routeKey }
+  const { items, error } = current
 
   const listStart = (page - 1) * 30 + 1
 

--- a/react/src/pages/Feed.tsx
+++ b/react/src/pages/Feed.tsx
@@ -13,7 +13,8 @@ interface FeedProps {
 
 export function Feed({ feedType }: FeedProps) {
   const { page: pageParam } = useParams()
-  const page = /^[1-9]\d*$/.test(pageParam ?? '') ? Number(pageParam) : null
+  const parsed = /^[1-9]\d*$/.test(pageParam ?? '') ? Number(pageParam) : NaN
+  const page = Number.isSafeInteger(parsed) ? parsed : null
   const routeKey = `${feedType}/${page}`
   const [state, setState] = useState<{
     key: string

--- a/react/src/router.tsx
+++ b/react/src/router.tsx
@@ -1,0 +1,36 @@
+import { Navigate, createBrowserRouter } from 'react-router-dom'
+import { Layout } from './components/Layout'
+import { Feed } from './pages/Feed'
+
+export const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <Layout />,
+    children: [
+      {
+        index: true,
+        element: <Navigate to="/news/1" replace />,
+      },
+      {
+        path: 'news/:page',
+        element: <Feed feedType="news" />,
+      },
+      {
+        path: 'newest/:page',
+        element: <Feed feedType="newest" />,
+      },
+      {
+        path: 'show/:page',
+        element: <Feed feedType="show" />,
+      },
+      {
+        path: 'ask/:page',
+        element: <Feed feedType="ask" />,
+      },
+      {
+        path: 'jobs/:page',
+        element: <Feed feedType="jobs" />,
+      },
+    ],
+  },
+])

--- a/react/src/router.tsx
+++ b/react/src/router.tsx
@@ -31,6 +31,10 @@ export const router = createBrowserRouter([
         path: 'jobs/:page',
         element: <Feed feedType="jobs" />,
       },
+      {
+        path: '*',
+        element: <Navigate to="/news/1" replace />,
+      },
     ],
   },
 ])

--- a/react/src/utils/format-comments.ts
+++ b/react/src/utils/format-comments.ts
@@ -1,0 +1,6 @@
+export function formatCommentCount(count: number): string {
+  if (count > 0) {
+    return `${count} comment${count === 1 ? '' : 's'}`
+  }
+  return 'discuss'
+}


### PR DESCRIPTION
## Summary
Stacked on [3/8]. Mirrors `app.routes.ts` in `react/src/router.tsx` and ports the feed list.

- Routes: `/` → `<Navigate to="/news/1" replace/>`; explicit `news|newest|show|ask|jobs` + `:page` each rendering `<Feed feedType=…/>`.
- `pages/Feed.tsx` — fetches on `[feedType, page]` with a stale-result guard, `listStart = (page-1)*30+1`, Prev/More links (`listStart !== 1` / `items.length === 30`), jobs banner, loader/error states.
- `components/Item.tsx` — list row; title font size / list spacing / `target=_blank rel=noopener` driven by `useSettings()`.
- `utils/format-comments.ts` `formatCommentCount(n)` replaces the `comment` pipe.

Devin-Org: engineering

Link to Devin session: https://app.devin.ai/sessions/43958fcfde3c4663bde63cbf894f9e7a
Open in Devin Desktop: https://app.devin.ai/desktop/session/43958fcfde3c4663bde63cbf894f9e7a?variant=devin
Requested by: @charityquinn-cognition
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/angular2-hn/pull/730" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->