### PR TITLE
PR 5/10 — Port shared and core components (Loader, ErrorMessage, Header, Footer, Settings)

### DIFF
--- a/react-app/src/components/core/Footer.scss
+++ b/react-app/src/components/core/Footer.scss
@@ -1,0 +1,23 @@
+@import "../../styles/media";
+@import "../../styles/theme_variables";
+
+#footer {
+  position: relative;
+  padding: 10px;
+  height: 60px;
+  letter-spacing: 0.7px;
+  text-align: center;
+
+  a {
+  	font-weight: bold;
+  	text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  @media #{$mobile-only} {
+    display: none;
+  }
+}

--- a/react-app/src/components/core/Footer.tsx
+++ b/react-app/src/components/core/Footer.tsx
@@ -1,0 +1,18 @@
+import './Footer.scss';
+
+export default function Footer() {
+    return (
+        <div id="footer">
+            <p>
+                Show this project some ❤ on{' '}
+                <a
+                    href="https://github.com/hdjirdeh/angular2-hn"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                >
+                    GitHub
+                </a>
+            </p>
+        </div>
+    );
+}

--- a/react-app/src/components/core/Header.scss
+++ b/react-app/src/components/core/Header.scss
@@ -1,0 +1,149 @@
+@import "../../styles/media";
+@import "../../styles/theme_variables";
+
+#header {
+  color: #fff;
+  padding: 6px 0;
+  line-height: 18px;
+  vertical-align: middle;
+  position: relative;
+  z-index: 1;
+  width: 100%;
+
+  @media #{$mobile-only} {
+    height: 50px;
+    position: fixed;
+    top: 0;
+  }
+
+  a {
+    display: inline;
+  }
+}
+
+.home-link {
+  width: 50px;
+  height: 66px;
+}
+
+.logo-inner {
+  width: 32px;
+  position: absolute;
+  left: 17px;
+  top: 18px;
+  z-index: -1;
+  height: 32px;
+  border-radius: 50%;
+
+  @media #{$mobile-only} {
+    left: 16px;
+    top: 12px;
+  }
+}
+
+.logo {
+  width: 50px;
+  padding: 3px 8px 0;
+
+  @media #{$mobile-only} {
+    width: 45px;
+    padding: 0 0 0 10px;
+  }
+}
+
+h1 {
+  font-weight: normal;
+  display: inline-block;
+  vertical-align:middle;
+  margin: 0;
+  font-size: 16px;
+
+  a {
+    color: #fff;
+    text-decoration: none;
+  }
+}
+
+.name {
+  margin-right: 30px;
+  margin-bottom: 2px;
+
+  @media #{$mobile-only} {
+    display: none;
+  }
+}
+
+.header-text {
+  position: absolute;
+  width: inherit;
+  height: 20px;
+  left: 10px;
+  top: 27px;
+  z-index: -1;
+
+  @media #{$mobile-only} {
+    top: 22px;
+  }
+}
+
+.left {
+  position: absolute;
+  left: 60px;
+  font-size: 16px;
+
+  @media #{$mobile-only} {
+    width: 100%;
+    left: 0;
+  }
+}
+
+.header-nav {
+  display: inline-block;
+  margin-left: 20px;
+
+  @media #{$mobile-only} {
+    margin-left: 60px;
+  }
+
+  a {
+    color: hsla(0,0%,100%,.9);
+    text-decoration: none;
+    margin: 0 5px;
+    letter-spacing: 1.8px;
+
+    &:hover {
+      color: #fff;
+    }
+  }
+
+  .active {
+    color: #fff;
+  }
+}
+
+.info {
+  position: absolute;
+  top: 0;
+  right: 20px;
+  height: 100%;
+
+  @media #{$mobile-only} {
+    right: 10px;
+  }
+
+  img {
+    opacity: 0.8;
+    width: 25px;
+    margin-top: 21.5px;
+    display: block;
+
+    &:hover {
+      opacity: 1;
+      cursor: pointer;
+    }
+
+    @media #{$mobile-only} {
+      margin-top: 15px;
+    }
+  }
+}

