### PR TITLE
[6/7] React migration: lazy UserProfile route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { useSettings } from './context/SettingsContext';
 import './App.scss';
 
 const ItemDetails = lazy(() => import('./components/item-details/ItemDetails'));
+const UserProfile = lazy(() => import('./components/user/UserProfile'));
 
 const feedTypes = ['news', 'newest', 'show', 'ask', 'jobs'];
 
@@ -31,6 +32,7 @@ export default function App() {
                             />
                         ))}
                         <Route path="/item/:id" element={<ItemDetails />} />
+                        <Route path="/user/:id" element={<UserProfile />} />
                     </Routes>
                 </Suspense>
                 <Footer />

--- a/src/components/user/UserProfile.scss
+++ b/src/components/user/UserProfile.scss
@@ -1,0 +1,91 @@
+@use "../../app/shared/scss/media" as *;
+@use "../../app/shared/scss/theme_variables" as *;
+
+.c-user {
+  pre {
+    white-space: pre-wrap;
+  }
+
+  .profile {
+    padding: 30px;
+  }
+
+  @media #{$mobile-only} {
+    .profile {
+      padding: 110px 15px 0 15px;
+    }
+    .title-block {
+      font-size: 15px;
+      text-align: center;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      overflow: hidden;
+      margin: 0 75px;
+    }
+    .back-button {
+      position: absolute;
+      top: 52%;
+      width: 0.6rem;
+      height: 0.6rem;
+      background: transparent;
+      box-shadow: 0 0 0 lightgray;
+      transition: all 200ms ease;
+      left: 4%;
+      transform: translate3d(0, -50%, 0) rotate(-135deg);
+    }
+    .item-header {
+      padding-bottom: 10px;
+      background-color: #fff;
+      padding: 10px 0 10px 0;
+      position: fixed;
+      width: 100%;
+      left: 0;
+      top: 62px;
+      height: 20px;
+    }
+  }
+
+  @media #{$laptop-only} {
+    .mobile {
+      display: none;
+    }
+  }
+
+  .main-details {
+    .name {
+      font-weight: bold;
+      font-size: 32px;
+      letter-spacing: 2px;
+    }
+    .age {
+      font-weight: bold;
+      color: #696969;
+      padding-bottom: 0;
+    }
+    .right {
+      float: right;
+      font-weight: bold;
+      font-size: 32px;
+      letter-spacing: 2px;
+    }
+  }
+
+  @media #{$mobile-only} {
+    .main-details {
+      margin-top: 20px;
+      .name {
+        font-size: 18px;
+      }
+    }
+  }
+
+  @media #{$mobile-only} {
+    .main-details .right {
+      font-size: 18px;
+    }
+  }
+
+  .other-details {
+    word-wrap: break-word;
+  }
+}

--- a/src/components/user/UserProfile.tsx
+++ b/src/components/user/UserProfile.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+
+import type { User } from '../../models/user';
+import { fetchUser } from '../../services/hackernews-api';
+import ErrorMessage from '../shared/ErrorMessage';
+import Loader from '../shared/Loader';
+import './UserProfile.scss';
+
+export default function UserProfile() {
+    const { id } = useParams<{ id: string }>();
+    const navigate = useNavigate();
+    const [user, setUser] = useState<User | null>(null);
+    const [errorMessage, setErrorMessage] = useState('');
+
+    useEffect(() => {
+        const controller = new AbortController();
+        setUser(null);
+        setErrorMessage('');
+
+        fetchUser(id as string, controller.signal)
+            .then(setUser)
+            .catch((error: unknown) => {
+                if (!controller.signal.aborted) {
+                    setErrorMessage('Could not load user ' + id + '.');
+                    console.error(error);
+                }
+            });
+
+        return () => controller.abort();
+    }, [id]);
+
+    return (
+        <>
+            {!user && !errorMessage && <Loader />}
+            {!user && errorMessage !== '' && <ErrorMessage message={errorMessage} />}
+
+            {user && (
+                <div className="c-user profile">
+                    <div className="mobile item-header">
+                        <p className="title-block">
+                            <span className="back-button" onClick={() => navigate(-1)}></span>
+                            Profile: {user.id}
+                        </p>
+                    </div>
+                    <div className="main-details">
+                        <span className="name">{user.id}</span>
+                        <span className="right">{user.karma} ★</span>
+                        <p className="age">Created {user.created}</p>
+                    </div>
+                    {user.about && (
+                        <div className="other-details">
+                            <p dangerouslySetInnerHTML={{ __html: user.about }}></p>
+                        </div>
+                    )}
+                </div>
+            )}
+        </>
+    );
+}


### PR DESCRIPTION
## Summary

Ports `src/app/user/` to `components/user/UserProfile.tsx` and adds the lazy `/user/:id` route, mirroring the Angular `UserModule` lazy load. Fetch/abort and error handling follow the same pattern as `Feed`.

Worth knowing before reviewing the runtime behavior: the upstream endpoint this view depends on, `https://node-hnapi.herokuapp.com/user/:id`, no longer exists and responds 404 with an HTML body. That is equally true of the Angular version — the URL is unchanged — so the view renders its error state rather than a profile until the app moves to a different API. The API module rejects on `!response.ok`, so the failure surfaces as the component's error message instead of a `SyntaxError` from parsing HTML as JSON.

## Proposed fixes
- Add `UserProfile.tsx` / `UserProfile.scss`.
- Add the lazy `/user/:id` route to `App`.


Link to Devin session: https://app.devin.ai/sessions/a3a0ff57bab64e25860349a003a282ef
Open in Devin Desktop: https://app.devin.ai/desktop/session/a3a0ff57bab64e25860349a003a282ef?variant=devin
Requested by: @devanshi-gpta