### PR TITLE
[4/7] React migration: Feed and Item components with the five feed routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,12 @@
+import { Navigate, Route, Routes } from 'react-router-dom';
+
 import Footer from './components/core/Footer';
 import Header from './components/core/Header';
+import Feed from './components/feeds/Feed';
 import { useSettings } from './context/SettingsContext';
 import './App.scss';
+
+const feedTypes = ['news', 'newest', 'show', 'ask', 'jobs'];
 
 export default function App() {
     const { settings } = useSettings();
@@ -11,6 +16,16 @@ export default function App() {
             <div className="body-cover"></div>
             <div className="wrapper">
                 <Header />
+                <Routes>
+                    <Route path="/" element={<Navigate to="/news/1" replace />} />
+                    {feedTypes.map((feedType) => (
+                        <Route
+                            key={feedType}
+                            path={`/${feedType}/:page`}
+                            element={<Feed feedType={feedType} />}
+                        />
+                    ))}
+                </Routes>
                 <Footer />
             </div>
         </div>

--- a/src/components/feeds/Feed.scss
+++ b/src/components/feeds/Feed.scss
@@ -1,0 +1,111 @@
+@use "../../app/shared/scss/media" as *;
+@use "../../app/shared/scss/theme_variables" as *;
+
+.c-feed {
+  .job-header a,
+  .nav a {
+    text-decoration: none;
+    font-weight: bold;
+
+    &:hover {
+      text-decoration: underline;
+    };
+  }
+
+  ol {
+    padding: 0 40px;
+    margin: 0;
+
+    @media #{$mobile-only} {
+      box-sizing: border-box;
+      list-style: none;
+      padding: 0 10px;
+    }
+
+    li {
+      position: relative;
+      -webkit-transition: background-color .2s ease;
+      transition: background-color .2s ease;
+    }
+  }
+
+  .list-margin {
+    @media #{$mobile-only} {
+      margin-top: 55px;
+    }
+  }
+
+  .main-content {
+    position: relative;
+    width: 100%;
+    min-height: 100vh;
+    -webkit-transition: opacity .2s ease;
+    transition: opacity .2s ease;
+    box-sizing: border-box;
+    padding: 8px 0;
+    z-index: 0;
+  }
+
+  .post {
+    padding: 10px 0 10px 5px;
+    transition: background-color 0.2s ease;
+    border-bottom: 1px solid #CECECB;
+
+    .itemNum {
+      color: #696969;
+      position: absolute;
+      width: 30px;
+      text-align: right;
+      left: 0;
+      top: 4px;
+    }
+  }
+
+  .item-block {
+    display: block;
+  }
+
+
+  .nav {
+    padding: 10px 40px;
+    margin-top: 10px;
+    font-size: 17px;
+
+    a {
+      @media #{$mobile-only} {
+        text-decoration: none;
+      }
+    }
+
+    @media #{$mobile-only} {
+      margin: 20px 0;
+      text-align: center;
+      padding: 10px 80px;
+      height: 20px;
+    }
+
+    .prev {
+      padding-right: 20px;
+
+      @media #{$mobile-only} {
+        float: left;
+        padding-right: 0;
+      }
+    }
+
+    .more {
+      @media #{$mobile-only} {
+        float: right;
+      }
+    }
+  }
+
+  .job-header {
+    font-size: 15px;
+    padding: 0 40px 10px;
+
+    @media #{$mobile-only} {
+      padding: 60px 15px 25px 15px;
+    }
+  }
+}

--- a/src/components/feeds/Feed.test.tsx
+++ b/src/components/feeds/Feed.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { SettingsProvider } from '../../context/SettingsContext';
+import * as api from '../../services/hackernews-api';
+import type { Story } from '../../models/story';
+import Feed from './Feed';
+
+afterEach(() => vi.restoreAllMocks());
+
+function story(id: number): Story {
+    return {
+        id,
+        title: `Story ${id}`,
+        points: 1,
+        user: 'pg',
+        time_ago: '1 hour ago',
+        type: 'story',
+        url: `https://example.com/${id}`,
+        domain: 'example.com',
+        comments_count: 0,
+    } as Story;
+}
+
+function renderFeed(path = '/news/2') {
+    return render(
+        <SettingsProvider>
+            <MemoryRouter initialEntries={[path]}>
+                <Routes>
+                    <Route path="/news/:page" element={<Feed feedType="news" />} />
+                </Routes>
+            </MemoryRouter>
+        </SettingsProvider>
+    );
+}
+
+describe('Feed', () => {
+    it('renders the stories of the requested page with pagination links', async () => {
+        vi.spyOn(api, 'fetchFeed').mockResolvedValue(Array.from({ length: 30 }, (_unused, i) => story(i + 1)));
+
+        renderFeed();
+
+        expect(await screen.findByText('Story 1')).toBeInTheDocument();
+        expect(api.fetchFeed).toHaveBeenCalledWith('news', 2, expect.anything());
+        expect(screen.getByRole('list')).toHaveAttribute('start', '31');
+        expect(screen.getByText('‹ Prev')).toHaveAttribute('href', '/news/1');
+        expect(screen.getByText('More ›')).toHaveAttribute('href', '/news/3');
+    });
+
+    it('shows an error message when the feed cannot be loaded', async () => {
+        vi.spyOn(api, 'fetchFeed').mockRejectedValue(new Error('boom'));
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        renderFeed('/news/1');
+
+        await waitFor(() => expect(screen.getByText('Could not load news stories.')).toBeInTheDocument());
+    });
+});

