### PR TITLE
[3/7] React migration: Header, Footer and Settings panel

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,5 @@
+import Footer from './components/core/Footer';
+import Header from './components/core/Header';
 import { useSettings } from './context/SettingsContext';
 import './App.scss';
 
@@ -7,7 +9,10 @@ export default function App() {
     return (
         <div className={`c-app ${settings.theme}`}>
             <div className="body-cover"></div>
-            <div className="wrapper"></div>
+            <div className="wrapper">
+                <Header />
+                <Footer />
+            </div>
         </div>
     );
 }

--- a/src/components/core/Footer.scss
+++ b/src/components/core/Footer.scss
@@ -1,0 +1,25 @@
+@use "../../app/shared/scss/media" as *;
+@use "../../app/shared/scss/theme_variables" as *;
+
+.c-footer {
+  #footer {
+    position: relative;
+    padding: 10px;
+    height: 60px;
+    letter-spacing: 0.7px;
+    text-align: center;
+
+    a {
+    	font-weight: bold;
+    	text-decoration: none;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+
+    @media #{$mobile-only} {
+      display: none;
+    }
+  }
+}

--- a/src/components/core/Footer.tsx
+++ b/src/components/core/Footer.tsx
@@ -1,0 +1,14 @@
+import './Footer.scss';
+
+export default function Footer() {
+    return (
+        <div id="footer" className="c-footer">
+            <p>
+                Show this project some ❤ on{' '}
+                <a href="https://github.com/hdjirdeh/angular2-hn" target="_blank" rel="noopener">
+                    GitHub
+                </a>
+            </p>
+        </div>
+    );
+}

--- a/src/components/core/Header.scss
+++ b/src/components/core/Header.scss
@@ -1,0 +1,151 @@
+@use "../../app/shared/scss/media" as *;
+@use "../../app/shared/scss/theme_variables" as *;
+
+.c-header {
+  #header {
+    color: #fff;
+    padding: 6px 0;
+    line-height: 18px;
+    vertical-align: middle;
+    position: relative;
+    z-index: 1;
+    width: 100%;
+
+    @media #{$mobile-only} {
+      height: 50px;
+      position: fixed;
+      top: 0;
+    }
+
+    a {
+      display: inline;
+    }
+  }
+
+  .home-link {
+    width: 50px;
+    height: 66px;
+  }
+
+  .logo-inner {
+    width: 32px;
+    position: absolute;
+    left: 17px;
+    top: 18px;
+    z-index: -1;
+    height: 32px;
+    border-radius: 50%;
+
+    @media #{$mobile-only} {
+      left: 16px;
+      top: 12px;
+    }
+  }
+
+  .logo {
+    width: 50px;
+    padding: 3px 8px 0;
+
+    @media #{$mobile-only} {
+      width: 45px;
+      padding: 0 0 0 10px;
+    }
+  }
+
+  h1 {
+    font-weight: normal;
+    display: inline-block;
+    vertical-align:middle;
+    margin: 0;
+    font-size: 16px;
+
+    a {
+      color: #fff;
+      text-decoration: none;
+    }
+  }
+
+  .name {
+    margin-right: 30px;
+    margin-bottom: 2px;
+
+    @media #{$mobile-only} {
+      display: none;
+    }
+  }
+
+  .header-text {
+    position: absolute;
+    width: inherit;
+    height: 20px;
+    left: 10px;
+    top: 27px;
+    z-index: -1;
+
+    @media #{$mobile-only} {
+      top: 22px;
+    }
+  }
+
+  .left {
+    position: absolute;
+    left: 60px;
+    font-size: 16px;
+
+    @media #{$mobile-only} {
+      width: 100%;
+      left: 0;
+    }
+  }
+
+  .header-nav {
+    display: inline-block;
+    margin-left: 20px;
+
+    @media #{$mobile-only} {
+      margin-left: 60px;
+    }
+
+    a {
+      color: hsla(0,0%,100%,.9);
+      text-decoration: none;
+      margin: 0 5px;
+      letter-spacing: 1.8px;
+
+      &:hover {
+        color: #fff;
+      }
+    }
+
+    .active {
+      color: #fff;
+    }
+  }
+
+  .info {
+    position: absolute;
+    top: 0;
+    right: 20px;
+    height: 100%;
+
+    @media #{$mobile-only} {
+      right: 10px;
+    }
+
+    img {
+      opacity: 0.8;
+      width: 25px;
+      margin-top: 21.5px;
+      display: block;
+
+      &:hover {
+        opacity: 1;
+        cursor: pointer;
+      }
+
+      @media #{$mobile-only} {
+        margin-top: 15px;
+      }
+    }
+  }
+}

