### PR TITLE
PR 2/10 — Port shared models and SCSS

### DIFF
--- a/react-app/src/main.tsx
+++ b/react-app/src/main.tsx
@@ -3,6 +3,8 @@ import { createRoot } from 'react-dom/client';
 
 import App from './App';
 
+import './styles/styles.scss';
+
 createRoot(document.getElementById('root')!).render(
     <StrictMode>
         <App />

--- a/react-app/src/models/comment.ts
+++ b/react-app/src/models/comment.ts
@@ -1,0 +1,10 @@
+export interface Comment {
+    id: number;
+    level: number;
+    user: string;
+    time: number;
+    time_ago: string;
+    content: string;
+    deleted?: boolean;
+    comments: Comment[];
+}

--- a/react-app/src/models/feed-type.type.ts
+++ b/react-app/src/models/feed-type.type.ts
@@ -1,0 +1,1 @@
+export type FeedType = 'poll' | 'story' | 'job';

--- a/react-app/src/models/poll-result.ts
+++ b/react-app/src/models/poll-result.ts
@@ -1,0 +1,4 @@
+export interface PollResult {
+    points: number;
+    content: string;
+}

--- a/react-app/src/models/settings.ts
+++ b/react-app/src/models/settings.ts
@@ -1,0 +1,7 @@
+export interface Settings {
+    showSettings: boolean;
+    openLinkInNewTab: boolean;
+    theme: string;
+    titleFontSize: string;
+    listSpacing: string;
+}

--- a/react-app/src/models/story.ts
+++ b/react-app/src/models/story.ts
@@ -1,0 +1,23 @@
+import type { Comment } from './comment';
+import type { FeedType } from './feed-type.type';
+import type { PollResult } from './poll-result';
+
+export interface Story {
+    id: number;
+    title: string;
+    points: number;
+    user: string;
+    time: number;
+    time_ago: number;
+    type: FeedType;
+    url?: string;
+    domain?: string;
+    comments?: Comment[];
+    comments_count: number;
+    poll?: PollResult[];
+    poll_votes_count?: number;
+    deleted?: boolean;
+    dead?: boolean;
+    content?: string;
+    text?: string;
+}

--- a/react-app/src/models/user.ts
+++ b/react-app/src/models/user.ts
@@ -1,0 +1,8 @@
+export interface User {
+    id: string;
+    crated_time: number;
+    created: string;
+    karma: number;
+    avg: number;
+    about?: string;
+}

--- a/react-app/src/styles/_media.scss
+++ b/react-app/src/styles/_media.scss
@@ -1,0 +1,3 @@
+$mobile-only: "only screen and (max-width : 768px)";
+$laptop-only: "only screen and (min-width : 769px)";
+$tablet-only: "only screen and (max-width : 1024px)";

--- a/react-app/src/styles/_theme_variables.scss
+++ b/react-app/src/styles/_theme_variables.scss
@@ -1,0 +1,37 @@
+$skull-size: 200px;
+
+// -------------------------------------------------------------------------------------------
+// Theme Engine
+// -------------------------------------------------------------------------------------------
+
+// Day theme colors
+$theme-day-body-background-color: #fff;
+$theme-day-wrapper-background-color: #f5f5f5;
+$theme-day-wrapper-mobile-background-color: #fff;
+$theme-day-text-color: #000;
+$theme-day-subtext-color: #696969;
+$theme-day-secondary-color: #b92b27;
+$theme-day-header-background-color: $theme-day-secondary-color;
+$theme-day-logo-inner: #fff;
+
+// Day theme extras
+$theme-day-border: 2px solid #b92b27;
+
+// Night theme colors
+$theme-night-body-background-color: #37474F;
+$theme-night-wrapper-background-color: #263238;
+$theme-night-wrapper-mobile-background-color: $theme-night-wrapper-background-color;
+$theme-night-text-color: rgba(255, 255, 255, 0.7);
+$theme-night-subtext-color: #999;
+$theme-night-secondary-color: #00c0ff;
+$theme-night-header-background-color: #263238;
+$theme-night-logo-inner: $theme-night-header-background-color;
+
+// Night theme extras
+$theme-night-border: 2px solid #00c0ff;
+
+// Black theme colors
+$theme-amoledblack-body-background-color: #000;
+$theme-amoledblack-text-color: rgba(255, 255, 255, 0.75);
+$theme-amoledblack-subtext-color: rgba(255, 255, 255, 0.5);
+$theme-amoledblack-secondary-color: rgba(255, 255, 255, 0.6);

--- a/react-app/src/styles/_themes.scss
+++ b/react-app/src/styles/_themes.scss
@@ -1,0 +1,245 @@
+@import "./media";
+@import "./theme_variables";
+
+/* ----------------------------------
+
+  Want a new theme? Add your new theme variables here!
+
+---------------------------------- */
+
+@mixin theme(
+  $name,
+  $body-background-color,
+  $wrapper-background-color,
+  $wrapper-mobile-background-color,
+  $wrapper-color,
+  $item-a-color,
+  $item-a-visited-color,
+  $header-background-color,
+  $subtext-color,
+  $secondary-link-color,
+  $logo-inner-color,
+  $border
+) {
+  .#{$name} {
+    .body-cover {
+      background: $body-background-color;
+
+      @media #{$mobile-only} {
+       background: $wrapper-mobile-background-color;
+      }
+    }
+
+    .wrapper {
+      background: $wrapper-background-color;
+      color: $wrapper-color;
+
+      @media #{$mobile-only} {
+       background: $wrapper-mobile-background-color;
+      }
+
+      a {
+        color: $item-a-color;
+
+        &:visited {
+            color: $item-a-visited-color;
+        }
+      }
+
+      #header {
+        background: $header-background-color;
+        border-bottom: $border;
+      }
+
+      .logo-inner {
+        background: $logo-inner-color;
+      }
+
+      .nav {
+        a {
+          color: $secondary-link-color;
+
+          @media #{$mobile-only} {
+            color: $secondary-link-color;
+          }
+        }
+      }
+
+      #footer {
+        border-top: $border;
+
+        a {
+          color: $secondary-link-color;
+        }
+      }
+
+      .subtext, .subtext-palm, .subtext-laptop, .domain, .meta, .deleted-meta{
+        color: $subtext-color;
+
+        a {
+          color: $secondary-link-color;
+        }
+      }
+
+      .popup {
+        background: $header-background-color;
+      }
+
+      .item-header {
+        border-bottom: $border;
+
+        @media #{$mobile-only} {
+          background: $wrapper-mobile-background-color;
+        }
+      }
+
+      .pollContent {
+        .pollBar {
+          background: $secondary-link-color;
+        }
+      }
+
+      .loader {
+        color: $secondary-link-color;
+        background: $secondary-link-color;
+
+        &:before, &:after {
+          background: $secondary-link-color;
+        }
+      }
+
+      .job-header {
+        @media #{$mobile-only} {
+          border-bottom: $border;
+        }
+      }
+
+      .back-button {
+        @media #{$mobile-only} {
+          border-top: .3rem solid $secondary-link-color;
+          border-right: .3rem solid $secondary-link-color;
+        }
+      }
+
+      .error-section {
+        .skull {
+          .head {
+            background-color: $secondary-link-color;
+
+            &:before, &:after {
+              background-color: $wrapper-background-color;
+
+              @media #{$mobile-only} {
+                background-color: $wrapper-mobile-background-color;
+              }
+            }
+
+            .crack {
+              background-color: $wrapper-background-color;
+
+              @media #{$mobile-only} {
+                background-color: $wrapper-mobile-background-color;
+              }
+
+              &:before {
+                border-top: $skull-size / 8 solid $wrapper-background-color;
+
+                @media #{$mobile-only} {
+                  border-top: $skull-size / 8 solid $wrapper-mobile-background-color;
+                }
+              }
+            }
+          }
+
+          .mouth {
+            background-color: $secondary-link-color;
+
+            &:before {
+              background-color: $wrapper-background-color;
+
+              @media #{$mobile-only} {
+                background-color: $wrapper-mobile-background-color;
+              }
+            }
+          }
+
+          .teeth {
+            background-color: $wrapper-background-color;
+
+            @media #{$mobile-only} {
+              background-color: $wrapper-mobile-background-color;
+            }
+
+            &:before, &:after {
+              background-color: $wrapper-background-color;
+
+              @media #{$mobile-only} {
+                background-color: $wrapper-mobile-background-color;
+              }
+            }
+          }
+        }
+      }
+
+      .main-details {
+        .name {
+          color: $secondary-link-color;
+        }
+        .right {
+          color: $secondary-link-color;
+        }
+      }
+    }
+  }
+}
+
+@include theme(
+  default,
+  $theme-day-body-background-color,
+  $theme-day-wrapper-background-color,
+  $theme-day-wrapper-mobile-background-color,
+  $theme-day-text-color,
+  $theme-day-text-color,
+  $theme-day-subtext-color,
+  $theme-day-header-background-color,
+  $theme-day-subtext-color,
+  $theme-day-secondary-color,
+  $theme-day-logo-inner,
+  $theme-day-border
+);
+
+@include theme(
+  night,
+  $theme-night-body-background-color,
+  $theme-night-wrapper-background-color,
+  $theme-night-wrapper-mobile-background-color,
+  $theme-night-text-color,
+  $theme-night-text-color,
+  $theme-night-subtext-color,
+  $theme-night-header-background-color,
+  $theme-night-subtext-color,
+  $theme-night-secondary-color,
+  $theme-night-logo-inner,
+  $theme-night-border
+);
+
+@include theme(
+  amoledblack,
+  $theme-amoledblack-body-background-color,
+  $theme-amoledblack-body-background-color,
+  $theme-amoledblack-body-background-color,
+  $theme-amoledblack-text-color,
+  $theme-amoledblack-text-color,
+  darken($theme-amoledblack-text-color, 33%),
+  $theme-amoledblack-body-background-color,
+  $theme-amoledblack-subtext-color,
+  $theme-amoledblack-secondary-color,
+  $theme-amoledblack-body-background-color,
+  $theme-amoledblack-secondary-color
+);
+
+/* ----------------------------------
+
+  Include your new theme here as well as the settings component
+
+---------------------------------- */