--- a/src/components/feeds/Feed.tsx
+++ b/src/components/feeds/Feed.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+
+import type { Story } from '../../models/story';
+import { fetchFeed } from '../../services/hackernews-api';
+import ErrorMessage from '../shared/ErrorMessage';
+import Loader from '../shared/Loader';
+import Item from './Item';
+import './Feed.scss';
+
+export default function Feed({ feedType }: { feedType: string }) {
+    const { page } = useParams<{ page: string }>();
+    const pageNum = page ? +page : 1;
+    const [items, setItems] = useState<Story[] | null>(null);
+    const [errorMessage, setErrorMessage] = useState('');
+
+    useEffect(() => {
+        const controller = new AbortController();
+        setItems(null);
+        setErrorMessage('');
+
+        fetchFeed(feedType, pageNum, controller.signal)
+            .then((stories) => {
+                setItems(stories);
+                window.scrollTo(0, 0);
+            })
+            .catch((error: unknown) => {
+                if (!controller.signal.aborted) {
+                    setErrorMessage('Could not load ' + feedType + ' stories.');
+                    console.error(error);
+                }
+            });
+
+        return () => controller.abort();
+    }, [feedType, pageNum]);
+
+    const listStart = (pageNum - 1) * 30 + 1;
+
+    return (
+        <div className="c-feed main-content">
+            {!items && !errorMessage && <Loader />}
+            {!items && errorMessage !== '' && <ErrorMessage message={errorMessage} />}
+
+            {items && (
+                <div>
+                    {feedType === 'jobs' && (
+                        <p className="job-header">
+                            These are jobs at startups that were funded by Y Combinator. You can also get a job at a YC
+                            startup through <a href="https://triplebyte.com/?ref=yc_jobs">Triplebyte</a>.
+                        </p>
+                    )}
+                    <ol className={feedType !== 'jobs' ? 'list-margin' : undefined} start={listStart}>
+                        {items.map((item) => (
+                            <li key={item.id} className="post">
+                                <div className="item-block">
+                                    <Item item={item} />
+                                </div>
+                            </li>
+                        ))}
+                    </ol>
+                    <div className="nav">
+                        {listStart !== 1 && (
+                            <Link to={`/${feedType}/${pageNum - 1}`} className="prev">
+                                ‹ Prev
+                            </Link>
+                        )}
+                        {items.length === 30 && (
+                            <Link to={`/${feedType}/${pageNum + 1}`} className="more">
+                                More ›
+                            </Link>
+                        )}
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/components/feeds/Item.scss
+++ b/src/components/feeds/Item.scss
@@ -1,0 +1,70 @@
+@use "../../app/shared/scss/media" as *;
+@use "../../app/shared/scss/theme_variables" as *;
+
+.c-item {
+  p {
+      margin: 2px 0;
+
+      @media #{$mobile-only} {
+        margin-bottom: 5px;
+        margin-top: 0;
+     }
+    }
+
+    a {
+      cursor: pointer;
+      text-decoration: none;
+    }
+
+    .title {
+      font-size: 16px;
+      font-family: Verdana, Geneva, sans-serif;
+    }
+
+    .subtext-laptop {
+      font-size: 12px;
+      font-weight: bold;
+      letter-spacing: 0.5px;
+
+      a {
+        &:hover {
+          text-decoration: underline;
+        };
+      }
+      @media #{$mobile-only} {
+        display: none;
+      }
+    }
+
+    .subtext-palm {
+      font-size: 13px;
+      font-weight: bold;
+      letter-spacing: 0.5px;
+
+      a {
+        &:hover {
+          text-decoration: underline;
+        };
+      }
+
+      .details {
+        margin-top: 5px;
+
+        .right {
+          float: right;
+        }
+      }
+      @media #{$laptop-only} {
+        display: none;
+      }
+    }
+
+    .domain {
+      color: #696969;
+      letter-spacing: 0.5px;
+    }
+
+    .item-details {
+      padding: 10px;
+    }
+}

--- a/src/components/feeds/Item.test.tsx
+++ b/src/components/feeds/Item.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+
+import { SettingsProvider } from '../../context/SettingsContext';
+import type { Story } from '../../models/story';
+import Item from './Item';
+
+const story = {
+    id: 1,
+    title: 'A story',
+    points: 42,
+    user: 'pg',
+    time_ago: '2 hours ago',
+    type: 'story',
+    url: 'https://example.com/story',
+    domain: 'example.com',
+    comments_count: 1,
+} as Story;
+
+function renderItem(item: Story) {
+    return render(
+        <SettingsProvider>
+            <MemoryRouter>
+                <Item item={item} />
+            </MemoryRouter>
+        </SettingsProvider>
+    );
+}
+
+describe('Item', () => {
+    it('links external stories to their url and shows the domain', () => {
+        renderItem(story);
+
+        expect(screen.getByRole('link', { name: 'A story' })).toHaveAttribute('href', 'https://example.com/story');
+        expect(screen.getByText('(example.com)')).toBeInTheDocument();
+        expect(screen.getAllByText('1 comment').length).toBeGreaterThan(0);
+    });
+
+    it('links internal stories to the item page', () => {
+        renderItem({ ...story, url: 'item?id=1' });
+
+        expect(screen.getByRole('link', { name: 'A story' })).toHaveAttribute('href', '/item/1');
+    });
+
+    it('hides points and comments for jobs', () => {
+        renderItem({ ...story, type: 'job' });
+
+        expect(screen.queryByText('pg')).not.toBeInTheDocument();
+        expect(screen.queryByText('1 comment')).not.toBeInTheDocument();
+    });
+});

--- a/src/components/feeds/Item.tsx
+++ b/src/components/feeds/Item.tsx
@@ -1,0 +1,77 @@
+import { Link } from 'react-router-dom';
+
+import { useSettings } from '../../context/SettingsContext';
+import type { Story } from '../../models/story';
+import { commentCount } from '../../utils/comment';
+import './Item.scss';
+
+export default function Item({ item }: { item: Story }) {
+    const { settings } = useSettings();
+    const hasUrl = item.url ? item.url.indexOf('http') === 0 : false;
+    const target = settings.openLinkInNewTab ? '_blank' : undefined;
+    const rel = settings.openLinkInNewTab ? 'noopener' : undefined;
+
+    return (
+        <div className="c-item" style={{ marginBottom: `${settings.listSpacing}px` }}>
+            {hasUrl ? (
+                <p>
+                    <a
+                        className="title"
+                        style={{ fontSize: `${settings.titleFontSize}px` }}
+                        href={item.url}
+                        target={target}
+                        rel={rel}
+                    >
+                        {item.title}
+                    </a>
+                    {item.domain && <span className="domain">({item.domain})</span>}
+                </p>
+            ) : (
+                <p>
+                    <Link
+                        className="title"
+                        style={{ fontSize: `${settings.titleFontSize}px` }}
+                        to={`/item/${item.id}`}
+                    >
+                        {item.title}
+                    </Link>
+                </p>
+            )}
+            <div className="subtext-palm">
+                {item.type !== 'job' && (
+                    <div className="details">
+                        <span className="name">
+                            <Link to={`/user/${item.user}`}>{item.user}</Link>
+                        </span>
+                        <span className="right">{item.points} ★</span>
+                    </div>
+                )}
+                <div className="details">
+                    {item.time_ago}
+                    {item.type !== 'job' && (
+                        <Link to={`/item/${item.id}`} className="comment-number">
+                            {' '}
+                            • {commentCount(item.comments_count)}
+                        </Link>
+                    )}
+                </div>
+            </div>
+            <div className="subtext-laptop">
+                {item.type !== 'job' && (
+                    <span>
+                        {item.points} points by <Link to={`/user/${item.user}`}>{item.user}</Link>
+                    </span>
+                )}
+                <span className={item.type !== 'job' ? 'item-details' : undefined}>
+                    {item.time_ago}
+                    {item.type !== 'job' && (
+                        <span>
+                            {' | '}
+                            <Link to={`/item/${item.id}`}>{commentCount(item.comments_count)}</Link>
+                        </span>
+                    )}
+                </span>
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary

Ports `src/app/feeds/` and wires up routing: `/` redirects to `/news/1`, and `news|newest|show|ask|jobs` share one `Feed` component parameterised by feed type, matching `app.routes.ts`.

- `Feed` replaces the RxJS subscription with a `useEffect` fetch keyed on feed type and `useParams().page`, aborting the in-flight request on change so a fast page switch can't render stale stories.
- `Item` keeps the Angular template's link semantics exactly, including `[attr.target]="openLinkInNewTab ? '_blank' : null"` → `target={settings.openLinkInNewTab ? '_blank' : undefined}`, and the job-type branch that omits points and comments.
- `Feed.scss`'s bare `a { font-weight: bold }` is narrowed to `.job-header a, .nav a`. Under Angular it applied only inside the feed template; imported globally it would have bolded every story title rendered by `Item`.
- Vitest/RTL tests cover pagination link state, the error path, and item link behavior.

## Proposed fixes
- Add `Feed.tsx` / `Item.tsx` with stylesheets and tests.
- Add the redirect and five feed routes to `App`.


Link to Devin session: https://app.devin.ai/sessions/a3a0ff57bab64e25860349a003a282ef
Open in Devin Desktop: https://app.devin.ai/desktop/session/a3a0ff57bab64e25860349a003a282ef?variant=devin
Requested by: @devanshi-gpta