### PR TITLE
feature: add dependency-upgrade skill so manifest dependents are bumped together

### DIFF
--- a/.agents/skills/dependency-upgrade/SKILL.md
+++ b/.agents/skills/dependency-upgrade/SKILL.md
@@ -109,7 +109,7 @@ leave a one-line PR note explaining why.
 node .agents/skills/dependency-upgrade/scripts/find-dependents.mjs <pkg> --check   # exits 1 on unsatisfied ranges
 <pm validate tree>          # npm ls --all / yarn check --integrity; non-zero = invalid/missing/peer problems
 rm -rf node_modules && <pm clean install>   # npm ci / yarn install --frozen-lockfile; proves the lockfile is self-consistent
-npm run lint && npm run build && CHROME_BIN=$(find /opt/.devin/chrome -name chrome -type f | head -1) npm test -- --watch=false
+<pm> run lint && <pm> run build && CHROME_BIN=$(find /opt/.devin/chrome -name chrome -type f | head -1) <pm> test -- --watch=false   # yarn: drop the extra `--`
 ```
 Also grep the source for API changes called out in the target's changelog
 (`npm view <pkg>@<new> homepage`, then CHANGELOG / migration guide).

--- a/.agents/skills/dependency-upgrade/SKILL.md
+++ b/.agents/skills/dependency-upgrade/SKILL.md
@@ -25,10 +25,21 @@ dependent analysis so every affected manifest entry moves in ONE change.
    peer-depends on, plus siblings released in lockstep (see Cohorts).
 3. Use the framework's own migration tool when one exists (`ng update`,
    `npx @next/codemod`, etc.) — it computes the cohort for you.
-4. Regenerate the lockfile with the repo's package manager (this repo tracks
-   `package-lock.json` → `npm`; do NOT introduce or update `yarn.lock` unless
-   the repo already commits it). One lockfile, one package manager.
-5. Finish with install-from-lockfile (`npm ci`), lint, build, test. Do not open
+4. Use the package manager that owns the *tracked* lockfile
+   (`git ls-files | grep -iE 'lock'`): `yarn.lock` → yarn, `package-lock.json`
+   → npm, `pnpm-lock.yaml` → pnpm. Never add a second lockfile. On `master` of
+   this repo only `yarn.lock` is tracked (a local `package-lock.json` is
+   untracked noise — do not commit it); React-migration branches track
+   `package-lock.json`. Commands below use `<pm>`; substitute:
+
+   | step | npm | yarn (v1) | pnpm |
+   |---|---|---|---|
+   | add/bump | `npm install a@x b@y` | `yarn add a@x b@y` (`-D` for devDeps) | `pnpm add a@x b@y` |
+   | explain | `npm explain <p>` | `yarn why <p>` | `pnpm why <p>` |
+   | validate tree | `npm ls --all` | `yarn check --integrity` | `pnpm ls --depth Infinity` |
+   | clean install from lockfile | `npm ci` | `yarn install --frozen-lockfile` | `pnpm install --frozen-lockfile` |
+   | transitive pin | `overrides` | `resolutions` | `pnpm.overrides` |
+5. Finish with a frozen-lockfile clean install, lint, build, test. Do not open
    a PR until all four pass.
 
 ## Procedure
@@ -49,7 +60,7 @@ node .agents/skills/dependency-upgrade/scripts/find-dependents.mjs <pkg> [<pkg2>
 ```
 Cross-check with the lockfile view (who *actually* pulls it in):
 ```bash
-npm ls <pkg> --all 2>/dev/null | head -50     # or: npm explain <pkg>
+<pm> why <pkg>            # yarn why / pnpm why; npm: npm explain <pkg>
 ```
 Also list what the target itself peer-requires at the *new* version:
 ```bash
@@ -82,21 +93,22 @@ Well-known lockstep cohorts (bump all together, same major):
 
 ### 3. Apply the cohort in one install
 ```bash