--- a/react-app/src/styles/styles.scss
+++ b/react-app/src/styles/styles.scss
@@ -1,0 +1,43 @@
+@import "./themes";
+
+html {
+  height: 100%;
+  width: 100%;
+}
+
+body {
+  margin: 0;
+  height: 100%;
+  width: 100%;
+}
+
+pre {
+    white-space: pre-wrap;
+}
+
+.app-loader {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0;
+    position: fixed;
+    height: 100%;
+    width: 100%;
+    top: 0;
+    left: 0;
+    z-index: -1;
+}
+
+@media screen and (max-width: 768px) {
+  .app-loader {
+    background-color: #fff;
+  }
+}
+
+#root:empty + .app-loader {
+    opacity: 1;
+    z-index: 100;
+}
+#root:empty + .app-loader .logo {
+    width: 20vh;
+}

--- a/react-app/vite.config.ts
+++ b/react-app/vite.config.ts
@@ -8,5 +8,6 @@ export default defineConfig({
         environment: 'jsdom',
         globals: true,
         setupFiles: './src/test-setup.ts',
+        passWithNoTests: true,
     },
 });


### PR DESCRIPTION
## Summary

Part of the Angular -> React migration chain; based on `devin-09.08.2026-devanshi/scaffold-react-vite-app`. Types-and-styles only — no components or logic.

