### PR TITLE
[5/7] React migration: lazy ItemDetails route and recursive Comment component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,14 @@
+import { lazy, Suspense } from 'react';
 import { Navigate, Route, Routes } from 'react-router-dom';
 
 import Footer from './components/core/Footer';
 import Header from './components/core/Header';
 import Feed from './components/feeds/Feed';
+import Loader from './components/shared/Loader';
 import { useSettings } from './context/SettingsContext';
 import './App.scss';
+
+const ItemDetails = lazy(() => import('./components/item-details/ItemDetails'));
 
 const feedTypes = ['news', 'newest', 'show', 'ask', 'jobs'];
 
@@ -16,16 +20,19 @@ export default function App() {
             <div className="body-cover"></div>
             <div className="wrapper">
                 <Header />
-                <Routes>
-                    <Route path="/" element={<Navigate to="/news/1" replace />} />
-                    {feedTypes.map((feedType) => (
-                        <Route
-                            key={feedType}
-                            path={`/${feedType}/:page`}
-                            element={<Feed feedType={feedType} />}
-                        />
-                    ))}
-                </Routes>
+                <Suspense fallback={<Loader />}>
+                    <Routes>
+                        <Route path="/" element={<Navigate to="/news/1" replace />} />
+                        {feedTypes.map((feedType) => (
+                            <Route
+                                key={feedType}
+                                path={`/${feedType}/:page`}
+                                element={<Feed feedType={feedType} />}
+                            />
+                        ))}
+                        <Route path="/item/:id" element={<ItemDetails />} />
+                    </Routes>
+                </Suspense>
                 <Footer />
             </div>
         </div>

--- a/src/components/item-details/Comment.scss
+++ b/src/components/item-details/Comment.scss
@@ -1,0 +1,85 @@
+@use "../../app/shared/scss/media" as *;
+@use "../../app/shared/scss/theme_variables" as *;
+
+.c-comment {
+  a {
+    font-weight: bold;
+    text-decoration: none;
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  .meta {
+    font-size: 13px;
+    color: #696969;
+    font-weight: bold;
+    letter-spacing: 0.5px;
+    margin-bottom: 8px;
+    a {
+      text-decoration: none;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+    .time {
+      padding-left: 5px;
+    }
+  }
+
+  @media #{$mobile-only} {
+    .meta {
+      font-size: 14px;
+      margin-bottom: 10px;
+      .time {
+        padding: 0;
+        float: right;
+      }
+    }
+  }
+
+  .meta-collapse {
+    margin-bottom: 20px;
+  }
+
+  .deleted-meta {
+    font-size: 12px;
+    font-weight: bold;
+    letter-spacing: 0.5px;
+    margin: 30px 0;
+    a {
+      text-decoration: none;
+    }
+  }
+
+  .collapse {
+    font-size: 13px;
+    letter-spacing: 2px;
+    cursor: pointer;
+  }
+
+  .comment-tree {
+    margin-left: 24px;
+  }
+
+  @media #{$tablet-only} {
+    .comment-tree {
+      margin-left: 8px;
+    }
+  }
+
+  .comment-text {
+    font-size: 15px;
+    margin-top: 0;
+    margin-bottom: 20px;
+    word-wrap: break-word;
+    line-height: 1.5em;
+  }
+
+  .subtree {
+    margin-left: 0;
+    padding: 0;
+    list-style-type: none;
+  }
+}

--- a/src/components/item-details/Comment.test.tsx
+++ b/src/components/item-details/Comment.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+
+import type { Comment as CommentModel } from '../../models/comment';
+import Comment from './Comment';
+
+const comment = {
+    id: 1,
+    user: 'pg',
+    time_ago: '1 hour ago',
+    content: '<p>parent</p>',
+    deleted: false,
+    comments: [
+        { id: 2, user: 'kn', time_ago: '30 minutes ago', content: '<p>child</p>', deleted: false, comments: [] },
+    ],
+} as unknown as CommentModel;
+
+describe('Comment', () => {
+    it('renders nested comments and toggles collapse', async () => {
+        render(
+            <MemoryRouter>
+                <Comment comment={comment} />
+            </MemoryRouter>
+        );
+
+        expect(screen.getByText('child')).toBeInTheDocument();
+
+        await userEvent.click(screen.getAllByText('[-]')[0]);
+
+        expect(screen.getAllByText('[+]')[0]).toBeInTheDocument();
+        expect(screen.getByText('child').closest('div[hidden]')).not.toBeNull();
+    });
+
+    it('renders a placeholder for deleted comments', () => {
+        render(
+            <MemoryRouter>
+                <Comment comment={{ ...comment, deleted: true }} />
+            </MemoryRouter>
+        );
+
+        expect(screen.getByText('[deleted]')).toBeInTheDocument();
+    });
+});

--- a/src/components/item-details/Comment.tsx
+++ b/src/components/item-details/Comment.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+
+import type { Comment as CommentModel } from '../../models/comment';
+import './Comment.scss';
+
+export default function Comment({ comment }: { comment: CommentModel }) {
+    const [collapse, setCollapse] = useState(false);
+
+    if (comment.deleted) {
+        return (
+            <div className="c-comment">
+                <div className="deleted-meta">
+                    <span className="collapse">[deleted]</span> | Comment Deleted
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="c-comment">
+            <div className={`meta${collapse ? ' meta-collapse' : ''}`}>
+                <span className="collapse" onClick={() => setCollapse(!collapse)}>
+                    [{collapse ? '+' : '-'}]
+                </span>{' '}
+                <Link to={`/user/${comment.user}`}>{comment.user}</Link>
+                <span className="time">{comment.time_ago}</span>
+            </div>
+            <div className="comment-tree">
+                <div hidden={collapse}>
+                    <p className="comment-text" dangerouslySetInnerHTML={{ __html: comment.content }}></p>
+                    <ul className="subtree">
+                        {comment.comments.map((subComment) => (
+                            <li key={subComment.id}>
+                                <Comment comment={subComment} />
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/item-details/ItemDetails.scss
+++ b/src/components/item-details/ItemDetails.scss
@@ -1,0 +1,153 @@
+@use "../../app/shared/scss/media" as *;
+@use "../../app/shared/scss/theme_variables" as *;
+
+.c-item-details {
+  .main-content {
+    position: relative;
+    width: 100%;
+    min-height: 100vh;
+    -webkit-transition: opacity .2s ease;
+    transition: opacity .2s ease;
+    box-sizing: border-box;
+    padding: 8px 0;
+    z-index: 0;
+  }
+
+  .item {
+    box-sizing: border-box;
+    padding: 10px 40px 0 40px;
+    z-index: 0;
+  }
+
+  @media #{$tablet-only} {
+    .item {
+      padding: 10px 20px 0 40px;
+    }
+  }
+
+  @media #{$mobile-only} {
+    .item {
+      box-sizing: border-box;
+      padding: 110px 15px 0 15px;
+    }
+  }
+
+  .head-margin {
+    margin-bottom: 15px;
+  }
+
+  p {
+    margin: 2px 0;
+  }
+
+  .subject {
+    word-wrap: break-word;
+    margin-top: 20px;
+  }
+
+  a {
+    cursor: pointer;
+    text-decoration: none;
+  }
+
+  @media #{$mobile-only} {
+    .laptop {
+      display: none;
+    }
+  }
+
+  @media #{$laptop-only} {
+    .mobile {
+      display: none;
+    }
+  }
+
+  .title {
+    font-size: 16px;
+    font-family: Verdana, Geneva, sans-serif;
+  }
+
+  .title-block {
+    text-align: center;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    margin: 0 75px;
+  }
+
+  @media #{$mobile-only} {
+    .title {
+      font-size: 15px;
+    }
+    .back-button {
+      position: absolute;
+      top: 52%;
+      width: 0.6rem;
+      height: 0.6rem;
+      background: transparent;
+      box-shadow: 0 0 0 lightgray;
+      transition: all 200ms ease;
+      left: 4%;
+      transform: translate3d(0, -50%, 0) rotate(-135deg);
+    }
+  }
+
+  .subtext {
+    font-size: 12px;
+    font-weight: bold;
+    letter-spacing: 0.5px;
+  }
+
+  .domain {
+    letter-spacing: 0.5px;
+  }
+
+  .subtext a {
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  .item-details {
+    padding: 10px;
+  }
+
+  .item-header {
+    padding-bottom: 10px;
+  }
+
+  @media #{$mobile-only} {
+    .item-header {
+      padding: 10px 0 10px 0;
+      position: fixed;
+      width: 100%;
+      left: 0;
+      top: 62px;
+    }
+  }
+
+  .pollResults {
+    margin-bottom: 1em;
+  }
+
+  .pollContent {
+    * {
+      padding-bottom: 0;
+      margin-bottom: -1em;
+      margin-top: 1em;
+    }
+    .pollBar {
+      height: 10px;
+      margin-bottom: 1em;
+    }
+  }
+
+  ul {
+    list-style-type: none;
+    padding: 10px 0;
+  }
+
+  li {
+    display: list-item;
+  }
+}

--- a/src/components/item-details/ItemDetails.tsx
+++ b/src/components/item-details/ItemDetails.tsx
@@ -1,0 +1,127 @@
+import { useEffect, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+
+import { useSettings } from '../../context/SettingsContext';
+import type { Story } from '../../models/story';
+import { fetchItemContent } from '../../services/hackernews-api';
+import { commentCount } from '../../utils/comment';
+import ErrorMessage from '../shared/ErrorMessage';
+import Loader from '../shared/Loader';
+import Comment from './Comment';
+import './ItemDetails.scss';
+
+export default function ItemDetails() {
+    const { id } = useParams<{ id: string }>();
+    const navigate = useNavigate();
+    const { settings } = useSettings();
+    const [item, setItem] = useState<Story | null>(null);
+    const [errorMessage, setErrorMessage] = useState('');
+
+    useEffect(() => {
+        const controller = new AbortController();
+        setItem(null);
+        setErrorMessage('');
+
+        fetchItemContent(Number(id), controller.signal)
+            .then(setItem)
+            .catch((error: unknown) => {
+                if (!controller.signal.aborted) {
+                    setErrorMessage('Could not load item comments.');
+                    console.error(error);
+                }
+            });
+
+        window.scrollTo(0, 0);
+        return () => controller.abort();
+    }, [id]);
+
+    const hasUrl = item && item.url ? item.url.indexOf('http') === 0 : false;
+    const target = settings.openLinkInNewTab ? '_blank' : undefined;
+    const rel = settings.openLinkInNewTab ? 'noopener' : undefined;
+
+    return (
+        <div className="c-item-details main-content">
+            {!item && !errorMessage && <Loader />}
+            {!item && errorMessage !== '' && <ErrorMessage message={errorMessage} />}
+
+            {item && (
+                <div className="item">
+                    <div className="mobile item-header">
+                        <p className="title-block">
+                            <span className="back-button" onClick={() => navigate(-1)}></span>
+                            {hasUrl ? (
+                                <a className="title" href={item.url} target={target} rel={rel}>
+                                    {item.title}
+                                </a>
+                            ) : (
+                                <Link className="title" to={`/item/${item.id}`}>
+                                    {item.title}
+                                </Link>
+                            )}
+                        </p>
+                    </div>
+                    <div
+                        className={
+                            'laptop' +
+                            (item.comments_count > 0 || item.type === 'job' ? ' item-header' : '') +
+                            (item.text ? ' head-margin' : '')
+                        }
+                    >
+                        {hasUrl ? (
+                            <p>
+                                <a className="title" href={item.url} target={target} rel={rel}>
+                                    {item.title}
+                                </a>
+                                {item.domain && <span className="domain">({item.domain})</span>}
+                            </p>
+                        ) : (
+                            <p>
+                                <Link className="title" to={`/item/${item.id}`}>
+                                    {item.title}
+                                </Link>
+                            </p>
+                        )}
+                        <div className="subtext">
+                            {item.type !== 'job' && (
+                                <span>
+                                    {item.points} points by <Link to={`/user/${item.user}`}>{item.user}</Link>
+                                </span>
+                            )}
+                            <span className={item.type !== 'job' ? 'item-details' : undefined}>
+                                {item.time_ago}
+                                {item.type !== 'job' && (
+                                    <span>
+                                        {' | '}
+                                        <Link to={`/item/${item.id}`}>{commentCount(item.comments_count)}</Link>
+                                    </span>
+                                )}
+                            </span>
+                        </div>
+                    </div>
+                    {item.type === 'poll' && (
+                        <div className="pollResults">
+                            {item.poll.map((pollResult, index) => (
+                                <div key={index} className="pollContent">
+                                    <div dangerouslySetInnerHTML={{ __html: pollResult.content }}></div>
+                                    <div className="subtext">{pollResult.points} points</div>
+                                    <div
+                                        className="pollBar"
+                                        style={{ width: `${(pollResult.points / item.poll_votes_count) * 100}%` }}
+                                    ></div>
+                                </div>
+                            ))}
+                        </div>
+                    )}
+                    <p className="subject" dangerouslySetInnerHTML={{ __html: item.content }}></p>
+                    <ul className="comment-list">
+                        {item.comments.map((comment) => (
+                            <li key={comment.id}>
+                                <Comment comment={comment} />
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            )}
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary

Ports `src/app/item-details/` and adds `/item/:id`. The Angular `ItemDetailsModule` was lazy-loaded via `loadChildren`; the equivalent here is `React.lazy` plus a `Suspense` boundary around the routes that falls back to `Loader`, so the bundle split and loading state are preserved.

- `CommentComponent`'s self-recursion becomes a component that renders its own children, with `collapse` as `useState` instead of a template variable.
- `[innerHTML]` on comment/story content becomes `dangerouslySetInnerHTML`. The upstream API already returns sanitized HTML, which is what the Angular template relied on.
- Mobile back navigation swaps Angular's `Location.back()` for `useNavigate()(-1)`.
- Poll rendering keeps the percentage-width bars driven by `poll_votes_count` computed in the API module.

## Proposed fixes
- Add `ItemDetails.tsx` / `Comment.tsx` with stylesheets and a recursion/collapse test.
- Add the lazy `/item/:id` route and the `Suspense` boundary to `App`.


Link to Devin session: https://app.devin.ai/sessions/a3a0ff57bab64e25860349a003a282ef
Open in Devin Desktop: https://app.devin.ai/desktop/session/a3a0ff57bab64e25860349a003a282ef?variant=devin
Requested by: @devanshi-gpta