### PR TITLE
React migration PR 4 — page components & routing

### DIFF
--- a/react-app/src/App.scss
+++ b/react-app/src/App.scss
@@ -1,0 +1,24 @@
+@import "./styles/media";
+@import "./styles/theme_variables";
+
+.body-cover {
+  width: 100%;
+  z-index: 0;
+  position: fixed;
+  height: 100%;
+}
+
+.wrapper {
+  position: relative;
+  width: 85%;
+  min-height: 80px;
+  margin: 0 auto;
+  font-family: "HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
+  font-size: 15px;
+  height: 100%;
+  line-height: 1.3;
+
+  @media #{$mobile-only} {
+    width: 100%;
+  }
+}

--- a/react-app/src/App.tsx
+++ b/react-app/src/App.tsx
@@ -1,8 +1,52 @@
+import { Suspense, lazy } from 'react';
+import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
+
+import './App.scss';
+import { Footer } from './components/core/Footer';
+import { Header } from './components/core/Header';
+import { Feed } from './components/feeds/Feed';
+import { Loader } from './components/shared/Loader';
+import { SettingsProvider, useSettings } from './context/SettingsContext';
+
+const ItemDetails = lazy(() => import('./components/item-details/ItemDetails'));
+const UserProfile = lazy(() => import('./components/user/UserProfile'));
+
+const FEED_TYPES = ['news', 'newest', 'show', 'ask', 'jobs'];
+
+function AppShell() {
+    const { settings } = useSettings();
+
+    return (
+        <div className={settings.theme}>
+            <div className="body-cover"></div>
+            <div className="wrapper">
+                <Header />
+                <Suspense fallback={<Loader />}>
+                    <Routes>
+                        <Route path="/" element={<Navigate to="/news/1" replace />} />
+                        {FEED_TYPES.map(feedType => (
+                            <Route
+                                key={feedType}
+                                path={`/${feedType}/:page`}
+                                element={<Feed feedType={feedType} />}
+                            />
+                        ))}
+                        <Route path="/item/:id" element={<ItemDetails />} />
+                        <Route path="/user/:id" element={<UserProfile />} />
+                    </Routes>
+                </Suspense>
+                <Footer />
+            </div>
+        </div>
+    );
+}
+
 export default function App() {
     return (
-        <div className="default">
-            <div className="body-cover"></div>
-            <div className="wrapper"></div>
-        </div>
+        <BrowserRouter>
+            <SettingsProvider>
+                <AppShell />
+            </SettingsProvider>
+        </BrowserRouter>
     );
 }

--- a/react-app/src/components/feeds/Feed.module.scss
+++ b/react-app/src/components/feeds/Feed.module.scss
@@ -1,0 +1,96 @@
+@import "../../styles/media";
+@import "../../styles/theme_variables";
+
+.mainContent {
+  position: relative;
+  width: 100%;
+  min-height: 100vh;
+  transition: opacity .2s ease;
+  box-sizing: border-box;
+  padding: 8px 0;
+  z-index: 0;
+
+  a {
+    text-decoration: none;
+    font-weight: bold;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  ol {
+    padding: 0 40px;
+    margin: 0;
+
+    @media #{$mobile-only} {
+      box-sizing: border-box;
+      list-style: none;
+      padding: 0 10px;
+    }
+
+    li {
+      position: relative;
+      transition: background-color .2s ease;
+    }
+  }
+}
+
+.listMargin {
+  @media #{$mobile-only} {
+    margin-top: 55px;
+  }
+}
+
+.post {
+  padding: 10px 0 10px 5px;
+  transition: background-color 0.2s ease;
+  border-bottom: 1px solid #CECECB;
+}
+
+.itemBlock {
+  display: block;
+}
+
+.nav {
+  padding: 10px 40px;
+  margin-top: 10px;
+  font-size: 17px;
+
+  a {
+    @media #{$mobile-only} {
+      text-decoration: none;
+    }
+  }
+
+  @media #{$mobile-only} {
+    margin: 20px 0;
+    text-align: center;
+    padding: 10px 80px;
+    height: 20px;
+  }
+
+  .prev {
+    padding-right: 20px;
+
+    @media #{$mobile-only} {
+      float: left;
+      padding-right: 0;
+    }
+  }
+
+  .more {
+    @media #{$mobile-only} {
+      float: right;
+    }
+  }
+}
+
+.jobHeader {
+  font-size: 15px;
+  padding: 0 40px 10px;
+
+  @media #{$mobile-only} {
+    padding: 60px 15px 25px 15px;
+  }
+}