-npm install <pkg>@<new> <member1>@<v1> <member2>@<v2> ... --save-exact=false
+<pm> add <pkg>@<new> <member1>@<v1> <member2>@<v2> ...   # npm: npm install ...
 ```
+(`npm view` works for registry metadata regardless of which manager owns the lockfile.)
 Do NOT use `--legacy-peer-deps` or `--force` to make it "work" — those hide the
 exact problem this skill exists to prevent. An ERESOLVE at this step means the
 cohort is incomplete: read the error (it names the dependent), add it, repeat.
 
 If a transitive (non-manifest) package is the blocker and has no compatible
-release, add a targeted `overrides` (npm) / `resolutions` (yarn) entry and
+release, add a targeted `overrides` (npm) / `resolutions` (yarn) / `pnpm.overrides` entry and
 leave a one-line PR note explaining why.
 
 ### 4. Verify — nothing missed
 ```bash
 node .agents/skills/dependency-upgrade/scripts/find-dependents.mjs <pkg> --check   # exits 1 on unsatisfied ranges
-npm ls --all >/dev/null                                                              # non-zero = invalid/missing/peer problems
-rm -rf node_modules && npm ci                                                         # proves the lockfile is self-consistent
+<pm validate tree>          # npm ls --all / yarn check --integrity; non-zero = invalid/missing/peer problems
+rm -rf node_modules && <pm clean install>   # npm ci / yarn install --frozen-lockfile; proves the lockfile is self-consistent
 npm run lint && npm run build && CHROME_BIN=$(find /opt/.devin/chrome -name chrome -type f | head -1) npm test -- --watch=false
 ```
 Also grep the source for API changes called out in the target's changelog
@@ -111,8 +123,9 @@ see nothing was skipped.
 ## Quick checklist
 - [ ] `find-dependents` run for every target; cohort written down before editing
 - [ ] `npm view <pkg>@<new> peerDependencies` reviewed
-- [ ] All cohort members bumped in ONE `npm install`, no `--force`/`--legacy-peer-deps`
-- [ ] `find-dependents --check` and `npm ls --all` clean
-- [ ] `npm ci` from scratch + lint + build + test green
+- [ ] Package manager chosen from the tracked lockfile; no second lockfile created
+- [ ] All cohort members bumped in ONE add/install, no `--force`/`--legacy-peer-deps`
+- [ ] `find-dependents --check` and tree validation clean
+- [ ] Frozen-lockfile clean install + lint + build + test green
 - [ ] Only the repo's tracked lockfile changed
 - [ ] PR lists cohort table + rationale

--- a/.agents/skills/dependency-upgrade/SKILL.md
+++ b/.agents/skills/dependency-upgrade/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: dependency-upgrade
+description: >
+  Upgrade one or more npm/yarn packages WITHOUT missing the downstream packages
+  in package.json that depend on (or peer-depend on) the thing being upgraded.
+  Use whenever asked to bump, upgrade, update, or remediate a vulnerability in
+  a dependency, or when a previous upgrade PR failed install/build with
+  ERESOLVE / peer-dependency / "requires a peer of" errors.
+---
+
+# Dependency upgrade (no dependents left behind)
+
+The recurring failure mode: a package is bumped in isolation, `npm install`
+appears to work, then CI/build fails because a *manifest* dependent (something
+already listed in `package.json`) declares a peer/direct range that excludes the
+new version. Each miss costs a full PR iteration. This skill front-loads the
+dependent analysis so every affected manifest entry moves in ONE change.
+
+## Rules
+
+1. Never bump a single line of `package.json` by hand and stop there.
+   Every upgrade goes through the **Blast radius** step below first.
+2. Upgrade the whole *cohort*, not one package: everything in the manifest that
+   `peerDependencies`/`dependencies` on the target, plus everything the target
+   peer-depends on, plus siblings released in lockstep (see Cohorts).
+3. Use the framework's own migration tool when one exists (`ng update`,
+   `npx @next/codemod`, etc.) — it computes the cohort for you.
+4. Regenerate the lockfile with the repo's package manager (this repo tracks
+   `package-lock.json` → `npm`; do NOT introduce or update `yarn.lock` unless
+   the repo already commits it). One lockfile, one package manager.
+5. Finish with install-from-lockfile (`npm ci`), lint, build, test. Do not open
+   a PR until all four pass.
+
+## Procedure
+
+### 0. Snapshot the manifest
+```bash
+git checkout -b devin/$(date +%s)-upgrade-<pkg>
+node -v && npm -v                      # must satisfy package.json "engines" if set
+cat package.json | jq '{dependencies, devDependencies, peerDependencies, overrides, resolutions, engines}'
+```
+
+### 1. Blast radius — who in the manifest cares about `<pkg>`?
+Run the helper; it inspects the *installed* metadata of every manifest entry and
+prints those whose `peerDependencies`/`dependencies`/`optionalDependencies`
+mention the target(s):
+```bash
+node .agents/skills/dependency-upgrade/scripts/find-dependents.mjs <pkg> [<pkg2> ...]
+```
+Cross-check with the lockfile view (who *actually* pulls it in):
+```bash
+npm ls <pkg> --all 2>/dev/null | head -50     # or: npm explain <pkg>
+```
+Also list what the target itself peer-requires at the *new* version:
+```bash
+npm view <pkg>@<new> peerDependencies dependencies engines
+```
+Every manifest entry surfaced by these three commands is in the **cohort**.
+
+### 2. Resolve the cohort's versions
+For each cohort member, find the version compatible with `<pkg>@<new>`:
+```bash
+npm view <member> versions --json | tail -20
+npm view <member>@<candidate> peerDependencies
+```
+Well-known lockstep cohorts (bump all together, same major):
+- **Angular**: `@angular/*` (incl. `compiler-cli`, `language-service`,
+  `service-worker`), `@angular-devkit/build-angular`, `@angular/cli`,
+  `typescript` (check the supported range for that Angular major), `zone.js`,
+  `rxjs`, `tslib`. Prefer `NG_DISABLE_VERSION_CHECK=1 npx ng update @angular/core@<N> @angular/cli@<N>`.
+- **React**: `react`, `react-dom`, `@types/react`, `@types/react-dom`,
+  `react-test-renderer`, `@testing-library/react`, `react-router` +
+  `react-router-dom` (same version).
+- **Vite**: `vite`, `vitest`, `@vitejs/plugin-react`, `vite-plugin-pwa`,
+  `@vitest/coverage-*`, `@vitest/ui` (vitest packages share a version).
+- **Karma/Jasmine**: `karma`, `karma-jasmine`, `karma-jasmine-html-reporter`,
+  `jasmine-core`, `@types/jasmine`.
+- **TypeScript**: `typescript` + `ts-node`, `tslint`/`eslint` plugins,
+  `@typescript-eslint/*` (parser + plugin same version).
+- **Testing Library / Jest**: `jest`, `ts-jest`, `babel-jest`, `@types/jest`,
+  `jest-environment-*`.
+
+### 3. Apply the cohort in one install
+```bash
+npm install <pkg>@<new> <member1>@<v1> <member2>@<v2> ... --save-exact=false
+```
+Do NOT use `--legacy-peer-deps` or `--force` to make it "work" — those hide the
+exact problem this skill exists to prevent. An ERESOLVE at this step means the
+cohort is incomplete: read the error (it names the dependent), add it, repeat.
+
+If a transitive (non-manifest) package is the blocker and has no compatible
+release, add a targeted `overrides` (npm) / `resolutions` (yarn) entry and
+leave a one-line PR note explaining why.
+
+### 4. Verify — nothing missed
+```bash
+node .agents/skills/dependency-upgrade/scripts/find-dependents.mjs <pkg> --check   # exits 1 on unsatisfied ranges
+npm ls --all >/dev/null                                                              # non-zero = invalid/missing/peer problems
+rm -rf node_modules && npm ci                                                         # proves the lockfile is self-consistent
+npm run lint && npm run build && CHROME_BIN=$(find /opt/.devin/chrome -name chrome -type f | head -1) npm test -- --watch=false
+```
+Also grep the source for API changes called out in the target's changelog
+(`npm view <pkg>@<new> homepage`, then CHANGELOG / migration guide).
+
+### 5. PR
+Summary must list the full cohort as a table: package, old → new, and *why it
+is in the cohort* (target / peer of target / lockstep sibling / override).
+Include the exact `find-dependents` output in a collapsed block so reviewers can
+see nothing was skipped.
+
+## Quick checklist
+- [ ] `find-dependents` run for every target; cohort written down before editing
+- [ ] `npm view <pkg>@<new> peerDependencies` reviewed
+- [ ] All cohort members bumped in ONE `npm install`, no `--force`/`--legacy-peer-deps`
+- [ ] `find-dependents --check` and `npm ls --all` clean
+- [ ] `npm ci` from scratch + lint + build + test green
+- [ ] Only the repo's tracked lockfile changed
+- [ ] PR lists cohort table + rationale

--- a/.agents/skills/dependency-upgrade/scripts/find-dependents.mjs
+++ b/.agents/skills/dependency-upgrade/scripts/find-dependents.mjs
@@ -24,6 +24,11 @@ const manifestDeps = {
     ...manifest.optionalDependencies,
     ...manifest.peerDependencies,
 };
+// sections whose entries may legitimately be absent from node_modules
+const mayBeAbsent = new Set([
+    ...Object.keys(manifest.optionalDependencies ?? {}),
+    ...Object.keys(manifest.peerDependencies ?? {}),
+]);
 
 const require = createRequire(resolve(root, 'package.json'));
 let semver = null;
@@ -48,7 +53,8 @@ const rows = [];
 for (const name of Object.keys(manifestDeps).sort()) {
     const meta = installedPkg(name);
     if (!meta) {
-        rows.push({ dependent: name, kind: 'NOT INSTALLED', target: '-', range: '-', status: 'unknown (not installed)' });
+        const status = mayBeAbsent.has(name) ? 'skipped (optional/peer not installed)' : 'unknown (not installed)';
+        rows.push({ dependent: name, kind: 'NOT INSTALLED', target: '-', range: '-', status });
         continue;
     }
     for (const [kind, obj] of [

--- a/.agents/skills/dependency-upgrade/scripts/find-dependents.mjs
+++ b/.agents/skills/dependency-upgrade/scripts/find-dependents.mjs
@@ -3,7 +3,7 @@
 // Lists every package.json manifest entry whose installed metadata declares a
 // dependency / peerDependency / optionalDependency on any target package, with
 // the declared range and whether the currently installed target satisfies it.
-// --check: exit 1 if any range is unsatisfied (use after the upgrade).
+// --check: exit 1 if any range is unsatisfied or cannot be verified (use after the upgrade).
 import { readFileSync, existsSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { resolve } from 'node:path';
@@ -22,6 +22,7 @@ const manifestDeps = {
     ...manifest.dependencies,
     ...manifest.devDependencies,
     ...manifest.optionalDependencies,
+    ...manifest.peerDependencies,
 };
 
 const require = createRequire(resolve(root, 'package.json'));
@@ -47,7 +48,7 @@ const rows = [];
 for (const name of Object.keys(manifestDeps).sort()) {
     const meta = installedPkg(name);
     if (!meta) {
-        rows.push({ dependent: name, kind: 'NOT INSTALLED', target: '-', range: '-', status: 'unknown' });
+        rows.push({ dependent: name, kind: 'NOT INSTALLED', target: '-', range: '-', status: 'unknown (not installed)' });
         continue;
     }
     for (const [kind, obj] of [
@@ -63,10 +64,10 @@ for (const name of Object.keys(manifestDeps).sort()) {
             const nested = kind === 'peerDependencies' ? null : installedPkg(`${name}/node_modules/${t}`);
             const have = nested?.version ?? installedTargets[t];
             const optionalPeer = meta.peerDependenciesMeta?.[t]?.optional === true;
-            let status = 'unknown';
-            if (have && semver) {
-                status = semver.satisfies(have, range, { includePrerelease: true }) ? 'ok' : 'UNSATISFIED';
-            }
+            let status;
+            if (!have) status = 'unknown (target missing)';
+            else if (!semver) status = 'unknown (semver unavailable)';
+            else status = semver.satisfies(have, range, { includePrerelease: true }) ? 'ok' : 'UNSATISFIED';
             if (optionalPeer && status === 'UNSATISFIED') status = 'UNSATISFIED (optional peer)';
             rows.push({ dependent: name, kind, target: t, range, installed: have ?? 'missing', status });
         }
@@ -93,8 +94,10 @@ if (rows.length === 0) {
     console.log(`\nCohort (must be reviewed/bumped together with the target): ${cohort.join(', ')}`);
 }
 
-const bad = rows.filter((r) => r.status.startsWith('UNSATISFIED') && !r.status.includes('optional'));
-if (check && bad.length) {
-    console.error(`\n${bad.length} unsatisfied range(s) — upgrade incomplete.`);
-    process.exit(1);
+if (check) {
+    const bad = rows.filter((r) => r.status.startsWith('UNSATISFIED'));
+    const unverified = rows.filter((r) => r.status.startsWith('unknown'));
+    if (bad.length) console.error(`\n${bad.length} unsatisfied range(s) — upgrade incomplete.`);
+    if (unverified.length) console.error(`\n${unverified.length} range(s) could not be verified — install deps / semver and re-run.`);
+    if (bad.length || unverified.length) process.exit(1);
 }

--- a/.agents/skills/dependency-upgrade/scripts/find-dependents.mjs
+++ b/.agents/skills/dependency-upgrade/scripts/find-dependents.mjs
@@ -28,7 +28,7 @@ const manifestDeps = {
 const mayBeAbsent = new Set([
     ...Object.keys(manifest.optionalDependencies ?? {}),
     ...Object.keys(manifest.peerDependencies ?? {}),
-]);
+].filter((name) => !(name in (manifest.dependencies ?? {})) && !(name in (manifest.devDependencies ?? {}))));
 
 const require = createRequire(resolve(root, 'package.json'));
 let semver = null;

--- a/.agents/skills/dependency-upgrade/scripts/find-dependents.mjs
+++ b/.agents/skills/dependency-upgrade/scripts/find-dependents.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+// Usage: node find-dependents.mjs <pkg> [<pkg>...] [--check]
+// Lists every package.json manifest entry whose installed metadata declares a
+// dependency / peerDependency / optionalDependency on any target package, with
+// the declared range and whether the currently installed target satisfies it.
+// --check: exit 1 if any range is unsatisfied (use after the upgrade).
+import { readFileSync, existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { resolve } from 'node:path';
+
+const args = process.argv.slice(2);
+const check = args.includes('--check');
+const targets = args.filter((a) => !a.startsWith('--'));
+if (targets.length === 0) {
+    console.error('usage: find-dependents.mjs <pkg> [<pkg>...] [--check]');
+    process.exit(2);
+}
+
+const root = process.cwd();
+const manifest = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8'));
+const manifestDeps = {
+    ...manifest.dependencies,
+    ...manifest.devDependencies,
+    ...manifest.optionalDependencies,
+};
+
+const require = createRequire(resolve(root, 'package.json'));
+let semver = null;
+try {
+    semver = require('semver');
+} catch {
+    try {
+        semver = createRequire(import.meta.url)('npm/node_modules/semver');
+    } catch {
+        /* range checking degraded to "unknown" */
+    }
+}
+
+function installedPkg(name) {
+    const p = resolve(root, 'node_modules', name, 'package.json');
+    return existsSync(p) ? JSON.parse(readFileSync(p, 'utf8')) : null;
+}
+
+const installedTargets = Object.fromEntries(targets.map((t) => [t, installedPkg(t)?.version ?? null]));
+
+const rows = [];
+for (const name of Object.keys(manifestDeps).sort()) {
+    const meta = installedPkg(name);
+    if (!meta) {
+        rows.push({ dependent: name, kind: 'NOT INSTALLED', target: '-', range: '-', status: 'unknown' });
+        continue;
+    }
+    for (const [kind, obj] of [
+        ['peerDependencies', meta.peerDependencies],
+        ['dependencies', meta.dependencies],
+        ['optionalDependencies', meta.optionalDependencies],
+    ]) {
+        if (!obj) continue;
+        for (const t of targets) {
+            if (!(t in obj)) continue;
+            const range = obj[t];
+            // regular deps may be satisfied by a nested copy; peers must resolve to the hoisted one
+            const nested = kind === 'peerDependencies' ? null : installedPkg(`${name}/node_modules/${t}`);
+            const have = nested?.version ?? installedTargets[t];
+            const optionalPeer = meta.peerDependenciesMeta?.[t]?.optional === true;
+            let status = 'unknown';
+            if (have && semver) {
+                status = semver.satisfies(have, range, { includePrerelease: true }) ? 'ok' : 'UNSATISFIED';
+            }
+            if (optionalPeer && status === 'UNSATISFIED') status = 'UNSATISFIED (optional peer)';
+            rows.push({ dependent: name, kind, target: t, range, installed: have ?? 'missing', status });
+        }
+    }
+}
+
+const manifestTargets = targets.filter((t) => t in manifestDeps);
+const nonManifestTargets = targets.filter((t) => !(t in manifestDeps));
+
+console.log(`Targets: ${targets.map((t) => `${t}@${installedTargets[t] ?? 'missing'}`).join(', ')}`);
+if (nonManifestTargets.length) {
+    console.log(`Note: not direct manifest entries (transitive only): ${nonManifestTargets.join(', ')}`);
+}
+if (manifestTargets.length) {
+    console.log(`Manifest ranges: ${manifestTargets.map((t) => `${t}: ${manifestDeps[t]}`).join(', ')}`);
+}
+console.log('');
+
+if (rows.length === 0) {
+    console.log('No manifest entries depend on the target(s). Cohort = target(s) only.');
+} else {
+    console.table(rows);
+    const cohort = [...new Set(rows.filter((r) => r.kind !== 'NOT INSTALLED').map((r) => r.dependent))];
+    console.log(`\nCohort (must be reviewed/bumped together with the target): ${cohort.join(', ')}`);
+}
+
+const bad = rows.filter((r) => r.status.startsWith('UNSATISFIED') && !r.status.includes('optional'));
+if (check && bad.length) {
+    console.error(`\n${bad.length} unsatisfied range(s) — upgrade incomplete.`);
+    process.exit(1);
+}

