### PR TITLE
React migration PR 3 — shared & layout components

### DIFF
--- a/react-app/src/components/core/Footer.module.scss
+++ b/react-app/src/components/core/Footer.module.scss
@@ -1,0 +1,23 @@
+@import "../../styles/media";
+@import "../../styles/theme_variables";
+
+.footer {
+  position: relative;
+  padding: 10px;
+  height: 60px;
+  letter-spacing: 0.7px;
+  text-align: center;
+
+  a {
+    font-weight: bold;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  @media #{$mobile-only} {
+    display: none;
+  }
+}

--- a/react-app/src/components/core/Footer.tsx
+++ b/react-app/src/components/core/Footer.tsx
@@ -1,0 +1,14 @@
+import styles from './Footer.module.scss';
+
+export function Footer() {
+    return (
+        <div id="footer" className={styles.footer}>
+            <p>
+                Show this project some ❤ on{' '}
+                <a href="https://github.com/hdjirdeh/angular2-hn" target="_blank" rel="noopener noreferrer">
+                    GitHub
+                </a>
+            </p>
+        </div>
+    );
+}

--- a/react-app/src/components/core/Header.module.scss
+++ b/react-app/src/components/core/Header.module.scss
@@ -1,0 +1,130 @@
+@import "../../styles/media";
+@import "../../styles/theme_variables";
+
+.header {
+  color: #fff;
+  padding: 6px 0;
+  line-height: 18px;
+  vertical-align: middle;
+  position: relative;
+  z-index: 1;
+  width: 100%;
+
+  @media #{$mobile-only} {
+    height: 50px;
+    position: fixed;
+    top: 0;
+  }
+
+  a {
+    display: inline;
+  }
+}
+
+.homeLink {
+  width: 50px;
+  height: 66px;
+}
+
+.logoInner {
+  width: 32px;
+  position: absolute;
+  left: 17px;
+  top: 18px;
+  z-index: -1;
+  height: 32px;
+  border-radius: 50%;
+
+  @media #{$mobile-only} {
+    left: 16px;
+    top: 12px;
+  }
+}
+
+.logo {
+  width: 50px;
+  padding: 3px 8px 0;
+
+  @media #{$mobile-only} {
+    width: 45px;
+    padding: 0 0 0 10px;
+  }
+}
+
+.headerText {
+  position: absolute;
+  width: inherit;
+  height: 20px;
+  left: 10px;
+  top: 27px;
+  z-index: -1;
+
+  @media #{$mobile-only} {
+    top: 22px;
+  }
+}
+
+.left {
+  position: absolute;
+  left: 60px;
+  font-size: 16px;
+
+  @media #{$mobile-only} {
+    width: 100%;
+    left: 0;
+  }
+}
+
+.headerNav {
+  display: inline-block;
+  margin-left: 20px;
+
+  @media #{$mobile-only} {
+    margin-left: 60px;
+  }
+
+  a {
+    color: hsla(0,0%,100%,.9);
+    text-decoration: none;
+    margin: 0 5px;
+    letter-spacing: 1.8px;
+
+    &:hover {
+      color: #fff;
+    }
+
+    &:global(.active) {
+      color: #fff;
+    }
+  }
+}
+
+.info {
+  position: absolute;
+  top: 0;
+  right: 20px;
+  height: 100%;
+
+  @media #{$mobile-only} {
+    right: 10px;
+  }
+
+  img {
+    opacity: 0.8;
+    width: 25px;
+    margin-top: 21.5px;
+    display: block;
+    border: none;
+    background: none;
+    padding: 0;
+
+    &:hover {
+      opacity: 1;
+      cursor: pointer;
+    }
+
+    @media #{$mobile-only} {
+      margin-top: 15px;
+    }
+  }
+}

