### PR TITLE
[2/7] React migration: shared Loader and ErrorMessage components

### DIFF
--- a/src/components/shared/ErrorMessage.scss
+++ b/src/components/shared/ErrorMessage.scss
@@ -1,0 +1,118 @@
+@use "sass:math";
+@use "../../app/shared/scss/media" as *;
+@use "../../app/shared/scss/theme_variables" as *;
+
+.c-error-message {
+  .error-section {
+    height: 300px;
+    margin: 200px;
+
+    @media #{$mobile-only} {
+      height: 0;
+      display: block;
+      position: relative;
+      margin: 30vh 0;
+    }
+
+    p {
+      text-align: center;
+      padding: 0 25px;
+
+      &.strong {
+        margin-top: 25px;
+        font-weight: bold;
+      }
+    }
+
+    .skull {
+      width: $skull-size;
+      height: $skull-size;
+      position: relative;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      margin: auto;
+
+      .head {
+        width: 100%;
+        height: 75%;
+        border-radius: 15% / 20%;
+        position: absolute;
+        top: 0;
+        left: 0;
+        &:before, &:after {
+          content: "";
+          position: absolute;
+          border-radius: 50%;
+          width: 20%;
+          height: 30%;
+          bottom: 10%;
+        }
+        &:before {
+          left: 10%;
+        }
+        &:after {
+          right: 10%;
+        }
+        .crack {
+          width: 10%;
+          height: 10%;
+          position: absolute;
+          top: 0;
+          right: 25%;
+          transform: skew(-15deg);
+
+          &:before {
+            content: "";
+            position: absolute;
+            top: 100%;
+            left: math.div($skull-size, 15);
+            border-right: math.div($skull-size, 20) solid transparent;
+            border-left: math.div($skull-size, 40) solid transparent;
+          }
+        }
+      }
+      .mouth {
+        width: 40%;
+        height: 25%;
+        position: absolute;
+        top: 75%;
+        left: 30%;
+        border-radius: 0 0 math.div($skull-size, 10) math.div($skull-size, 10);
+        &:before {
+          content: "";
+          position: absolute;
+          width: 15%;
+          height: 50%;
+          border-radius: 50% / 30%;
+          left: 42.5%;
+          top: -25%;
+        }
+        .teeth {
+          position: absolute;
+          bottom: 0;
+          left: 45%;
+          width: 10%;
+          height: 50%;
+          margin-bottom: -5%;
+          border-radius: 50% / 20%;
+
+          &:before, &:after {
+            content: "";
+            position: absolute;
+            width: 100%;
+            height: 100%;
+            border-radius: 50% / 20%;
+          }
+          &:before {
+            left: -250%;
+          }
+          &:after {
+            right: -250%;
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/components/shared/ErrorMessage.tsx
+++ b/src/components/shared/ErrorMessage.tsx
@@ -1,0 +1,21 @@
+import './ErrorMessage.scss';
+
+export default function ErrorMessage({ message }: { message: string }) {
+    return (
+        <div className="c-error-message error-section">
+            <div className="skull">
+                <div className="head">
+                    <div className="crack"></div>
+                </div>
+                <div className="mouth">
+                    <div className="teeth"></div>
+                </div>
+            </div>
+            <p className="strong">{message}</p>
+            <p>
+                If you are offline viewing, you&apos;ll need to visit this page with a network connection first before
+                it can work offline.
+            </p>
+        </div>
+    );
+}

--- a/src/components/shared/Loader.scss
+++ b/src/components/shared/Loader.scss
@@ -1,0 +1,111 @@
+@use "../../app/shared/scss/media" as *;
+@use "../../app/shared/scss/theme_variables" as *;
+
+.c-loader {
+  .loader {
+    -webkit-animation: load1 1s infinite ease-in-out;
+    animation: load1 1s infinite ease-in-out;
+    width: 1em;
+    height: 4em;
+    &:before, &:after {
+      -webkit-animation: load1 1s infinite ease-in-out;
+      animation: load1 1s infinite ease-in-out;
+      width: 1em;
+      height: 4em;
+    }
+    &:before, &:after {
+      position: absolute;
+      top: 0;
+      content: '';
+    }
+    &:before {
+      left: -1.5em;
+      -webkit-animation-delay: -0.32s;
+      animation-delay: -0.32s;
+    }
+  }
+
+  .loading-section {
+      height: 70px;
+      margin: 40px 0 40px 40px;
+
+    @media #{$mobile-only} {
+      display: block;
+      position: relative;
+      margin: 45vh 0;
+    }
+  }
+
+  .loader {
+    text-indent: -9999em;
+    margin: 20px 20px;
+    position: relative;
+    font-size: 11px;
+    -webkit-transform: translateZ(0);
+    -ms-transform: translateZ(0);
+    transform: translateZ(0);
+    -webkit-animation-delay: -0.16s;
+    animation-delay: -0.16s;
+    &:after {
+      left: 1.5em;
+    }
+
+    @media #{$mobile-only} {
+      margin: 20px auto;
+    }
+  }
+
+  @-webkit-keyframes load1 {
+    0%,
+      80%,
+      100% {
+      box-shadow: 0 0;
+      height: 2em;
+    }
+    40% {
+      box-shadow: 0 -2em;
+      height: 3em;
+    }
+  }
+
+  @keyframes load1 {
+    0%,
+      80%,
+      100% {
+      box-shadow: 0 0;
+      height: 2em;
+    }
+    40% {
+      box-shadow: 0 -2em;
+      height: 3em;
+    }
+  }
+
+  @media #{$mobile-only} {
+    @-webkit-keyframes load1 {
+      0%,
+        80%,
+        100% {
+        box-shadow: 0 0;
+        height: 4em;
+      }
+      40% {
+        box-shadow: 0 -2em;
+        height: 5em;
+      }
+    }
+
+    @keyframes load1 {
+      0%,
+        80%,
+        100% {
+        box-shadow: 0 0;
+        height: 3em;
+      }
+      40% {
+        box-shadow: 0 -2em;
+        height: 4em;
+      }
+    }
+  }
+}

--- a/src/components/shared/Loader.tsx
+++ b/src/components/shared/Loader.tsx
@@ -1,0 +1,9 @@
+import './Loader.scss';
+
+export default function Loader() {
+    return (
+        <div className="c-loader loading-section">
+            <div className="loader">Loading...</div>
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary

Ports the two shared presentational components from `src/app/shared/components/` to `src/components/shared/`. Markup is a 1:1 JSX translation of the Angular templates; nothing consumes them yet (the feed and detail views land higher in the stack).

The only substantive change is style scoping. Angular's emulated encapsulation kept these stylesheets local; with plain global SCSS imports the skull/loader rules would leak, so each stylesheet is wrapped in a class applied to the component root (`.c-loader`, `.c-error-message`). `ErrorMessage.scss` also replaces the deprecated `$skull-size / N` divisions with `math.div($skull-size, N)`, which computes identically.

## Proposed fixes
- Add `Loader.tsx` / `Loader.scss`.
- Add `ErrorMessage.tsx` / `ErrorMessage.scss`.


Link to Devin session: https://app.devin.ai/sessions/a3a0ff57bab64e25860349a003a282ef
Open in Devin Desktop: https://app.devin.ai/desktop/session/a3a0ff57bab64e25860349a003a282ef?variant=devin
Requested by: @devanshi-gpta