--- a/react-app/src/components/feeds/Feed.tsx
+++ b/react-app/src/components/feeds/Feed.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+
+import { fetchFeed } from '../../api/hackernews';
+import type { Story } from '../../types';
+import { ErrorMessage } from '../shared/ErrorMessage';
+import { Loader } from '../shared/Loader';
+import { Item } from './Item';
+import styles from './Feed.module.scss';
+
+const PAGE_SIZE = 30;
+
+export function Feed({ feedType }: { feedType: string }) {
+    const { page } = useParams<{ page: string }>();
+    const pageNum = page ? Number(page) : 1;
+
+    const [items, setItems] = useState<Story[] | null>(null);
+    const [errorMessage, setErrorMessage] = useState('');
+
+    useEffect(() => {
+        const controller = new AbortController();
+        setItems(null);
+        setErrorMessage('');
+
+        fetchFeed(feedType, pageNum, controller.signal)
+            .then(stories => {
+                setItems(stories);
+                window.scrollTo(0, 0);
+            })
+            .catch((error: unknown) => {
+                if (error instanceof DOMException && error.name === 'AbortError') {
+                    return;
+                }
+                setErrorMessage(`Could not load ${feedType} stories.`);
+            });
+
+        return () => controller.abort();
+    }, [feedType, pageNum]);
+
+    const listStart = (pageNum - 1) * PAGE_SIZE + 1;
+
+    return (
+        <div className={styles.mainContent}>
+            {!items && !errorMessage && <Loader />}
+            {!items && errorMessage !== '' && <ErrorMessage message={errorMessage} />}
+
+            {items && (
+                <div>
+                    {feedType === 'jobs' && (
+                        <p className={`job-header ${styles.jobHeader}`}>
+                            These are jobs at startups that were funded by Y Combinator. You can also get a job at a
+                            YC startup through <a href="https://triplebyte.com/?ref=yc_jobs">Triplebyte</a>.
+                        </p>
+                    )}
+                    <ol className={feedType !== 'jobs' ? styles.listMargin : undefined} start={listStart}>
+                        {items.map(item => (
+                            <li key={item.id} className={styles.post}>
+                                <div className={styles.itemBlock}>
+                                    <Item item={item} />
+                                </div>
+                            </li>
+                        ))}
+                    </ol>
+                    <div className={`nav ${styles.nav}`}>
+                        {listStart !== 1 && (
+                            <Link to={`/${feedType}/${pageNum - 1}`} className={styles.prev}>
+                                ‹ Prev
+                            </Link>
+                        )}
+                        {items.length === PAGE_SIZE && (
+                            <Link to={`/${feedType}/${pageNum + 1}`} className={styles.more}>
+                                More ›
+                            </Link>
+                        )}
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/react-app/src/components/feeds/Item.module.scss
+++ b/react-app/src/components/feeds/Item.module.scss
@@ -1,0 +1,67 @@
+@import "../../styles/media";
+@import "../../styles/theme_variables";
+
+.item {
+  p {
+    margin: 2px 0;
+
+    @media #{$mobile-only} {
+      margin-bottom: 5px;
+      margin-top: 0;
+    }
+  }
+
+  a {
+    cursor: pointer;
+    text-decoration: none;
+  }
+
+  .title {
+    font-size: 16px;
+    font-family: Verdana, Geneva, sans-serif;
+  }
+
+  :global(.subtext-laptop) {
+    font-size: 12px;
+    font-weight: bold;
+    letter-spacing: 0.5px;
+
+    a:hover {
+      text-decoration: underline;
+    }
+
+    @media #{$mobile-only} {
+      display: none;
+    }
+  }
+
+  :global(.subtext-palm) {
+    font-size: 13px;
+    font-weight: bold;
+    letter-spacing: 0.5px;
+
+    a:hover {
+      text-decoration: underline;
+    }
+
+    .details {
+      margin-top: 5px;
+
+      .right {
+        float: right;
+      }
+    }
+
+    @media #{$laptop-only} {
+      display: none;
+    }
+  }
+
+  :global(.domain) {
+    letter-spacing: 0.5px;
+  }
+
+  .itemDetails {
+    padding: 10px;
+  }
+}

--- a/react-app/src/components/feeds/Item.tsx
+++ b/react-app/src/components/feeds/Item.tsx
@@ -1,0 +1,68 @@
+import { Link } from 'react-router-dom';
+
+import { useSettings } from '../../context/SettingsContext';
+import type { Story } from '../../types';
+import { commentLabel } from '../../utils/comment';
+import styles from './Item.module.scss';
+
+export function Item({ item }: { item: Story }) {
+    const { settings } = useSettings();
+
+    const hasUrl = item.url?.indexOf('http') === 0;
+    const isJob = item.type === 'job';
+    const titleStyle = { fontSize: `${settings.titleFontSize}px` };
+    const externalLinkProps = settings.openLinkInNewTab
+        ? { target: '_blank', rel: 'noopener noreferrer' }
+        : undefined;
+
+    return (
+        <div className={styles.item} style={{ marginBottom: `${settings.listSpacing}px` }}>
+            {hasUrl ? (
+                <p>
+                    <a className={styles.title} style={titleStyle} href={item.url} {...externalLinkProps}>
+                        {item.title}
+                    </a>
+                    {item.domain && <span className="domain"> ({item.domain})</span>}
+                </p>
+            ) : (
+                <p>
+                    <Link className={styles.title} style={titleStyle} to={`/item/${item.id}`}>
+                        {item.title}
+                    </Link>
+                </p>
+            )}
+            <div className="subtext-palm">
+                {!isJob && (
+                    <div className={styles.details}>
+                        <span className={styles.name}>
+                            <Link to={`/user/${item.user}`}>{item.user}</Link>
+                        </span>
+                        <span className={styles.right}>{item.points} ★</span>
+                    </div>
+                )}
+                <div className={styles.details}>
+                    {item.time_ago}
+                    {!isJob && (
+                        <Link to={`/item/${item.id}`}> • {commentLabel(item.comments_count)}</Link>
+                    )}
+                </div>
+            </div>
+            <div className="subtext-laptop">
+                {!isJob && (
+                    <span>
+                        {item.points} points by <Link to={`/user/${item.user}`}>{item.user}</Link>
+                    </span>
+                )}
+                <span className={isJob ? undefined : styles.itemDetails}>
+                    {item.time_ago}
+                    {!isJob && (
+                        <span>
+                            {' | '}
+                            <Link to={`/item/${item.id}`}>{commentLabel(item.comments_count)}</Link>
+                        </span>
+                    )}
+                </span>
+            </div>
+        </div>
+    );
+}

--- a/react-app/src/components/item-details/Comment.module.scss
+++ b/react-app/src/components/item-details/Comment.module.scss
@@ -1,0 +1,73 @@
+@import "../../styles/media";
+@import "../../styles/theme_variables";
+
+.comment {
+  a {
+    font-weight: bold;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  :global(.meta) {
+    font-size: 13px;
+    font-weight: bold;
+    letter-spacing: 0.5px;
+    margin-bottom: 8px;
+
+    .time {
+      padding-left: 5px;
+    }
+
+    @media #{$mobile-only} {
+      font-size: 14px;
+      margin-bottom: 10px;
+
+      .time {
+        padding: 0;
+        float: right;
+      }
+    }
+  }
+
+  .metaCollapse {
+    margin-bottom: 20px;
+  }
+
+  :global(.deleted-meta) {
+    font-size: 12px;
+    font-weight: bold;
+    letter-spacing: 0.5px;
+    margin: 30px 0;
+  }
+
+  .collapse {
+    font-size: 13px;
+    letter-spacing: 2px;
+    cursor: pointer;
+  }
+
+  .commentTree {
+    margin-left: 24px;
+
+    @media #{$tablet-only} {
+      margin-left: 8px;
+    }
+  }
+
+  .commentText {
+    font-size: 15px;
+    margin-top: 0;
+    margin-bottom: 20px;
+    word-wrap: break-word;
+    line-height: 1.5em;
+  }
+
+  .subtree {
+    margin-left: 0;
+    padding: 0;
+    list-style-type: none;
+  }
+}