--- a/react-app/src/components/core/Header.tsx
+++ b/react-app/src/components/core/Header.tsx
@@ -1,0 +1,55 @@
+import { NavLink } from 'react-router-dom';
+
+import { useSettings } from '../../context/SettingsContext';
+import { Settings } from './Settings';
+import styles from './Header.module.scss';
+
+const NAV_LINKS = [
+    { to: '/newest/1', label: 'new' },
+    { to: '/show/1', label: 'show' },
+    { to: '/ask/1', label: 'ask' },
+    { to: '/jobs/1', label: 'jobs' },
+];
+
+function scrollTop() {
+    window.scrollTo(0, 0);
+}
+
+export function Header() {
+    const { settings, toggleSettings } = useSettings();
+
+    return (
+        <header>
+            <div id="header" className={styles.header}>
+                <NavLink to="/news/1" className={styles.homeLink} onClick={scrollTop}>
+                    <div className={`logo-inner ${styles.logoInner}`}></div>
+                    <img className={styles.logo} src="/assets/images/logo.svg" alt="Logo" />
+                </NavLink>
+                <div className={styles.headerText}>
+                    <div className={styles.left}>
+                        <span className={`nav ${styles.headerNav}`}>
+                            {NAV_LINKS.map((link, index) => (
+                                <span key={link.to}>
+                                    {index > 0 && ' | '}
+                                    <NavLink to={link.to} onClick={scrollTop}>
+                                        {link.label}
+                                    </NavLink>
+                                </span>
+                            ))}
+                        </span>
+                    </div>
+                </div>
+                <div className={styles.info}>
+                    <img
+                        src="/assets/images/cog.svg"
+                        alt="Settings"
+                        role="button"
+                        tabIndex={0}
+                        onClick={toggleSettings}
+                    />
+                </div>
+            </div>
+            {settings.showSettings && <Settings />}
+        </header>
+    );
+}

--- a/react-app/src/components/core/Settings.module.scss
+++ b/react-app/src/components/core/Settings.module.scss
@@ -1,0 +1,76 @@
+@import "../../styles/media";
+@import "../../styles/theme_variables";
+
+.overlay {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: rgba(0, 0, 0, 0.7);
+  opacity: 1;
+  z-index: 1;
+}
+
+.popup {
+  margin: 70px auto;
+  padding: 30px;
+  border-radius: 5px;
+  width: 30%;
+  position: relative;
+
+  h1 {
+    margin-top: 0;
+    margin-bottom: 0px;
+    color: #fff;
+    text-align: center;
+    letter-spacing: 1px;
+  }
+  h2 {
+    padding-top: 10px;
+  }
+  hr {
+    width: 40%;
+    margin-bottom: 20px;
+  }
+  .close {
+    position: absolute;
+    top: 12px;
+    right: 20px;
+    font-size: 30px;
+    font-weight: bold;
+    text-decoration: none;
+    color: rgba(255,255,255,0.8);
+
+    &:hover {
+      color: #fff;
+      cursor: pointer;
+    }
+  }
+  .content {
+    max-height: 30%;
+    color: #fff;
+    letter-spacing: 1px;
+    overflow: auto;
+  }
+  input[type=number] {
+    display: block;
+    width: 80%;
+    height: 20px;
+    margin-bottom: 15px;
+    border-radius: 5px;
+    padding: 2px;
+  }
+}
+
+.controlSection {
+  margin-bottom: 15px;
+  padding-bottom: 15px;
+  border-bottom: 1px solid white;
+}
+
+@media screen and (max-width: 700px) {
+  .popup {
+    width: 70%;
+  }
+}