--- a/react-app/src/components/core/Header.test.tsx
+++ b/react-app/src/components/core/Header.test.tsx
@@ -1,0 +1,52 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SettingsProvider } from '../../context/SettingsContext';
+import Header from './Header';
+
+function renderHeader(initialEntry = '/news/1') {
+    return render(
+        <MemoryRouter initialEntries={[initialEntry]}>
+            <SettingsProvider>
+                <Header />
+            </SettingsProvider>
+        </MemoryRouter>
+    );
+}
+
+describe('Header', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        vi.stubGlobal(
+            'matchMedia',
+            vi.fn(() => ({
+                matches: false,
+                media: '(prefers-color-scheme: dark)',
+                onchange: null,
+                addEventListener: () => {},
+                removeEventListener: () => {},
+                addListener: () => {},
+                removeListener: () => {},
+                dispatchEvent: () => true,
+            }))
+        );
+    });
+
+    it('marks the current feed link as active', () => {
+        renderHeader('/show/1');
+
+        expect(screen.getByRole('link', { name: 'show' })).toHaveClass('active');
+        expect(screen.getByRole('link', { name: 'ask' })).not.toHaveClass('active');
+    });
+
+    it('toggles the settings modal from the cog', () => {
+        renderHeader();
+
+        expect(screen.queryByText('Settings', { selector: 'h1' })).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getByAltText('Settings'));
+
+        expect(screen.getByText('Settings', { selector: 'h1' })).toBeInTheDocument();
+    });
+});

--- a/react-app/src/components/core/Header.tsx
+++ b/react-app/src/components/core/Header.tsx
@@ -1,0 +1,67 @@
+import { NavLink } from 'react-router-dom';
+
+import { useSettings } from '../../context/SettingsContext';
+import Settings from './Settings';
+
+import './Header.scss';
+
+const NAV_LINKS = [
+    { to: '/newest/1', label: 'new' },
+    { to: '/show/1', label: 'show' },
+    { to: '/ask/1', label: 'ask' },
+    { to: '/jobs/1', label: 'jobs' },
+];
+
+function scrollTop() {
+    window.scrollTo(0, 0);
+}
+
+function activeClass({ isActive }: { isActive: boolean }) {
+    return isActive ? 'active' : '';
+}
+
+export default function Header() {
+    const { settings, toggleSettings } = useSettings();
+
+    return (
+        <header>
+            <div id="header">
+                <NavLink
+                    to="/news/1"
+                    className={({ isActive }) => (isActive ? 'home-link active' : 'home-link')}
+                    onClick={scrollTop}
+                >
+                    <div className="logo-inner"></div>
+                    <img className="logo" src="/assets/images/logo.svg" alt="Logo" />
+                </NavLink>
+                <div className="header-text">
+                    <div className="left">
+                        <span className="header-nav">
+                            {NAV_LINKS.map((link, index) => (
+                                <span key={link.to}>
+                                    {index > 0 && ' | '}
+                                    <NavLink
+                                        to={link.to}
+                                        className={activeClass}
+                                        onClick={scrollTop}
+                                    >
+                                        {link.label}
+                                    </NavLink>
+                                </span>
+                            ))}
+                        </span>
+                    </div>
+                </div>
+                <div className="info">
+                    <img
+                        className="settings"
+                        src="/assets/images/cog.svg"
+                        alt="Settings"
+                        onClick={toggleSettings}
+                    />
+                </div>
+            </div>
+            {settings.showSettings && <Settings />}
+        </header>
+    );
+}

--- a/react-app/src/components/core/Settings.scss
+++ b/react-app/src/components/core/Settings.scss
@@ -1,0 +1,74 @@
+@import "../../styles/media";
+@import "../../styles/theme_variables";
+
+.overlay {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: rgba(0, 0, 0, 0.7);
+  opacity: 1;
+  z-index: 1;
+}
+
+.popup {
+  margin: 70px auto;
+  padding: 30px;
+  border-radius: 5px;
+  width: 30%;
+  position: relative;
+  h1 {
+    margin-top: 0;
+    margin-bottom: 0px;
+    color: #fff;
+    text-align: center;
+    letter-spacing: 1px;
+  }
+  h2 {
+    padding-top: 10px;
+  }
+  hr {
+    width: 40%;
+    margin-bottom: 20px;
+  }
+  .close {
+    position: absolute;
+    top: 12px;
+    right: 20px;
+    font-size: 30px;
+    font-weight: bold;
+    text-decoration: none;
+    color: rgba(255,255,255,0.8);
+    &:hover {
+      color: #fff;
+      cursor: pointer;
+    }
+  }
+  .content {
+    max-height: 30%;
+    color: #fff;
+    letter-spacing: 1px;
+    overflow: auto;
+  }
+  input[type=number] {
+      display: block;
+      width: 80%;
+      height: 20px;
+      margin-bottom: 15px;
+      border-radius: 5px;
+      padding: 2px;
+  }
+}
+
+.control-section {
+    margin-bottom: 15px;
+    padding-bottom: 15px;
+    border-bottom: 1px solid white;
+}
+
+@media screen and (max-width: 700px) {
+  .box, .popup {
+    width: 70%;
+  }
+}

