### PR TITLE
[6/8] Port user profile page

### DIFF
--- a/react/src/pages/User.tsx
+++ b/react/src/pages/User.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { fetchUser } from '../api/hackernews'
+import { ErrorMessage } from '../components/ErrorMessage'
+import { Loader } from '../components/Loader'
+import type { User as UserModel } from '../models/user'
+
+export default function User() {
+  const { id = '' } = useParams()
+  const navigate = useNavigate()
+  const [user, setUser] = useState<UserModel>()
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    let cancelled = false
+    setUser(undefined)
+    setError('')
+    fetchUser(id)
+      .then((nextUser) => {
+        if (!cancelled) setUser(nextUser)
+      })
+      .catch(() => {
+        if (!cancelled) setError(`Could not load user ${id}.`)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [id])
+
+  return (
+    <>
+      {!user && !error && <Loader />}
+      {!user && error && <ErrorMessage message={error} />}
+      {user && (
+        <div className="profile">
+          <div className="mobile item-header">
+            <p className="title-block">
+              <span className="back-button" onClick={() => navigate(-1)} />
+              Profile: {user.id}
+            </p>
+          </div>
+          <div className="main-details">
+            <span className="name">{user.id}</span>
+            <span className="right">{user.karma} ★</span>
+            <p className="age">Created {user.created}</p>
+          </div>
+          {user.about && (
+            <div className="other-details">
+              <p dangerouslySetInnerHTML={{ __html: user.about }} />
+            </div>
+          )}
+        </div>
+      )}
+    </>
+  )
+}

--- a/react/src/pages/User.tsx
+++ b/react/src/pages/User.tsx
@@ -4,28 +4,41 @@ import { fetchUser } from '../api/hackernews'
 import { ErrorMessage } from '../components/ErrorMessage'
 import { Loader } from '../components/Loader'
 import type { User as UserModel } from '../models/user'
+import { sanitizeHtml } from '../utils/sanitize'
 
 export default function User() {
   const { id = '' } = useParams()
   const navigate = useNavigate()
-  const [user, setUser] = useState<UserModel>()
-  const [error, setError] = useState('')
+  const routeKey = id
+  const [state, setState] = useState<{
+    key: string
+    user?: UserModel
+    error?: string
+  }>({ key: '' })
 
   useEffect(() => {
+    window.scrollTo(0, 0)
     let cancelled = false
-    setUser(undefined)
-    setError('')
+    setState({ key: routeKey })
     fetchUser(id)
       .then((nextUser) => {
-        if (!cancelled) setUser(nextUser)
+        if (!nextUser || nextUser.id !== id) {
+          throw new Error('Invalid user response')
+        }
+        if (!cancelled) setState({ key: routeKey, user: nextUser })
       })
       .catch(() => {
-        if (!cancelled) setError(`Could not load user ${id}.`)
+        if (!cancelled) {
+          setState({ key: routeKey, error: `Could not load user ${id}.` })
+        }
       })
     return () => {
       cancelled = true
     }
-  }, [id])
+  }, [id, routeKey])
+
+  const current = state.key === routeKey ? state : { key: routeKey }
+  const { user, error } = current
 
   return (
     <>
@@ -46,7 +59,7 @@ export default function User() {
           </div>
           {user.about && (
             <div className="other-details">
-              <p dangerouslySetInnerHTML={{ __html: user.about }} />
+              <p dangerouslySetInnerHTML={{ __html: sanitizeHtml(user.about) }} />
             </div>
           )}
         </div>

--- a/react/src/router.tsx
+++ b/react/src/router.tsx
@@ -5,11 +5,20 @@ import { Loader } from './components/Loader'
 import { Feed } from './pages/Feed'
 
 const ItemDetails = lazy(() => import('./pages/ItemDetails'))
+const User = lazy(() => import('./pages/User'))
 
 function LazyItemDetails() {
   return (
     <Suspense fallback={<Loader />}>
       <ItemDetails />
+    </Suspense>
+  )
+}
+
+function LazyUser() {
+  return (
+    <Suspense fallback={<Loader />}>
+      <User />
     </Suspense>
   )
 }
@@ -46,6 +55,10 @@ export const router = createBrowserRouter([
       {
         path: 'item/:id',
         element: <LazyItemDetails />,
+      },
+      {
+        path: 'user/:id',
+        element: <LazyUser />,
       },
       {
         path: '*',


### PR DESCRIPTION
## Summary
Stacked on [5/8]. `/user/:id` → lazily loaded `pages/User.tsx` calling `fetchUser`, with loader/error (`Could not load user <id>.`), back button, and `about` rendered via `dangerouslySetInnerHTML`.

Devin-Org: engineering

Link to Devin session: https://app.devin.ai/sessions/43958fcfde3c4663bde63cbf894f9e7a
Open in Devin Desktop: https://app.devin.ai/desktop/session/43958fcfde3c4663bde63cbf894f9e7a?variant=devin
Requested by: @charityquinn-cognition
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/angular2-hn/pull/732" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->