--- a/react-app/src/components/item-details/Comment.tsx
+++ b/react-app/src/components/item-details/Comment.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+
+import type { Comment as CommentModel } from '../../types';
+import styles from './Comment.module.scss';
+
+export function Comment({ comment }: { comment: CommentModel }) {
+    const [collapsed, setCollapsed] = useState(false);
+
+    if (comment.deleted) {
+        return (
+            <div className={styles.comment}>
+                <div className="deleted-meta">
+                    <span className={styles.collapse}>[deleted]</span> | Comment Deleted
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className={styles.comment}>
+            <div className={`meta ${collapsed ? styles.metaCollapse : ''}`}>
+                <span className={styles.collapse} role="button" tabIndex={0} onClick={() => setCollapsed(!collapsed)}>
+                    [{collapsed ? '+' : '-'}]
+                </span>{' '}
+                <Link to={`/user/${comment.user}`}>{comment.user}</Link>
+                <span className={styles.time}>{comment.time_ago}</span>
+            </div>
+            <div className={styles.commentTree}>
+                <div hidden={collapsed}>
+                    <p className={styles.commentText} dangerouslySetInnerHTML={{ __html: comment.content }}></p>
+                    <ul className={styles.subtree}>
+                        {comment.comments?.map(subComment => (
+                            <li key={subComment.id}>
+                                <Comment comment={subComment} />
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/react-app/src/components/item-details/ItemDetails.module.scss
+++ b/react-app/src/components/item-details/ItemDetails.module.scss
@@ -1,0 +1,140 @@
+@import "../../styles/media";
+@import "../../styles/theme_variables";
+
+.mainContent {
+  position: relative;
+  width: 100%;
+  min-height: 100vh;
+  transition: opacity .2s ease;
+  box-sizing: border-box;
+  padding: 8px 0;
+  z-index: 0;
+}
+
+.item {
+  box-sizing: border-box;
+  padding: 10px 40px 0 40px;
+  z-index: 0;
+
+  @media #{$tablet-only} {
+    padding: 10px 20px 0 40px;
+  }
+
+  @media #{$mobile-only} {
+    padding: 110px 15px 0 15px;
+  }
+
+  p {
+    margin: 2px 0;
+  }
+
+  a {
+    cursor: pointer;
+    text-decoration: none;
+  }
+
+  ul {
+    list-style-type: none;
+    padding: 10px 0;
+  }
+
+  li {
+    display: list-item;
+  }
+}
+
+.headMargin {
+  margin-bottom: 15px;
+}
+
+.subject {
+  word-wrap: break-word;
+  margin-top: 20px;
+}
+
+.laptop {
+  @media #{$mobile-only} {
+    display: none;
+  }
+}
+
+.mobile {
+  @media #{$laptop-only} {
+    display: none;
+  }
+}
+
+.title {
+  font-size: 16px;
+  font-family: Verdana, Geneva, sans-serif;
+
+  @media #{$mobile-only} {
+    font-size: 15px;
+  }
+}
+
+.titleBlock {
+  text-align: center;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  margin: 0 75px;
+}
+
+.backButton {
+  @media #{$mobile-only} {
+    position: absolute;
+    top: 52%;
+    width: 0.6rem;
+    height: 0.6rem;
+    background: transparent;
+    box-shadow: 0 0 0 lightgray;
+    transition: all 200ms ease;
+    left: 4%;
+    transform: translate3d(0, -50%, 0) rotate(-135deg);
+    cursor: pointer;
+  }
+}
+
+.subtext {
+  font-size: 12px;
+  font-weight: bold;
+  letter-spacing: 0.5px;
+
+  a:hover {
+    text-decoration: underline;
+  }
+}
+
+.itemDetails {
+  padding: 10px;
+}
+
+.itemHeader {
+  padding-bottom: 10px;
+
+  @media #{$mobile-only} {
+    padding: 10px 0 10px 0;
+    position: fixed;
+    width: 100%;
+    left: 0;
+    top: 62px;
+  }
+}
+
+.pollResults {
+  margin-bottom: 1em;
+
+  :global(.pollContent) {
+    * {
+      padding-bottom: 0;
+      margin-bottom: -1em;
+      margin-top: 1em;
+    }
+
+    :global(.pollBar) {
+      height: 10px;
+      margin-bottom: 1em;
+    }
+  }
+}