--- a/react-app/src/components/core/Settings.test.tsx
+++ b/react-app/src/components/core/Settings.test.tsx
@@ -1,0 +1,63 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SettingsProvider } from '../../context/SettingsContext';
+import Settings from './Settings';
+
+function renderSettings() {
+    return render(
+        <SettingsProvider>
+            <Settings />
+        </SettingsProvider>
+    );
+}
+
+describe('Settings', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        vi.stubGlobal(
+            'matchMedia',
+            vi.fn(() => ({
+                matches: false,
+                media: '(prefers-color-scheme: dark)',
+                onchange: null,
+                addEventListener: () => {},
+                removeEventListener: () => {},
+                addListener: () => {},
+                removeListener: () => {},
+                dispatchEvent: () => true,
+            }))
+        );
+    });
+
+    it('toggles opening links in a new tab', () => {
+        renderSettings();
+
+        const checkbox = screen.getByRole('checkbox');
+        expect(checkbox).not.toBeChecked();
+
+        fireEvent.click(checkbox);
+
+        expect(checkbox).toBeChecked();
+        expect(localStorage.getItem('openLinkInNewTab')).toBe('true');
+    });
+
+    it('selects a theme', () => {
+        renderSettings();
+
+        fireEvent.click(screen.getByLabelText('Night'));
+
+        expect(screen.getByLabelText('Night')).toBeChecked();
+        expect(localStorage.getItem('theme')).toBe('night');
+    });
+
+    it('updates the font size and list spacing', () => {
+        renderSettings();
+
+        fireEvent.change(screen.getByLabelText(/Font size:/), { target: { value: '20' } });
+        fireEvent.change(screen.getByLabelText(/List spacing:/), { target: { value: '5' } });
+
+        expect(localStorage.getItem('titleFontSize')).toBe('20');
+        expect(localStorage.getItem('listSpacing')).toBe('5');
+    });
+});

