### PR TITLE
PR 3/10 — Port Hacker News data layer to fetch + useFetch hook

### DIFF
--- a/react-app/src/hooks/useFetch.ts
+++ b/react-app/src/hooks/useFetch.ts
@@ -1,0 +1,53 @@
+import { useEffect, useState } from 'react';
+
+export interface FetchState<T> {
+    data: T | null;
+    error: Error | null;
+    loading: boolean;
+}
+
+function isAbortError(error: unknown): boolean {
+    return error instanceof DOMException && error.name === 'AbortError';
+}
+
+export function useFetch<T>(
+    fetcher: (signal: AbortSignal) => Promise<T>,
+    deps: unknown[]
+): FetchState<T> {
+    const [state, setState] = useState<FetchState<T>>({
+        data: null,
+        error: null,
+        loading: true,
+    });
+
+    // oxlint-disable-next-line react-hooks/exhaustive-deps -- deps are supplied by the caller
+    useEffect(() => {
+        const controller = new AbortController();
+        let cancelled = false;
+        setState({ data: null, error: null, loading: true });
+
+        fetcher(controller.signal)
+            .then((data) => {
+                if (!cancelled) {
+                    setState({ data, error: null, loading: false });
+                }
+            })
+            .catch((error: unknown) => {
+                if (cancelled || isAbortError(error)) {
+                    return;
+                }
+                setState({
+                    data: null,
+                    error: error instanceof Error ? error : new Error(String(error)),
+                    loading: false,
+                });
+            });
+
+        return () => {
+            cancelled = true;
+            controller.abort();
+        };
+    }, deps);
+
+    return state;
+}