--- a/react-app/src/components/item-details/ItemDetails.tsx
+++ b/react-app/src/components/item-details/ItemDetails.tsx
@@ -1,0 +1,139 @@
+import { useEffect, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+
+import { fetchItemContent } from '../../api/hackernews';
+import { useSettings } from '../../context/SettingsContext';
+import type { Story } from '../../types';
+import { commentLabel } from '../../utils/comment';
+import { ErrorMessage } from '../shared/ErrorMessage';
+import { Loader } from '../shared/Loader';
+import { Comment } from './Comment';
+import styles from './ItemDetails.module.scss';
+
+export default function ItemDetails() {
+    const { id } = useParams<{ id: string }>();
+    const navigate = useNavigate();
+    const { settings } = useSettings();
+
+    const [item, setItem] = useState<Story | null>(null);
+    const [errorMessage, setErrorMessage] = useState('');
+
+    useEffect(() => {
+        const controller = new AbortController();
+        setItem(null);
+        setErrorMessage('');
+        window.scrollTo(0, 0);
+
+        fetchItemContent(Number(id), controller.signal)
+            .then(setItem)
+            .catch((error: unknown) => {
+                if (error instanceof DOMException && error.name === 'AbortError') {
+                    return;
+                }
+                setErrorMessage('Could not load item comments.');
+            });
+
+        return () => controller.abort();
+    }, [id]);
+
+    if (!item) {
+        return (
+            <div className={styles.mainContent}>
+                {errorMessage === '' ? <Loader /> : <ErrorMessage message={errorMessage} />}
+            </div>
+        );
+    }
+
+    const hasUrl = item.url?.indexOf('http') === 0;
+    const isJob = item.type === 'job';
+    const externalLinkProps = settings.openLinkInNewTab
+        ? { target: '_blank', rel: 'noopener noreferrer' }
+        : undefined;
+    const titleLink = hasUrl ? (
+        <a className={styles.title} href={item.url} {...externalLinkProps}>
+            {item.title}
+        </a>
+    ) : (
+        <Link className={styles.title} to={`/item/${item.id}`}>
+            {item.title}
+        </Link>
+    );
+
+    return (
+        <div className={styles.mainContent}>
+            <div className={styles.item}>
+                <div className={`item-header ${styles.mobile} ${styles.itemHeader}`}>
+                    <p className={styles.titleBlock}>
+                        <span
+                            className={`back-button ${styles.backButton}`}
+                            role="button"
+                            tabIndex={0}
+                            aria-label="Go back"
+                            onClick={() => navigate(-1)}
+                        ></span>
+                        {titleLink}
+                    </p>
+                </div>
+                <div
+                    className={[
+                        styles.laptop,
+                        item.comments_count > 0 || isJob ? `item-header ${styles.itemHeader}` : '',
+                        item.content ? styles.headMargin : '',
+                    ]
+                        .filter(Boolean)
+                        .join(' ')}
+                >
+                    <p>
+                        {titleLink}
+                        {hasUrl && item.domain && <span className="domain"> ({item.domain})</span>}
+                    </p>
+                    <div className={`subtext ${styles.subtext}`}>
+                        {!isJob && (
+                            <span>
+                                {item.points} points by <Link to={`/user/${item.user}`}>{item.user}</Link>
+                            </span>
+                        )}
+                        <span className={isJob ? undefined : styles.itemDetails}>
+                            {item.time_ago}
+                            {!isJob && (
+                                <span>
+                                    {' | '}
+                                    <Link to={`/item/${item.id}`}>{commentLabel(item.comments_count)}</Link>
+                                </span>
+                            )}
+                        </span>
+                    </div>
+                </div>
+
+                {item.type === 'poll' && item.poll && (
+                    <div className={styles.pollResults}>
+                        {item.poll.map((pollResult, index) => (
+                            <div key={index} className="pollContent">
+                                <div dangerouslySetInnerHTML={{ __html: pollResult.content }}></div>
+                                <div className="subtext">{pollResult.points} points</div>
+                                <div
+                                    className="pollBar"
+                                    style={{
+                                        width: `${(pollResult.points / (item.poll_votes_count || 1)) * 100}%`,
+                                    }}
+                                ></div>
+                            </div>
+                        ))}
+                    </div>
+                )}
+
+                {item.content && (
+                    <p className={styles.subject} dangerouslySetInnerHTML={{ __html: item.content }}></p>
+                )}
+
+                <ul>
+                    {item.comments?.map(comment => (
+                        <li key={comment.id}>
+                            <Comment comment={comment} />
+                        </li>
+                    ))}
+                </ul>
+            </div>
+        </div>
+    );
+}

--- a/react-app/src/components/user/UserProfile.module.scss
+++ b/react-app/src/components/user/UserProfile.module.scss
@@ -1,0 +1,94 @@
+@import "../../styles/media";
+@import "../../styles/theme_variables";
+
+.profile {
+  padding: 30px;
+
+  @media #{$mobile-only} {
+    padding: 110px 15px 0 15px;
+  }
+
+  pre {
+    white-space: pre-wrap;
+  }
+}
+
+.titleBlock {
+  @media #{$mobile-only} {
+    font-size: 15px;
+    text-align: center;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    margin: 0 75px;
+  }
+}
+
+.backButton {
+  @media #{$mobile-only} {
+    position: absolute;
+    top: 52%;
+    width: 0.6rem;
+    height: 0.6rem;
+    background: transparent;
+    box-shadow: 0 0 0 lightgray;
+    transition: all 200ms ease;
+    left: 4%;
+    transform: translate3d(0, -50%, 0) rotate(-135deg);
+    cursor: pointer;
+  }
+}
+
+.itemHeader {
+  @media #{$mobile-only} {
+    padding: 10px 0 10px 0;
+    position: fixed;
+    width: 100%;
+    left: 0;
+    top: 62px;
+    height: 20px;
+  }
+}
+
+.mobile {
+  @media #{$laptop-only} {
+    display: none;
+  }
+}
+
+.mainDetails {
+  .name {
+    font-weight: bold;
+    font-size: 32px;
+    letter-spacing: 2px;
+
+    @media #{$mobile-only} {
+      font-size: 18px;
+    }
+  }
+
+  .age {
+    font-weight: bold;
+    color: #696969;
+    padding-bottom: 0;
+  }
+
+  .right {
+    float: right;
+    font-weight: bold;
+    font-size: 32px;
+    letter-spacing: 2px;
+
+    @media #{$mobile-only} {
+      font-size: 18px;
+    }
+  }
+
+  @media #{$mobile-only} {
+    margin-top: 20px;
+  }
+}
+
+.otherDetails {
+  word-wrap: break-word;
+}

