### PR TITLE
[5/8] Port item details page and recursive comments

### DIFF
--- a/react/package-lock.json
+++ b/react/package-lock.json
@@ -8,6 +8,7 @@
       "name": "react",
       "version": "0.0.0",
       "dependencies": {
+        "dompurify": "^3.4.13",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^7.18.3"
@@ -1784,6 +1785,13 @@
         "@types/react": "^18.0.0"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.69.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.69.0.tgz",
@@ -2395,6 +2403,15 @@
       "optional": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/electron-to-chromium": {

--- a/react/package.json
+++ b/react/package.json
@@ -13,6 +13,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "dompurify": "^3.4.13",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^7.18.3"

--- a/react/src/components/Comment.tsx
+++ b/react/src/components/Comment.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import type { Comment as CommentModel } from '../models/comment'
+import { sanitizeHtml } from '../utils/sanitize'
 
 interface CommentProps {
   comment: CommentModel
@@ -32,7 +33,7 @@ export function Comment({ comment }: CommentProps) {
         <div hidden={collapse}>
           <p
             className="comment-text"
-            dangerouslySetInnerHTML={{ __html: comment.content }}
+            dangerouslySetInnerHTML={{ __html: sanitizeHtml(comment.content) }}
           />
           <ul className="subtree">
             {comment.comments?.map((subComment) => (

--- a/react/src/components/Comment.tsx
+++ b/react/src/components/Comment.tsx
@@ -1,0 +1,48 @@
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+import type { Comment as CommentModel } from '../models/comment'
+
+interface CommentProps {
+  comment: CommentModel
+}
+
+export function Comment({ comment }: CommentProps) {
+  const [collapse, setCollapse] = useState(false)
+
+  if (comment.deleted) {
+    return (
+      <div>
+        <div className="deleted-meta">
+          <span className="collapse">[deleted]</span> | Comment Deleted
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      <div className={`meta${collapse ? ' meta-collapse' : ''}`}>
+        <span className="collapse" onClick={() => setCollapse(!collapse)}>
+          [{collapse ? '+' : '-'}]
+        </span>{' '}
+        <Link to={`/user/${comment.user}`}>{comment.user}</Link>{' '}
+        <span className="time">{comment.time_ago}</span>
+      </div>
+      <div className="comment-tree">
+        <div hidden={collapse}>
+          <p
+            className="comment-text"
+            dangerouslySetInnerHTML={{ __html: comment.content }}
+          />
+          <ul className="subtree">
+            {comment.comments?.map((subComment) => (
+              <li key={subComment.id}>
+                <Comment comment={subComment} />
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/react/src/pages/ItemDetails.tsx
+++ b/react/src/pages/ItemDetails.tsx
@@ -7,6 +7,7 @@ import { Loader } from '../components/Loader'
 import { useSettings } from '../context/SettingsContext'
 import type { Story } from '../models/story'
 import { formatCommentCount } from '../utils/format-comments'
+import { sanitizeHtml } from '../utils/sanitize'
 
 function StoryTitle({ item }: { item: Story }) {
   const { settings } = useSettings()
@@ -32,25 +33,36 @@ function StoryTitle({ item }: { item: Story }) {
 export default function ItemDetails() {
   const { id } = useParams()
   const navigate = useNavigate()
-  const [item, setItem] = useState<Story>()
-  const [error, setError] = useState('')
+  const routeKey = id ?? ''
+  const [state, setState] = useState<{
+    key: string
+    item?: Story
+    error?: string
+  }>({ key: '' })
 
   useEffect(() => {
     let cancelled = false
-    setItem(undefined)
-    setError('')
+    setState({ key: routeKey })
     window.scrollTo(0, 0)
     fetchItemContent(Number(id))
       .then((nextItem) => {
-        if (!cancelled) setItem(nextItem)
+        if (!nextItem || nextItem.id !== Number(id)) {
+          throw new Error('Invalid item response')
+        }
+        if (!cancelled) setState({ key: routeKey, item: nextItem })
       })
       .catch(() => {
-        if (!cancelled) setError('Could not load item comments.')
+        if (!cancelled) {
+          setState({ key: routeKey, error: 'Could not load item comments.' })
+        }
       })
     return () => {
       cancelled = true
     }
-  }, [id])
+  }, [id, routeKey])
+
+  const current = state.key === routeKey ? state : { key: routeKey }
+  const { item, error } = current
 
   return (
     <div className="main-content">
@@ -95,7 +107,9 @@ export default function ItemDetails() {
               {item.poll.map((pollResult, index) => (
                 <div className="pollContent" key={index}>
                   <div
-                    dangerouslySetInnerHTML={{ __html: pollResult.content }}
+                    dangerouslySetInnerHTML={{
+                      __html: sanitizeHtml(pollResult.content),
+                    }}
                   />
                   <div className="subtext">{pollResult.points} points</div>
                   <div
@@ -112,7 +126,7 @@ export default function ItemDetails() {
           )}
           <p
             className="subject"
-            dangerouslySetInnerHTML={{ __html: item.content }}
+            dangerouslySetInnerHTML={{ __html: sanitizeHtml(item.content) }}
           />
           <ul className="comment-list">
             {item.comments?.map((comment) => (

--- a/react/src/pages/ItemDetails.tsx
+++ b/react/src/pages/ItemDetails.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useState } from 'react'
+import { Link, useNavigate, useParams } from 'react-router-dom'
+import { fetchItemContent } from '../api/hackernews'
+import { Comment } from '../components/Comment'
+import { ErrorMessage } from '../components/ErrorMessage'
+import { Loader } from '../components/Loader'
+import { useSettings } from '../context/SettingsContext'
+import type { Story } from '../models/story'
+import { formatCommentCount } from '../utils/format-comments'
+
+function StoryTitle({ item }: { item: Story }) {
+  const { settings } = useSettings()
+  const hasUrl = item.url?.startsWith('http') ?? false
+  const linkProps = settings.openLinkInNewTab
+    ? { target: '_blank', rel: 'noopener' }
+    : {}
+
+  return hasUrl ? (
+    <>
+      <a className="title" href={item.url} {...linkProps}>
+        {item.title}
+      </a>
+      {item.domain && <span className="domain">({item.domain})</span>}
+    </>
+  ) : (
+    <Link className="title" to={`/item/${item.id}`}>
+      {item.title}
+    </Link>
+  )
+}
+
+export default function ItemDetails() {
+  const { id } = useParams()
+  const navigate = useNavigate()
+  const [item, setItem] = useState<Story>()
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    let cancelled = false
+    setItem(undefined)
+    setError('')
+    window.scrollTo(0, 0)
+    fetchItemContent(Number(id))
+      .then((nextItem) => {
+        if (!cancelled) setItem(nextItem)
+      })
+      .catch(() => {
+        if (!cancelled) setError('Could not load item comments.')
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [id])
+
+  return (
+    <div className="main-content">
+      {!item && !error && <Loader />}
+      {!item && error && <ErrorMessage message={error} />}
+      {item && (
+        <div className="item">
+          <div className="mobile item-header">
+            <p className="title-block">
+              <span className="back-button" onClick={() => navigate(-1)} />
+              <StoryTitle item={item} />
+            </p>
+          </div>
+          <div
+            className={`laptop${item.comments_count > 0 || item.type === 'job' ? ' item-header' : ''}${item.content ? ' head-margin' : ''}`}
+          >
+            <p>
+              <StoryTitle item={item} />
+            </p>
+            <div className="subtext">
+              {item.type !== 'job' && (
+                <span>
+                  {item.points} points by{' '}
+                  <Link to={`/user/${item.user}`}>{item.user}</Link>
+                </span>
+              )}
+              <span className={item.type !== 'job' ? 'item-details' : ''}>
+                {item.time_ago}
+                {item.type !== 'job' && (
+                  <>
+                    {' | '}
+                    <Link to={`/item/${item.id}`}>
+                      {formatCommentCount(item.comments_count)}
+                    </Link>
+                  </>
+                )}
+              </span>
+            </div>
+          </div>
+          {item.type === 'poll' && (
+            <div className="pollResults">
+              {item.poll.map((pollResult, index) => (
+                <div className="pollContent" key={index}>
+                  <div
+                    dangerouslySetInnerHTML={{ __html: pollResult.content }}
+                  />
+                  <div className="subtext">{pollResult.points} points</div>
+                  <div
+                    className="pollBar"
+                    style={{
+                      width: `${item.poll_votes_count
+                        ? (pollResult.points / item.poll_votes_count) * 100
+                        : 0}%`,
+                    }}
+                  />
+                </div>
+              ))}
+            </div>
+          )}
+          <p
+            className="subject"
+            dangerouslySetInnerHTML={{ __html: item.content }}
+          />
+          <ul className="comment-list">
+            {item.comments?.map((comment) => (
+              <li key={comment.id}>
+                <Comment comment={comment} />
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/react/src/router.tsx
+++ b/react/src/router.tsx
@@ -1,6 +1,18 @@
+import { lazy, Suspense } from 'react'
 import { Navigate, createBrowserRouter } from 'react-router-dom'
 import { Layout } from './components/Layout'
+import { Loader } from './components/Loader'
 import { Feed } from './pages/Feed'
+
+const ItemDetails = lazy(() => import('./pages/ItemDetails'))
+
+function LazyItemDetails() {
+  return (
+    <Suspense fallback={<Loader />}>
+      <ItemDetails />
+    </Suspense>
+  )
+}
 
 export const router = createBrowserRouter([
   {
@@ -30,6 +42,10 @@ export const router = createBrowserRouter([
       {
         path: 'jobs/:page',
         element: <Feed feedType="jobs" />,
+      },
+      {
+        path: 'item/:id',
+        element: <LazyItemDetails />,
       },
       {
         path: '*',

--- a/react/src/utils/sanitize.ts
+++ b/react/src/utils/sanitize.ts
@@ -1,0 +1,5 @@
+import DOMPurify from 'dompurify'
+
+export function sanitizeHtml(html: string | undefined): string {
+  return DOMPurify.sanitize(html ?? '')
+}


### PR DESCRIPTION
## Summary
Stacked on [4/8].

- `/item/:id` → lazily loaded `pages/ItemDetails.tsx` (`React.lazy` + `Suspense` fallback `<Loader/>`, matching Angular's lazy module). Calls `fetchItemContent`, renders poll options with `pollBar` width `points / poll_votes_count * 100%`, story text via `dangerouslySetInnerHTML`, back button via `navigate(-1)`, error `Could not load item comments.`
- `components/Comment.tsx` — recursive; `[+]/[-]` collapse toggles `meta-collapse` and `hidden` on the subtree, deleted-comment state, HTML content via `dangerouslySetInnerHTML` (equivalent to Angular's `[innerHTML]`).

Devin-Org: engineering

Link to Devin session: https://app.devin.ai/sessions/43958fcfde3c4663bde63cbf894f9e7a
Open in Devin Desktop: https://app.devin.ai/desktop/session/43958fcfde3c4663bde63cbf894f9e7a?variant=devin
Requested by: @charityquinn-cognition
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/angular2-hn/pull/731" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->