--- a/.agents/skills/dependency-upgrade/scripts/find-dependents.mjs
+++ b/.agents/skills/dependency-upgrade/scripts/find-dependents.mjs
@@ -28,7 +28,10 @@ const manifestDeps = {
 const mayBeAbsent = new Set([
     ...Object.keys(manifest.optionalDependencies ?? {}),
     ...Object.keys(manifest.peerDependencies ?? {}),
-].filter((name) => !(name in (manifest.dependencies ?? {})) && !(name in (manifest.devDependencies ?? {}))));
+].filter((name) =>
+    name in (manifest.optionalDependencies ?? {}) ||
+    (!(name in (manifest.dependencies ?? {})) && !(name in (manifest.devDependencies ?? {})))
+));
 
 const require = createRequire(resolve(root, 'package.json'));
 let semver = null;


### PR DESCRIPTION
## Summary
Adds `.agents/skills/dependency-upgrade/` so future upgrade sessions compute the full "cohort" of manifest packages that must move together, instead of bumping one package and discovering peer-dep breakage in CI.

- `SKILL.md`: procedure — pick the package manager from the *tracked* lockfile (`yarn.lock` on master, `package-lock.json` on React branches; npm/yarn/pnpm command table), blast-radius analysis before editing, resolve cohort versions (`npm view <pkg>@<new> peerDependencies`), apply everything in one add/install (no `--force`/`--legacy-peer-deps`), verify with tree validation + frozen-lockfile clean install + lint/build/test, and a PR table listing each cohort member with its reason. Includes known lockstep cohorts (Angular, React, Vite/Vitest, Karma/Jasmine, TS, Jest).
- `scripts/find-dependents.mjs <pkg>... [--check]`: reads installed metadata of every `package.json` entry (deps, devDeps, optional, root peers) and prints those whose `peerDependencies`/`dependencies`/`optionalDependencies` mention the target, with the declared range and whether the resolved install (nested copy for regular deps, hoisted for peers) satisfies it. `--check` exits 1 on any unsatisfied range (incl. optional peers) or any range it could not verify (not installed / target missing / semver unavailable).

Example on this repo: `find-dependents.mjs rxjs` → cohort `@angular-devkit/build-angular, @angular/common, @angular/core, @angular/forms, @angular/router`.

Devin-Org: engineering

Link to Devin session: https://app.devin.ai/sessions/3e4eceba1169489a9f5cc8a5ea73b291
Open in Devin Desktop: https://app.devin.ai/desktop/session/3e4eceba1169489a9f5cc8a5ea73b291?variant=devin
Requested by: @charityquinn-cognition
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/angular2-hn/pull/760" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->