--- a/src/components/core/Header.tsx
+++ b/src/components/core/Header.tsx
@@ -1,0 +1,55 @@
+import { NavLink } from 'react-router-dom';
+
+import { useSettings } from '../../context/SettingsContext';
+import Settings from './Settings';
+import './Header.scss';
+
+function scrollTop() {
+    window.scrollTo(0, 0);
+}
+
+const navLinkClass = ({ isActive }: { isActive: boolean }) => (isActive ? 'active' : '');
+
+export default function Header() {
+    const { settings, toggleSettings } = useSettings();
+
+    return (
+        <header className="c-header">
+            <div id="header">
+                <NavLink
+                    className={({ isActive }) => `home-link${isActive ? ' active' : ''}`}
+                    to="/news/1"
+                    onClick={scrollTop}
+                >
+                    <div className="logo-inner"></div>
+                    <img className="logo" src="/assets/images/logo.svg" alt="Logo" />
+                </NavLink>
+                <div className="header-text">
+                    <div className="left">
+                        <span className="header-nav">
+                            <NavLink className={navLinkClass} to="/newest/1" onClick={scrollTop}>
+                                new
+                            </NavLink>
+                            {' | '}
+                            <NavLink className={navLinkClass} to="/show/1" onClick={scrollTop}>
+                                show
+                            </NavLink>
+                            {' | '}
+                            <NavLink className={navLinkClass} to="/ask/1" onClick={scrollTop}>
+                                ask
+                            </NavLink>
+                            {' | '}
+                            <NavLink className={navLinkClass} to="/jobs/1" onClick={scrollTop}>
+                                jobs
+                            </NavLink>
+                        </span>
+                    </div>
+                </div>
+                <div className="info">
+                    <img className="settings" src="/assets/images/cog.svg" alt="Settings" onClick={toggleSettings} />
+                </div>
+            </div>
+            {settings.showSettings && <Settings />}
+        </header>
+    );
+}

--- a/src/components/core/Settings.scss
+++ b/src/components/core/Settings.scss
@@ -1,0 +1,76 @@
+@use "../../app/shared/scss/media" as *;
+@use "../../app/shared/scss/theme_variables" as *;
+
+.c-settings {
+  .overlay {
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background: rgba(0, 0, 0, 0.7);
+    opacity: 1;
+    z-index: 1;
+  }
+
+  .popup {
+    margin: 70px auto;
+    padding: 30px;
+    border-radius: 5px;
+    width: 30%;
+    position: relative;
+    h1 {
+      margin-top: 0;
+      margin-bottom: 0px;
+      color: #fff;
+      text-align: center;
+      letter-spacing: 1px;
+    }
+    h2 {
+      padding-top: 10px;
+    }
+    hr {
+      width: 40%;
+      margin-bottom: 20px;
+    }
+    .close {
+      position: absolute;
+      top: 12px;
+      right: 20px;
+      font-size: 30px;
+      font-weight: bold;
+      text-decoration: none;
+      color: rgba(255,255,255,0.8);
+      &:hover {
+        color: #fff;
+        cursor: pointer;
+      }
+    }
+    .content {
+      max-height: 30%;
+      color: #fff;
+      letter-spacing: 1px;
+      overflow: auto;
+    }
+    input[type=number] {
+        display: block;
+        width: 80%;
+        height: 20px;
+        margin-bottom: 15px;
+        border-radius: 5px;
+        padding: 2px;
+    }
+  }
+
+  .control-section {
+      margin-bottom: 15px;
+      padding-bottom: 15px;
+      border-bottom: 1px solid white;
+  }
+
+  @media screen and (max-width: 700px) {
+    .box, .popup {
+      width: 70%;
+    }
+  }
+}