--- a/react-app/src/components/user/UserProfile.tsx
+++ b/react-app/src/components/user/UserProfile.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+
+import { fetchUser } from '../../api/hackernews';
+import type { User } from '../../types';
+import { ErrorMessage } from '../shared/ErrorMessage';
+import { Loader } from '../shared/Loader';
+import styles from './UserProfile.module.scss';
+
+export default function UserProfile() {
+    const { id } = useParams<{ id: string }>();
+    const navigate = useNavigate();
+
+    const [user, setUser] = useState<User | null>(null);
+    const [errorMessage, setErrorMessage] = useState('');
+
+    useEffect(() => {
+        const controller = new AbortController();
+        setUser(null);
+        setErrorMessage('');
+
+        fetchUser(id ?? '', controller.signal)
+            .then(setUser)
+            .catch((error: unknown) => {
+                if (error instanceof DOMException && error.name === 'AbortError') {
+                    return;
+                }
+                setErrorMessage(`Could not load user ${id}.`);
+            });
+
+        return () => controller.abort();
+    }, [id]);
+
+    if (!user) {
+        return errorMessage === '' ? <Loader /> : <ErrorMessage message={errorMessage} />;
+    }
+
+    return (
+        <div className={styles.profile}>
+            <div className={`item-header ${styles.mobile} ${styles.itemHeader}`}>
+                <p className={styles.titleBlock}>
+                    <span
+                        className={`back-button ${styles.backButton}`}
+                        role="button"
+                        tabIndex={0}
+                        aria-label="Go back"
+                        onClick={() => navigate(-1)}
+                    ></span>
+                    Profile: {user.id}
+                </p>
+            </div>
+            <div className={`main-details ${styles.mainDetails}`}>
+                <span className={`name ${styles.name}`}>{user.id}</span>
+                <span className={`right ${styles.right}`}>{user.karma} ★</span>
+                <p className={styles.age}>Created {user.created}</p>
+            </div>
+            {user.about && (
+                <div className={styles.otherDetails}>
+                    <p dangerouslySetInnerHTML={{ __html: user.about }}></p>
+                </div>
+            )}
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary

PR 4 of 6 (based on #738). Ports `Item`, `Feed`, `Comment`, `ItemDetails`, `UserProfile` and wires the real app shell, so the React app is now navigable end to end.

Routing replaces Angular's `data: {feedType}` child-route trick with one `<Route>` per feed and the type passed as a prop:

```tsx
{['news','newest','show','ask','jobs'].map(t =>
  <Route path={`/${t}/:page`} element={<Feed feedType={t} />} />)}
<Route path="/" element={<Navigate to="/news/1" replace />} />
<Route path="/item/:id" element={<ItemDetails />} />   // React.lazy + default export
<Route path="/user/:id" element={<UserProfile />} />   // React.lazy + default export
```

Notable conversions:
- Fetching moves from RxJS subscriptions to `useEffect` + `AbortController`; cleanup aborts in-flight requests on param change, so a fast feed/page switch can no longer render a stale response (the Angular version never unsubscribed).
- `Comment` recurses on itself with local `useState` collapse instead of Angular's template recursion; `[innerHTML]` becomes `dangerouslySetInnerHTML`.
- Back buttons use `useNavigate(-1)`; internal links use `<Link>`, external story links honor `settings.openLinkInNewTab`.
- Poll bars keep the original percentage math but guard `poll_votes_count` against 0.
- `.wrapper` / `.body-cover` stay global (`src/App.scss`) because `_themes.scss` selects through them; per-page styles are CSS Modules with `:global()` for theme-targeted names like `.subtext-palm`, `.meta`, `.domain`.


Link to Devin session: https://app.devin.ai/sessions/263cf968800f4f1d97c307c62856974b
Open in Devin Desktop: https://app.devin.ai/desktop/session/263cf968800f4f1d97c307c62856974b?variant=devin
Requested by: @devanshi-gpta