### PR TITLE
React migration PR 2 — API layer & settings context

### DIFF
--- a/react-app/src/api/hackernews.ts
+++ b/react-app/src/api/hackernews.ts
@@ -1,0 +1,37 @@
+import type { PollResult, Story, User } from '../types';
+
+export const BASE_URL = 'https://node-hnapi.herokuapp.com';
+
+async function getJson<T>(url: string, signal?: AbortSignal): Promise<T> {
+    const response = await fetch(url, { signal });
+    if (!response.ok) {
+        throw new Error(`Request failed with status ${response.status}`);
+    }
+    return (await response.json()) as T;
+}
+
+export function fetchFeed(feedType: string, page: number, signal?: AbortSignal): Promise<Story[]> {
+    return getJson<Story[]>(`${BASE_URL}/${feedType}?page=${page}`, signal);
+}
+
+export function fetchPollContent(id: number, signal?: AbortSignal): Promise<PollResult> {
+    return getJson<PollResult>(`${BASE_URL}/item/${id}`, signal);
+}
+
+export async function fetchItemContent(id: number, signal?: AbortSignal): Promise<Story> {
+    const story = await getJson<Story>(`${BASE_URL}/item/${id}`, signal);
+
+    if (story.type === 'poll' && story.poll) {
+        const pollResults = await Promise.all(
+            story.poll.map((_, index) => fetchPollContent(story.id + index + 1, signal))
+        );
+        story.poll = pollResults;
+        story.poll_votes_count = pollResults.reduce((total, result) => total + result.points, 0);
+    }
+
+    return story;
+}
+
+export function fetchUser(id: string, signal?: AbortSignal): Promise<User> {
+    return getJson<User>(`${BASE_URL}/user/${id}`, signal);
+}

--- a/react-app/src/context/SettingsContext.tsx
+++ b/react-app/src/context/SettingsContext.tsx
@@ -1,0 +1,90 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
+
+import type { Settings } from '../types';
+
+interface SettingsContextValue {
+    settings: Settings;
+    toggleSettings: () => void;
+    toggleOpenLinksInNewTab: () => void;
+    setTheme: (theme: string) => void;
+    setFont: (titleFontSize: string) => void;
+    setSpacing: (listSpacing: string) => void;
+}
+
+const SettingsContext = createContext<SettingsContextValue | undefined>(undefined);
+
+function readInitialSettings(): Settings {
+    const openLinkInNewTab = localStorage.getItem('openLinkInNewTab');
+    return {
+        showSettings: false,
+        openLinkInNewTab: openLinkInNewTab ? (JSON.parse(openLinkInNewTab) as boolean) : false,
+        theme: localStorage.getItem('theme') ?? 'default',
+        titleFontSize: localStorage.getItem('titleFontSize') ?? '16',
+        listSpacing: localStorage.getItem('listSpacing') ?? '0',
+    };
+}
+
+export function SettingsProvider({ children }: { children: ReactNode }) {
+    const [settings, setSettings] = useState<Settings>(readInitialSettings);
+
+    useEffect(() => {
+        const media = window.matchMedia('(prefers-color-scheme: dark)');
+
+        const applySystemTheme = (matches: boolean) => {
+            const theme = matches ? 'night' : 'default';
+            setSettings(current => ({ ...current, theme }));
+            localStorage.setItem('theme', theme);
+        };
+
+        if (!localStorage.getItem('theme')) {
+            applySystemTheme(media.matches);
+        }
+
+        const handleChange = (event: MediaQueryListEvent) => applySystemTheme(event.matches);
+        media.addEventListener('change', handleChange);
+        return () => media.removeEventListener('change', handleChange);
+    }, []);
+
+    const toggleSettings = useCallback(() => {
+        setSettings(current => ({ ...current, showSettings: !current.showSettings }));
+    }, []);
+
+    const toggleOpenLinksInNewTab = useCallback(() => {
+        setSettings(current => {
+            const openLinkInNewTab = !current.openLinkInNewTab;
+            localStorage.setItem('openLinkInNewTab', JSON.stringify(openLinkInNewTab));
+            return { ...current, openLinkInNewTab };
+        });
+    }, []);
+
+    const setTheme = useCallback((theme: string) => {
+        localStorage.setItem('theme', theme);
+        setSettings(current => ({ ...current, theme }));
+    }, []);
+
+    const setFont = useCallback((titleFontSize: string) => {
+        localStorage.setItem('titleFontSize', titleFontSize);
+        setSettings(current => ({ ...current, titleFontSize }));
+    }, []);
+
+    const setSpacing = useCallback((listSpacing: string) => {
+        localStorage.setItem('listSpacing', listSpacing);
+        setSettings(current => ({ ...current, listSpacing }));
+    }, []);
+
+    const value = useMemo(
+        () => ({ settings, toggleSettings, toggleOpenLinksInNewTab, setTheme, setFont, setSpacing }),
+        [settings, toggleSettings, toggleOpenLinksInNewTab, setTheme, setFont, setSpacing]
+    );
+
+    return <SettingsContext.Provider value={value}>{children}</SettingsContext.Provider>;
+}
+
+export function useSettings(): SettingsContextValue {
+    const context = useContext(SettingsContext);
+    if (!context) {
+        throw new Error('useSettings must be used within a SettingsProvider');
+    }
+    return context;
+}

--- a/react-app/src/utils/comment.ts
+++ b/react-app/src/utils/comment.ts
@@ -1,0 +1,6 @@
+export function commentLabel(count: number): string {
+    if (count > 0) {
+        return `${count} ${count === 1 ? 'comment' : 'comments'}`;
+    }
+    return 'discuss';
+}


### PR DESCRIPTION
## Summary

PR 2 of 6 (based on #736). Ports the two Angular singletons — `HackerNewsAPIService` and `SettingsService` — plus the `comment` pipe. No UI yet.

`src/api/hackernews.ts`: RxJS `Observable` wrappers around `unfetch` become plain `async` functions over native `fetch`, each accepting an optional `AbortSignal` (the React equivalent of the old observable teardown `cancelToken`). The poll fan-out was a nested `subscribe` inside a `map` — i.e. the returned story could be emitted before its poll options resolved — and is now awaited:

```ts
if (story.type === 'poll' && story.poll) {
    const results = await Promise.all(story.poll.map((_, i) => fetchPollContent(story.id + i + 1)));
    story.poll = results;
    story.poll_votes_count = results.reduce((t, r) => t + r.points, 0);
}
```

`src/context/SettingsContext.tsx`: `SettingsProvider` holds the settings object in `useState`, initialized from `localStorage`; every mutator writes through to `localStorage` before updating state. The Angular service faked a `change` event on the `prefers-color-scheme` media query to seed the theme; the hook instead applies `media.matches` directly on mount when no saved theme exists, and subscribes to `change` for later system switches. `useSettings()` throws outside a provider.

`src/utils/comment.ts`: `CommentPipe.transform` → `commentLabel(count)`.


Link to Devin session: https://app.devin.ai/sessions/263cf968800f4f1d97c307c62856974b
Open in Devin Desktop: https://app.devin.ai/desktop/session/263cf968800f4f1d97c307c62856974b?variant=devin
Requested by: @devanshi-gpta