--- a/react-app/src/components/core/Settings.tsx
+++ b/react-app/src/components/core/Settings.tsx
@@ -1,0 +1,83 @@
+import { useSettings } from '../../context/SettingsContext';
+
+import './Settings.scss';
+
+const THEMES = [
+    { value: 'default', label: 'Default' },
+    { value: 'night', label: 'Night' },
+    { value: 'amoledblack', label: 'Black (AMOLED)' },
+];
+
+export default function Settings() {
+    const { settings, toggleSettings, toggleOpenLinksInNewTab, setTheme, setFont, setSpacing } =
+        useSettings();
+
+    return (
+        <div id="popup1" className="overlay">
+            <div className="popup">
+                <h1>Settings</h1>
+                <hr />
+                <span className="close" onClick={toggleSettings}>
+                    &times;
+                </span>
+                <div className="content">
+                    <div className="control-section">
+                        <h2>Links</h2>
+                        <input
+                            type="checkbox"
+                            checked={settings.openLinkInNewTab}
+                            onChange={toggleOpenLinksInNewTab}
+                        />
+                        Open links in a new tab
+                    </div>
+                    <div className="theme-controls">
+                        <div className="control-section">
+                            <h2>Select a theme</h2>
+                            {THEMES.map((theme) => (
+                                <div key={theme.value}>
+                                    <label>
+                                        <input
+                                            name="theme"
+                                            type="radio"
+                                            value={theme.value}
+                                            checked={settings.theme === theme.value}
+                                            onChange={() => setTheme(theme.value)}
+                                        />
+                                        {theme.label}
+                                    </label>
+                                </div>
+                            ))}
+                        </div>
+                        <div className="control-section">
+                            <h2>Change Font</h2>
+                            <div>
+                                <label>
+                                    Font size:
+                                    <input
+                                        min="1"
+                                        value={settings.titleFontSize}
+                                        name="titleFontSize"
+                                        type="number"
+                                        onChange={(event) => setFont(event.target.value)}
+                                    />
+                                </label>
+                            </div>
+                            <div>
+                                <label>
+                                    List spacing:
+                                    <input
+                                        min="0"
+                                        value={settings.listSpacing}
+                                        name="listSpacing"
+                                        type="number"
+                                        onChange={(event) => setSpacing(event.target.value)}
+                                    />
+                                </label>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/react-app/src/components/shared/ErrorMessage.scss
+++ b/react-app/src/components/shared/ErrorMessage.scss
@@ -1,0 +1,115 @@
+@import "../../styles/media";
+@import "../../styles/theme_variables";
+
+.error-section {
+  height: 300px;
+  margin: 200px;
+
+  @media #{$mobile-only} {
+    height: 0;
+    display: block;
+    position: relative;
+    margin: 30vh 0;
+  }
+
+  p {
+    text-align: center;
+    padding: 0 25px;
+
+    &.strong {
+      margin-top: 25px;
+      font-weight: bold;
+    }
+  }
+
+  .skull {
+    width: $skull-size;
+    height: $skull-size;
+    position: relative;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    margin: auto;
+
+    .head {
+      width: 100%;
+      height: 75%;
+      border-radius: 15% / 20%;
+      position: absolute;
+      top: 0;
+      left: 0;
+      &:before, &:after {
+        content: "";
+        position: absolute;
+        border-radius: 50%;
+        width: 20%;
+        height: 30%;
+        bottom: 10%;
+      }
+      &:before {
+        left: 10%;
+      }
+      &:after {
+        right: 10%;
+      }
+      .crack {
+        width: 10%;
+        height: 10%;
+        position: absolute;
+        top: 0;
+        right: 25%;
+        transform: skew(-15deg);
+
+        &:before {
+          content: "";
+          position: absolute;
+          top: 100%;
+          left: $skull-size / 15;
+          border-right: $skull-size / 20 solid transparent;
+          border-left: $skull-size / 40 solid transparent;
+        }
+      }
+    }
+    .mouth {
+      width: 40%;
+      height: 25%;
+      position: absolute;
+      top: 75%;
+      left: 30%;
+      border-radius: 0 0 $skull-size / 10 $skull-size / 10;
+      &:before {
+        content: "";
+        position: absolute;
+        width: 15%;
+        height: 50%;
+        border-radius: 50% / 30%;
+        left: 42.5%;
+        top: -25%;
+      }
+      .teeth {
+        position: absolute;
+        bottom: 0;
+        left: 45%;
+        width: 10%;
+        height: 50%;
+        margin-bottom: -5%;
+        border-radius: 50% / 20%;
+
+        &:before, &:after {
+          content: "";
+          position: absolute;
+          width: 100%;
+          height: 100%;
+          border-radius: 50% / 20%;
+        }
+        &:before {
+          left: -250%;
+        }
+        &:after {
+          right: -250%;
+        }
+      }
+    }
+  }
+}

--- a/react-app/src/components/shared/ErrorMessage.test.tsx
+++ b/react-app/src/components/shared/ErrorMessage.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import ErrorMessage from './ErrorMessage';
+
+describe('ErrorMessage', () => {
+    it('renders the provided message', () => {
+        render(<ErrorMessage message="Something went wrong" />);
+
+        expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+    });
+});

--- a/react-app/src/components/shared/ErrorMessage.tsx
+++ b/react-app/src/components/shared/ErrorMessage.tsx
@@ -1,0 +1,25 @@
+import './ErrorMessage.scss';
+
+export interface ErrorMessageProps {
+    message: string;
+}
+
+export default function ErrorMessage({ message }: ErrorMessageProps) {
+    return (
+        <div className="error-section">
+            <div className="skull">
+                <div className="head">
+                    <div className="crack"></div>
+                </div>
+                <div className="mouth">
+                    <div className="teeth"></div>
+                </div>
+            </div>
+            <p className="strong">{message}</p>
+            <p>
+                If you are offline viewing, you&apos;ll need to visit this page with a network
+                connection first before it can work offline.
+            </p>
+        </div>
+    );
+}

--- a/react-app/src/components/shared/Loader.scss
+++ b/react-app/src/components/shared/Loader.scss
@@ -1,0 +1,109 @@
+@import "../../styles/media";
+@import "../../styles/theme_variables";
+
+.loader {
+  -webkit-animation: load1 1s infinite ease-in-out;
+  animation: load1 1s infinite ease-in-out;
+  width: 1em;
+  height: 4em;
+  &:before, &:after {
+    -webkit-animation: load1 1s infinite ease-in-out;
+    animation: load1 1s infinite ease-in-out;
+    width: 1em;
+    height: 4em;
+  }
+  &:before, &:after {
+    position: absolute;
+    top: 0;
+    content: '';
+  }
+  &:before {
+    left: -1.5em;
+    -webkit-animation-delay: -0.32s;
+    animation-delay: -0.32s;
+  }
+}
+
+.loading-section {
+    height: 70px;
+    margin: 40px 0 40px 40px;
+
+  @media #{$mobile-only} {
+    display: block;
+    position: relative;
+    margin: 45vh 0;
+  }
+}
+
+.loader {
+  text-indent: -9999em;
+  margin: 20px 20px;
+  position: relative;
+  font-size: 11px;
+  -webkit-transform: translateZ(0);
+  -ms-transform: translateZ(0);
+  transform: translateZ(0);
+  -webkit-animation-delay: -0.16s;
+  animation-delay: -0.16s;
+  &:after {
+    left: 1.5em;
+  }
+
+  @media #{$mobile-only} {
+    margin: 20px auto;
+  }
+}
+
+@-webkit-keyframes load1 {
+  0%,
+    80%,
+    100% {
+    box-shadow: 0 0;
+    height: 2em;
+  }
+  40% {
+    box-shadow: 0 -2em;
+    height: 3em;
+  }
+}
+
+@keyframes load1 {
+  0%,
+    80%,
+    100% {
+    box-shadow: 0 0;
+    height: 2em;
+  }
+  40% {
+    box-shadow: 0 -2em;
+    height: 3em;
+  }
+}
+
+@media #{$mobile-only} {
+  @-webkit-keyframes load1 {
+    0%,
+      80%,
+      100% {
+      box-shadow: 0 0;
+      height: 4em;
+    }
+    40% {
+      box-shadow: 0 -2em;
+      height: 5em;
+    }
+  }
+
+  @keyframes load1 {
+    0%,
+      80%,
+      100% {
+      box-shadow: 0 0;
+      height: 3em;
+    }
+    40% {
+      box-shadow: 0 -2em;
+      height: 4em;
+    }
+  }
+}