--- a/react-app/src/components/core/Settings.tsx
+++ b/react-app/src/components/core/Settings.tsx
@@ -1,0 +1,81 @@
+import { useSettings } from '../../context/SettingsContext';
+import styles from './Settings.module.scss';
+
+const THEMES = [
+    { value: 'default', label: 'Default' },
+    { value: 'night', label: 'Night' },
+    { value: 'amoledblack', label: 'Black (AMOLED)' },
+];
+
+export function Settings() {
+    const { settings, toggleSettings, toggleOpenLinksInNewTab, setTheme, setFont, setSpacing } = useSettings();
+
+    return (
+        <div className={styles.overlay}>
+            <div className={`popup ${styles.popup}`}>
+                <h1>Settings</h1>
+                <hr />
+                <span className={styles.close} role="button" tabIndex={0} onClick={toggleSettings}>
+                    &times;
+                </span>
+                <div className={styles.content}>
+                    <div className={styles.controlSection}>
+                        <h2>Links</h2>
+                        <label>
+                            <input
+                                type="checkbox"
+                                checked={settings.openLinkInNewTab}
+                                onChange={toggleOpenLinksInNewTab}
+                            />
+                            Open links in a new tab
+                        </label>
+                    </div>
+                    <div>
+                        <div className={styles.controlSection}>
+                            <h2>Select a theme</h2>
+                            {THEMES.map(theme => (
+                                <div key={theme.value}>
+                                    <label>
+                                        <input
+                                            name="theme"
+                                            type="radio"
+                                            value={theme.value}
+                                            checked={settings.theme === theme.value}
+                                            onChange={() => setTheme(theme.value)}
+                                        />
+                                        {theme.label}
+                                    </label>
+                                </div>
+                            ))}
+                        </div>
+                        <div className={styles.controlSection}>
+                            <h2>Change Font</h2>
+                            <div>
+                                <label>
+                                    Font size:
+                                    <input
+                                        min="1"
+                                        type="number"
+                                        value={settings.titleFontSize}
+                                        onChange={event => setFont(event.target.value)}
+                                    />
+                                </label>
+                            </div>
+                            <div>
+                                <label>
+                                    List spacing:
+                                    <input
+                                        min="0"
+                                        type="number"
+                                        value={settings.listSpacing}
+                                        onChange={event => setSpacing(event.target.value)}
+                                    />
+                                </label>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/react-app/src/components/shared/ErrorMessage.module.scss
+++ b/react-app/src/components/shared/ErrorMessage.module.scss
@@ -1,0 +1,121 @@
+@use "sass:math";
+@import "../../styles/media";
+@import "../../styles/theme_variables";
+
+.errorSection {
+  height: 300px;
+  margin: 200px;
+
+  @media #{$mobile-only} {
+    height: 0;
+    display: block;
+    position: relative;
+    margin: 30vh 0;
+  }
+
+  p {
+    text-align: center;
+    padding: 0 25px;
+
+    &.strong {
+      margin-top: 25px;
+      font-weight: bold;
+    }
+  }
+
+  :global(.skull) {
+    width: $skull-size;
+    height: $skull-size;
+    position: relative;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    margin: auto;
+
+    :global(.head) {
+      width: 100%;
+      height: 75%;
+      border-radius: 15% / 20%;
+      position: absolute;
+      top: 0;
+      left: 0;
+
+      &:before, &:after {
+        content: "";
+        position: absolute;
+        border-radius: 50%;
+        width: 20%;
+        height: 30%;
+        bottom: 10%;
+      }
+      &:before {
+        left: 10%;
+      }
+      &:after {
+        right: 10%;
+      }
+
+      :global(.crack) {
+        width: 10%;
+        height: 10%;
+        position: absolute;
+        top: 0;
+        right: 25%;
+        transform: skew(-15deg);
+
+        &:before {
+          content: "";
+          position: absolute;
+          top: 100%;
+          left: math.div($skull-size, 15);
+          border-right: math.div($skull-size, 20) solid transparent;
+          border-left: math.div($skull-size, 40) solid transparent;
+        }
+      }
+    }
+
+    :global(.mouth) {
+      width: 40%;
+      height: 25%;
+      position: absolute;
+      top: 75%;
+      left: 30%;
+      border-radius: 0 0 math.div($skull-size, 10) math.div($skull-size, 10);
+
+      &:before {
+        content: "";
+        position: absolute;
+        width: 15%;
+        height: 50%;
+        border-radius: 50% / 30%;
+        left: 42.5%;
+        top: -25%;
+      }
+
+      :global(.teeth) {
+        position: absolute;
+        bottom: 0;
+        left: 45%;
+        width: 10%;
+        height: 50%;
+        margin-bottom: -5%;
+        border-radius: 50% / 20%;
+
+        &:before, &:after {
+          content: "";
+          position: absolute;
+          width: 100%;
+          height: 100%;
+          border-radius: 50% / 20%;
+        }
+        &:before {
+          left: -250%;
+        }
+        &:after {
+          right: -250%;
+        }
+      }
+    }
+  }
+}

--- a/react-app/src/components/shared/ErrorMessage.tsx
+++ b/react-app/src/components/shared/ErrorMessage.tsx
@@ -1,0 +1,21 @@
+import styles from './ErrorMessage.module.scss';
+
+export function ErrorMessage({ message }: { message: string }) {
+    return (
+        <div className={`error-section ${styles.errorSection}`}>
+            <div className="skull">
+                <div className="head">
+                    <div className="crack"></div>
+                </div>
+                <div className="mouth">
+                    <div className="teeth"></div>
+                </div>
+            </div>
+            <p className={styles.strong}>{message}</p>
+            <p>
+                If you are offline viewing, you'll need to visit this page with a network connection first before it
+                can work offline.
+            </p>
+        </div>
+    );
+}

--- a/react-app/src/components/shared/Loader.module.scss
+++ b/react-app/src/components/shared/Loader.module.scss
@@ -1,0 +1,80 @@
+@import "../../styles/media";
+@import "../../styles/theme_variables";
+
+.loader {
+  -webkit-animation: load1 1s infinite ease-in-out;
+  animation: load1 1s infinite ease-in-out;
+  width: 1em;
+  height: 4em;
+  text-indent: -9999em;
+  margin: 20px 20px;
+  position: relative;
+  font-size: 11px;
+  -webkit-transform: translateZ(0);
+  transform: translateZ(0);
+  -webkit-animation-delay: -0.16s;
+  animation-delay: -0.16s;
+
+  &:before, &:after {
+    -webkit-animation: load1 1s infinite ease-in-out;
+    animation: load1 1s infinite ease-in-out;
+    width: 1em;
+    height: 4em;
+    position: absolute;
+    top: 0;
+    content: '';
+  }
+
+  &:before {
+    left: -1.5em;
+    -webkit-animation-delay: -0.32s;
+    animation-delay: -0.32s;
+  }
+
+  &:after {
+    left: 1.5em;
+  }
+
+  @media #{$mobile-only} {
+    margin: 20px auto;
+  }
+}
+
+.loadingSection {
+  height: 70px;
+  margin: 40px 0 40px 40px;
+
+  @media #{$mobile-only} {
+    display: block;
+    position: relative;
+    margin: 45vh 0;
+  }
+}
+
+@keyframes load1 {
+  0%,
+    80%,
+    100% {
+    box-shadow: 0 0;
+    height: 2em;
+  }
+  40% {
+    box-shadow: 0 -2em;
+    height: 3em;
+  }
+}
+
+@media #{$mobile-only} {
+  @keyframes load1 {
+    0%,
+      80%,
+      100% {
+      box-shadow: 0 0;
+      height: 3em;
+    }
+    40% {
+      box-shadow: 0 -2em;
+      height: 4em;
+    }
+  }
+}