--- a/react-app/src/services/hackernews-api.test.ts
+++ b/react-app/src/services/hackernews-api.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { fetchFeed, fetchItemContent } from './hackernews-api';
+
+function jsonResponse(body: unknown, ok = true, status = 200): Response {
+    return {
+        ok,
+        status,
+        json: () => Promise.resolve(body),
+    } as Response;
+}
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+describe('fetchItemContent', () => {
+    it('aggregates poll options and votes before resolving', async () => {
+        const story = {
+            id: 100,
+            type: 'poll',
+            poll: [
+                { points: 0, content: '' },
+                { points: 0, content: '' },
+            ],
+        };
+        const fetchMock = vi.fn((input: string) => {
+            if (input.endsWith('/item/100')) {
+                return Promise.resolve(jsonResponse(story));
+            }
+            if (input.endsWith('/item/101')) {
+                return Promise.resolve(jsonResponse({ points: 5, content: 'first' }));
+            }
+            if (input.endsWith('/item/102')) {
+                return Promise.resolve(jsonResponse({ points: 7, content: 'second' }));
+            }
+            throw new Error(`unexpected url ${input}`);
+        });
+        vi.stubGlobal('fetch', fetchMock);
+
+        const result = await fetchItemContent(100);
+
+        expect(result.poll_votes_count).toBe(12);
+        expect(result.poll).toEqual([
+            { points: 5, content: 'first' },
+            { points: 7, content: 'second' },
+        ]);
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
+
+    it('leaves non-poll stories untouched', async () => {
+        const fetchMock = vi.fn(() =>
+            Promise.resolve(jsonResponse({ id: 1, type: 'link', title: 'hello' }))
+        );
+        vi.stubGlobal('fetch', fetchMock);
+
+        const result = await fetchItemContent(1);
+
+        expect(result.poll_votes_count).toBeUndefined();
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('fetchFeed', () => {
+    it('throws on a non-ok response', async () => {
+        vi.stubGlobal('fetch', vi.fn(() => Promise.resolve(jsonResponse(null, false, 500))));
+
+        await expect(fetchFeed('news', 1)).rejects.toThrow('500');
+    });
+
+    it('passes the abort signal through', async () => {
+        const fetchMock = vi.fn(() => Promise.resolve(jsonResponse([])));
+        vi.stubGlobal('fetch', fetchMock);
+        const controller = new AbortController();
+
+        await fetchFeed('news', 2, controller.signal);
+
+        expect(fetchMock).toHaveBeenCalledWith(
+            'https://node-hnapi.herokuapp.com/news?page=2',
+            { signal: controller.signal }
+        );
+    });
+});

--- a/react-app/src/services/hackernews-api.ts
+++ b/react-app/src/services/hackernews-api.ts
@@ -1,0 +1,41 @@
+import type { PollResult } from '../models/poll-result';
+import type { Story } from '../models/story';
+import type { User } from '../models/user';
+
+const BASE_URL = 'https://node-hnapi.herokuapp.com';
+
+async function getJson<T>(url: string, signal?: AbortSignal): Promise<T> {
+    const response = await fetch(url, { signal });
+    if (!response.ok) {
+        throw new Error(`Request to ${url} failed with status ${response.status}`);
+    }
+    return (await response.json()) as T;
+}
+
+export function fetchFeed(feedType: string, page: number, signal?: AbortSignal): Promise<Story[]> {
+    return getJson<Story[]>(`${BASE_URL}/${feedType}?page=${page}`, signal);
+}
+
+export function fetchPollContent(id: number, signal?: AbortSignal): Promise<PollResult> {
+    return getJson<PollResult>(`${BASE_URL}/item/${id}`, signal);
+}
+
+export function fetchUser(id: string, signal?: AbortSignal): Promise<User> {
+    return getJson<User>(`${BASE_URL}/user/${id}`, signal);
+}
+
+export async function fetchItemContent(id: number, signal?: AbortSignal): Promise<Story> {
+    const story = await getJson<Story>(`${BASE_URL}/item/${id}`, signal);
+    if (story.type === 'poll' && story.poll) {
+        const poll = story.poll;
+        story.poll_votes_count = 0;
+        const results = await Promise.all(
+            poll.map((_, index) => fetchPollContent(story.id + index + 1, signal))
+        );
+        results.forEach((pollResults, index) => {
+            poll[index] = pollResults;
+            story.poll_votes_count = (story.poll_votes_count ?? 0) + pollResults.points;
+        });
+    }
+    return story;
+}

--- a/react-app/src/utils/format-comment-count.test.ts
+++ b/react-app/src/utils/format-comment-count.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatCommentCount } from './format-comment-count';
+
+describe('formatCommentCount', () => {
+    it('returns discuss for zero or negative counts', () => {
+        expect(formatCommentCount(0)).toBe('discuss');
+        expect(formatCommentCount(-3)).toBe('discuss');
+    });
+
+    it('uses the singular form for a single comment', () => {
+        expect(formatCommentCount(1)).toBe('1 comment');
+    });
+
+    it('uses the plural form for several comments', () => {
+        expect(formatCommentCount(42)).toBe('42 comments');
+    });
+});

--- a/react-app/src/utils/format-comment-count.ts
+++ b/react-app/src/utils/format-comment-count.ts
@@ -1,0 +1,6 @@
+export function formatCommentCount(count: number): string {
+    if (count > 0) {
+        return `${count} ${count === 1 ? 'comment' : 'comments'}`;
+    }
+    return 'discuss';
+}


### PR DESCRIPTION
## Summary

Part of the Angular -> React migration chain; based on `devin-09.08.2026-devanshi/port-models-and-shared-styles`.

Ports `src/app/shared/services/hackernews-api.service.ts` and `src/app/shared/pipes/comment.pipe.ts` into `react-app/`, dropping RxJS entirely:

- `src/services/hackernews-api.ts` — `fetchFeed`, `fetchItemContent`, `fetchPollContent`, `fetchUser` as plain `async` functions over `fetch`, each taking an optional `AbortSignal` and throwing on non-ok responses (the Angular `lazyFetch` Observable wrapper silently ignored HTTP errors).
- Behaviour change in the poll aggregation: the Angular version emitted the story first and mutated `poll` / `poll_votes_count` later via `subscribe`, so consumers saw a partially populated story. The port awaits the per-option requests in parallel, so the resolved story is already complete:

```ts
if (story.type === 'poll' && story.poll) {
    story.poll_votes_count = 0;
    const results = await Promise.all(story.poll.map((_, i) => fetchPollContent(story.id + i + 1, signal)));
    results.forEach((r, i) => { story.poll[i] = r; story.poll_votes_count += r.points; });
}
```

- `src/hooks/useFetch.ts` — `useFetch<T>(fetcher, deps)` returning `{ data, error, loading }`; aborts the in-flight request on deps change/unmount and swallows `AbortError`. Will back the feed, item-details and user pages.
- `src/utils/format-comment-count.ts` — `formatCommentCount(count)` replacing `CommentPipe` (`'discuss'` / `'1 comment'` / `'N comments'`).

## Proposed fixes

- Vitest coverage for `formatCommentCount` and, with a stubbed `globalThis.fetch`, for poll aggregation, the non-poll path, non-ok rejection and signal pass-through.
- `npm run typecheck`, `npm run lint`, `npm test` and `npm run build` pass in `react-app/`.
- No files under `src/` (the Angular app) are touched.


Link to Devin session: https://app.devin.ai/sessions/50f5f5797eb8469d9e8e0eaab2586019
Open in Devin Desktop: https://app.devin.ai/desktop/session/50f5f5797eb8469d9e8e0eaab2586019?variant=devin
Requested by: @devanshi-gpta