--- a/src/components/core/Settings.tsx
+++ b/src/components/core/Settings.tsx
@@ -1,0 +1,97 @@
+import { useSettings } from '../../context/SettingsContext';
+import './Settings.scss';
+
+export default function Settings() {
+    const { settings, toggleSettings, toggleOpenLinksInNewTab, setTheme, setFont, setSpacing } = useSettings();
+
+    return (
+        <div id="popup1" className="c-settings overlay">
+            <div className="popup">
+                <h1>Settings</h1>
+                <hr />
+                <span className="close" onClick={toggleSettings}>
+                    &times;
+                </span>
+                <div className="content">
+                    <div className="control-section">
+                        <h2>Links</h2>
+                        <input
+                            type="checkbox"
+                            checked={settings.openLinkInNewTab}
+                            onChange={toggleOpenLinksInNewTab}
+                        />
+                        Open links in a new tab
+                    </div>
+                    <div className="theme-controls">
+                        <div className="control-section">
+                            <h2>Select a theme</h2>
+                            <div>
+                                <label>
+                                    <input
+                                        name="theme"
+                                        type="radio"
+                                        value="default"
+                                        checked={settings.theme === 'default'}
+                                        onChange={() => setTheme('default')}
+                                    />
+                                    Default
+                                </label>
+                            </div>
+                            <div>
+                                <label>
+                                    <input
+                                        name="theme"
+                                        type="radio"
+                                        value="night"
+                                        checked={settings.theme === 'night'}
+                                        onChange={() => setTheme('night')}
+                                    />
+                                    Night
+                                </label>
+                            </div>
+                            <div>
+                                <label>
+                                    <input
+                                        name="theme"
+                                        type="radio"
+                                        value="amoledblack"
+                                        checked={settings.theme === 'amoledblack'}
+                                        onChange={() => setTheme('amoledblack')}
+                                    />
+                                    Black (AMOLED)
+                                </label>
+                            </div>
+                        </div>
+                        <div className="control-section">
+                            <h2>Change Font</h2>
+                            <div>
+                                <label>
+                                    Font size:
+                                    <input
+                                        min="1"
+                                        name="theme"
+                                        type="number"
+                                        value={settings.titleFontSize}
+                                        onChange={(event) => setFont(event.target.value)}
+                                    />
+                                </label>
+                            </div>
+                            <div>
+                                <label>
+                                    List spacing:
+                                    <input
+                                        min="0"
+                                        name="theme"
+                                        type="number"
+                                        value={settings.listSpacing}
+                                        onChange={(event) => setSpacing(event.target.value)}
+                                    />
+                                </label>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary

Ports the app chrome from `src/app/core/` and mounts it in `App`. `Header` renders the settings panel itself when `settings.showSettings` is true, exactly as the Angular template did with `*ngIf`.

- `routerLink` + `routerLinkActive` → `NavLink` with an `isActive` class callback; the scroll-to-top click handler is preserved.
- `Settings` translates the theme radios, font-size and spacing selects and the new-tab checkbox into controlled inputs driven by `useSettings()`.
- Header image `src` values are root-relative (`/assets/images/logo.svg`). Angular resolved the relative form via `<base href="/">`, which Vite's `index.html` has no equivalent for — left relative, the logo and cog 404 on any nested route such as `/item/123`.
- Stylesheets are wrapped in `.c-header` / `.c-footer` / `.c-settings` to replace Angular's emulated encapsulation.

## Proposed fixes
- Add `Header.tsx`, `Footer.tsx`, `Settings.tsx` and their stylesheets.
- Render `Header` and `Footer` in the `App` layout.


Link to Devin session: https://app.devin.ai/sessions/a3a0ff57bab64e25860349a003a282ef
Open in Devin Desktop: https://app.devin.ai/desktop/session/a3a0ff57bab64e25860349a003a282ef?variant=devin
Requested by: @devanshi-gpta