--- a/react-app/src/components/shared/Loader.tsx
+++ b/react-app/src/components/shared/Loader.tsx
@@ -1,0 +1,9 @@
+import styles from './Loader.module.scss';
+
+export function Loader() {
+    return (
+        <div className={styles.loadingSection}>
+            <div className={`loader ${styles.loader}`}>Loading...</div>
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary

PR 3 of 6 (based on #737). Ports `Loader`, `ErrorMessage`, `Header`, `Footer` and `Settings` to React with CSS Modules (`*.module.scss`). They are not mounted yet — the app shell arrives in PR 4.

The one non-obvious part is theming. `src/styles/_themes.scss` is global and colors components by selector (`.wrapper #header`, `.wrapper .loader`, `.wrapper .error-section .skull .head`, …), which CSS Modules would hash away. Each themed element therefore keeps its original global class/id alongside its module class, and nested skull markup is styled through `:global()`:

```tsx
<div className={`loader ${styles.loader}`}>Loading...</div>   // .loader stays global for the theme
<div id="header" className={styles.header}>                   // themes target #header / #footer by id
```

Behavior notes:
- `Header` uses `<NavLink>` (react-router's `active` class replaces `routerLinkActive`, matched via `a:global(.active)` in the module) and renders `<Settings />` from `settings.showSettings`.
- `Settings` inputs are controlled: theme radios use `checked={settings.theme === value}` + `onChange`, and the font-size / list-spacing number inputs move from Angular's `keyup` handlers to `onChange`, so pasting or stepping the value also persists.
- Angular's `:host >>> ` piercing selectors and the duplicated `.loader` blocks are collapsed into single module rules; `$skull-size / n` divisions become `math.div`.


Link to Devin session: https://app.devin.ai/sessions/263cf968800f4f1d97c307c62856974b
Open in Devin Desktop: https://app.devin.ai/desktop/session/263cf968800f4f1d97c307c62856974b?variant=devin
Requested by: @devanshi-gpta