- `src/app/shared/models/*.ts` -> `react-app/src/models/`, converted from classes to `interface`s (they were used purely as types); `FeedType` stays a string-literal union. Field names/types unchanged, except `Story` gains the optional `content` and `text` fields the Angular templates read (`item.content` / `item.text`), and fields the HN API omits are optional (`Story.url|domain|comments|poll|poll_votes_count|deleted|dead`, `Comment.deleted`, `User.about`). `Story.time_ago: number` is kept verbatim from the Angular model even though the API returns a string, to avoid behavioural drift in this PR.
- `_media.scss`, `_theme_variables.scss`, `_themes.scss` copied unchanged into `react-app/src/styles/` (their relative `@import`s still resolve). `src/styles.scss` -> `react-app/src/styles/styles.scss` with the import repointed to `./themes` and the Angular-only host selectors swapped for the React root:

```diff
-@import "./app/shared/scss/themes";
+@import "./themes";
-app-root:empty + .app-loader { ... }
+#root:empty + .app-loader { ... }
```

- `main.tsx` imports `./styles/styles.scss` globally (not CSS Modules, so theme class names stay global).

## Proposed fixes

- `vite.config.ts`: `test.passWithNoTests: true` — the scaffold has a vitest setup but no spec files yet, so `npm test` exited 1 on the base branch; later PRs in the chain add real tests.
- Sass emits deprecation warnings for `@import` / `darken()` from the copied theme files; left as-is to keep the copy faithful, worth a follow-up to move to `@use` / `color.adjust`.

Verified in `react-app/`: `npm run typecheck`, `npm run lint`, `npm test`, `npm run build` all pass.


Link to Devin session: https://app.devin.ai/sessions/09c4d1e3aa4f4f928ab6f6b0ac47ee03
Open in Devin Desktop: https://app.devin.ai/desktop/session/09c4d1e3aa4f4f928ab6f6b0ac47ee03?variant=devin
Requested by: @devanshi-gpta