--- a/react-app/src/components/shared/Loader.tsx
+++ b/react-app/src/components/shared/Loader.tsx
@@ -1,0 +1,9 @@
+import './Loader.scss';
+
+export default function Loader() {
+    return (
+        <div className="loading-section">
+            <div className="loader">Loading...</div>
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary

Part of the Angular → React migration chain; based on `devin-09.08.2026-devanshi/add-settings-context`.

Ports the presentational shell components from `src/app/{shared,core}` to `react-app/src/components`, keeping markup and class names identical so the global theme stylesheet (`src/styles/_themes.scss`, which targets `.wrapper`, `.nav`, `#header`, …) keeps working. Each component's SCSS is copied next to its `.tsx` with the `@import` paths repointed from `../../shared/scss/*` to `../../styles/*` and imported globally (not as CSS Modules).

Angular-specific behaviour mapped as:
- `routerLink` + `routerLinkActive="active"` → `<NavLink to=... className={({isActive}) => isActive ? 'active' : ''}>`, preserving `/news/1`, `/newest/1`, `/show/1`, `/ask/1`, `/jobs/1` and the `scrollTop()` click handler.
- `SettingsService` injection → `useSettings()`; the cog image calls `toggleSettings`, and `Settings` renders only when `settings.showSettings`.
- Settings inputs become controlled inputs bound to the context (`openLinkInNewTab` checkbox, three theme radios, numeric font-size / list-spacing). Angular updated the numeric inputs on `keyup`; React uses `onChange` so the number spinners also work.

Tests: Settings modal smoke tests (toggle a setting, pick a theme, change font/spacing persist to `localStorage`), Header active-link + cog-toggles-modal (wrapped in `MemoryRouter`), and an ErrorMessage render test. `npm run typecheck`, `npm run build`, `npm run lint` and `npm test` pass in `react-app/`.

## Proposed fixes

- Add `react-app/src/components/shared/{Loader,ErrorMessage}.{tsx,scss}`.
- Add `react-app/src/components/core/{Header,Footer,Settings}.{tsx,scss}`.
- Add `Header.test.tsx`, `Settings.test.tsx`, `ErrorMessage.test.tsx`.
- No changes to the Angular app under `src/` (removed in the final cleanup PR).


Link to Devin session: https://app.devin.ai/sessions/1e1c792cfa2e4508b64c8061876debf6
Open in Devin Desktop: https://app.devin.ai/desktop/session/1e1c792cfa2e4508b64c8061876debf6?variant=devin
Requested by: @devanshi-gpta