### PR TITLE
Add unit tests for services, pipes and components

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,0 +1,51 @@
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { NavigationEnd, Router } from '@angular/router';
+import { Subject } from 'rxjs';
+
+import { AppComponent } from './app.component';
+import { SettingsService } from './shared/services/settings.service';
+
+describe('AppComponent', () => {
+  let events: Subject<any>;
+  let settingsService: any;
+
+  beforeEach(() => {
+    events = new Subject<any>();
+    settingsService = {
+      settings: {
+        showSettings: false,
+        openLinkInNewTab: false,
+        theme: 'default',
+        titleFontSize: '16',
+        listSpacing: '0'
+      }
+    };
+    (window as any).ga = jasmine.createSpy('ga');
+    TestBed.configureTestingModule({
+      declarations: [AppComponent],
+      providers: [
+        {provide: Router, useValue: {events}},
+        {provide: SettingsService, useValue: settingsService}
+      ],
+      schemas: [NO_ERRORS_SCHEMA]
+    });
+  });
+
+  it('sends page views for navigation end events', () => {
+    TestBed.createComponent(AppComponent);
+
+    events.next(new NavigationEnd(1, '/news/1', '/news/1'));
+
+    expect((window as any).ga).toHaveBeenCalledWith('set', 'page', '/news/1');
+    expect((window as any).ga).toHaveBeenCalledWith('send', 'pageview');
+  });
+
+  it('does not send page views for other router events', () => {
+    TestBed.createComponent(AppComponent);
+
+    events.next({type: 'other'});
+
+    expect((window as any).ga).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/core/header/header.component.spec.ts
+++ b/src/app/core/header/header.component.spec.ts
@@ -1,0 +1,50 @@
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { HeaderComponent } from './header.component';
+import { SettingsService } from '../../shared/services/settings.service';
+
+describe('HeaderComponent', () => {
+  let settingsService: jasmine.SpyObj<SettingsService>;
+  let originalScrollTo: any;
+
+  beforeEach(() => {
+    originalScrollTo = (window as any).scrollTo;
+    settingsService = jasmine.createSpyObj('SettingsService', ['toggleSettings']);
+    settingsService.settings = {
+      showSettings: false,
+      openLinkInNewTab: false,
+      theme: 'default',
+      titleFontSize: '16',
+      listSpacing: '0'
+    };
+    (window as any).scrollTo = jasmine.createSpy('scrollTo');
+    TestBed.configureTestingModule({
+      declarations: [HeaderComponent],
+      providers: [
+        {provide: SettingsService, useValue: settingsService}
+      ],
+      schemas: [NO_ERRORS_SCHEMA]
+    });
+  });
+
+  afterEach(() => {
+    (window as any).scrollTo = originalScrollTo;
+  });
+
+  it('delegates toggling settings', () => {
+    const component = new HeaderComponent(settingsService);
+
+    component.toggleSettings();
+
+    expect(settingsService.toggleSettings).toHaveBeenCalled();
+  });
+
+  it('scrolls to the top', () => {
+    const component = new HeaderComponent(settingsService);
+
+    component.scrollTop();
+
+    expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
+  });
+});

--- a/src/app/core/settings/settings.component.spec.ts
+++ b/src/app/core/settings/settings.component.spec.ts
@@ -1,0 +1,49 @@
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { SettingsComponent } from './settings.component';
+import { SettingsService } from '../../shared/services/settings.service';
+
+describe('SettingsComponent', () => {
+  let settingsService: jasmine.SpyObj<SettingsService>;
+
+  beforeEach(() => {
+    settingsService = jasmine.createSpyObj('SettingsService', [
+      'toggleSettings',
+      'toggleOpenLinksInNewTab',
+      'setTheme',
+      'setFont',
+      'setSpacing'
+    ]);
+    settingsService.settings = {
+      showSettings: false,
+      openLinkInNewTab: false,
+      theme: 'default',
+      titleFontSize: '16',
+      listSpacing: '0'
+    };
+    TestBed.configureTestingModule({
+      declarations: [SettingsComponent],
+      providers: [
+        {provide: SettingsService, useValue: settingsService}
+      ],
+      schemas: [NO_ERRORS_SCHEMA]
+    });
+  });
+
+  it('delegates settings actions', () => {
+    const component = TestBed.createComponent(SettingsComponent).componentInstance;
+
+    component.closeSettings();
+    component.toggleOpenLinksInNewTab();
+    component.selectTheme('night');
+    component.changeTitleFont('18');
+    component.changeSpacing('4');
+
+    expect(settingsService.toggleSettings).toHaveBeenCalled();
+    expect(settingsService.toggleOpenLinksInNewTab).toHaveBeenCalled();
+    expect(settingsService.setTheme).toHaveBeenCalledWith('night');
+    expect(settingsService.setFont).toHaveBeenCalledWith('18');
+    expect(settingsService.setSpacing).toHaveBeenCalledWith('4');
+  });
+});

--- a/src/app/feeds/feed/feed.component.spec.ts
+++ b/src/app/feeds/feed/feed.component.spec.ts
@@ -1,0 +1,64 @@
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { of, throwError } from 'rxjs';
+
+import { FeedComponent } from './feed.component';
+import { HackerNewsAPIService } from '../../shared/services/hackernews-api.service';
+
+describe('FeedComponent', () => {
+  let api: jasmine.SpyObj<HackerNewsAPIService>;
+  let route: any;
+  const story = {id: 1, title: 'Story'} as any;
+
+  beforeEach(() => {
+    api = jasmine.createSpyObj('HackerNewsAPIService', ['fetchFeed']);
+    route = {
+      data: of({feedType: 'ask'}),
+      params: of({page: '2'})
+    };
+    spyOn(window, 'scrollTo').and.stub();
+    TestBed.configureTestingModule({
+      declarations: [FeedComponent],
+      providers: [
+        {provide: ActivatedRoute, useValue: route},
+        {provide: HackerNewsAPIService, useValue: api}
+      ],
+      schemas: [NO_ERRORS_SCHEMA]
+    });
+  });
+
+  it('loads a feed and calculates its list start', () => {
+    api.fetchFeed.and.returnValue(of([story]));
+    const component = TestBed.createComponent(FeedComponent).componentInstance;
+
+    component.ngOnInit();
+
+    expect(component.feedType).toBe('ask');
+    expect(component.pageNum).toBe(2);
+    expect(api.fetchFeed).toHaveBeenCalledWith('ask', 2);
+    expect(component.items).toEqual([story]);
+    expect(component.listStart).toBe(31);
+    expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
+  });
+
+  it('defaults to the first page', () => {
+    route.params = of({});
+    api.fetchFeed.and.returnValue(of([story]));
+    const component = TestBed.createComponent(FeedComponent).componentInstance;
+
+    component.ngOnInit();
+
+    expect(component.pageNum).toBe(1);
+    expect(component.listStart).toBe(1);
+  });
+
+  it('sets an error message when the feed fails', () => {
+    api.fetchFeed.and.returnValue(throwError('x'));
+    const component = TestBed.createComponent(FeedComponent).componentInstance;
+
+    component.ngOnInit();
+
+    expect(component.errorMessage).toBe('Could not load ask stories.');
+  });
+});

--- a/src/app/feeds/item/item.component.spec.ts
+++ b/src/app/feeds/item/item.component.spec.ts
@@ -1,0 +1,35 @@
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { ItemComponent } from './item.component';
+import { SettingsService } from '../../shared/services/settings.service';
+
+describe('ItemComponent', () => {
+  const settings = {
+    showSettings: false,
+    openLinkInNewTab: false,
+    theme: 'default',
+    titleFontSize: '16',
+    listSpacing: '0'
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [ItemComponent],
+      providers: [
+        {provide: SettingsService, useValue: {settings}}
+      ],
+      schemas: [NO_ERRORS_SCHEMA]
+    });
+  });
+
+  it('binds settings and detects external URLs', () => {
+    const component = TestBed.createComponent(ItemComponent).componentInstance;
+
+    component.item = {url: 'https://x'} as any;
+    expect(component.settings).toBe(settings);
+    expect(component.hasUrl).toBe(true);
+    component.item = {url: 'item?id=1'} as any;
+    expect(component.hasUrl).toBe(false);
+  });
+});

--- a/src/app/item-details/comment/comment.component.spec.ts
+++ b/src/app/item-details/comment/comment.component.spec.ts
@@ -1,0 +1,11 @@
+import { CommentComponent } from './comment.component';
+
+describe('CommentComponent', () => {
+  it('starts expanded', () => {
+    const component = new CommentComponent();
+
+    component.ngOnInit();
+
+    expect(component.collapse).toBe(false);
+  });
+});

--- a/src/app/item-details/item-details.component.spec.ts
+++ b/src/app/item-details/item-details.component.spec.ts
@@ -1,0 +1,78 @@
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { Location } from '@angular/common';
+import { of, throwError } from 'rxjs';
+
+import { ItemDetailsComponent } from './item-details.component';
+import { HackerNewsAPIService } from '../shared/services/hackernews-api.service';
+import { SettingsService } from '../shared/services/settings.service';
+
+describe('ItemDetailsComponent', () => {
+  let api: jasmine.SpyObj<HackerNewsAPIService>;
+  let location: jasmine.SpyObj<Location>;
+  let settingsService: any;
+  const settings = {
+    showSettings: false,
+    openLinkInNewTab: false,
+    theme: 'default',
+    titleFontSize: '16',
+    listSpacing: '0'
+  };
+
+  beforeEach(() => {
+    api = jasmine.createSpyObj('HackerNewsAPIService', ['fetchItemContent']);
+    location = jasmine.createSpyObj('Location', ['back']);
+    settingsService = {settings};
+    spyOn(window, 'scrollTo').and.stub();
+    TestBed.configureTestingModule({
+      declarations: [ItemDetailsComponent],
+      providers: [
+        {provide: ActivatedRoute, useValue: {params: of({id: '123'})}},
+        {provide: HackerNewsAPIService, useValue: api},
+        {provide: SettingsService, useValue: settingsService},
+        {provide: Location, useValue: location}
+      ],
+      schemas: [NO_ERRORS_SCHEMA]
+    });
+  });
+
+  it('loads an item and scrolls to the top', () => {
+    const item = {id: 123, url: 'https://x'} as any;
+    api.fetchItemContent.and.returnValue(of(item));
+    const component = TestBed.createComponent(ItemDetailsComponent).componentInstance;
+
+    component.ngOnInit();
+
+    expect(api.fetchItemContent).toHaveBeenCalledWith(123);
+    expect(component.item).toBe(item);
+    expect(component.settings).toBe(settings);
+    expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
+  });
+
+  it('sets an error message when loading comments fails', () => {
+    api.fetchItemContent.and.returnValue(throwError('x'));
+    const component = TestBed.createComponent(ItemDetailsComponent).componentInstance;
+
+    component.ngOnInit();
+
+    expect(component.errorMessage).toBe('Could not load item comments.');
+  });
+
+  it('goes back in browser history', () => {
+    const component = TestBed.createComponent(ItemDetailsComponent).componentInstance;
+
+    component.goBack();
+
+    expect(location.back).toHaveBeenCalled();
+  });
+
+  it('detects external URLs', () => {
+    const component = TestBed.createComponent(ItemDetailsComponent).componentInstance;
+
+    component.item = {url: 'https://x'} as any;
+    expect(component.hasUrl).toBe(true);
+    component.item = {url: 'item?id=1'} as any;
+    expect(component.hasUrl).toBe(false);
+  });
+});

--- a/src/app/shared/pipes/comment.pipe.spec.ts
+++ b/src/app/shared/pipes/comment.pipe.spec.ts
@@ -1,0 +1,12 @@
+import { CommentPipe } from './comment.pipe';
+
+describe('CommentPipe', () => {
+  it('formats comment counts and zero as discuss', () => {
+    const pipe = new CommentPipe();
+
+    expect(pipe.transform(0)).toBe('discuss');
+    expect(pipe.transform(1)).toBe('1 comment');
+    expect(pipe.transform(5)).toBe('5 comments');
+    expect(pipe.transform(-1)).toBe('discuss');
+  });
+});

--- a/src/app/shared/services/hackernews-api.service.spec.ts
+++ b/src/app/shared/services/hackernews-api.service.spec.ts
@@ -1,0 +1,223 @@
+import { fakeAsync, tick } from '@angular/core/testing';
+
+import { HackerNewsAPIService } from './hackernews-api.service';
+
+class FakeXMLHttpRequest {
+  static original: any;
+  static responses: {[url: string]: any} = {};
+  static errorUrls: {[url: string]: boolean} = {};
+  static deferred = false;
+  static instances: FakeXMLHttpRequest[] = [];
+
+  method: string;
+  url: string;
+  async: boolean;
+  private delegate: any;
+  private responseBody = '';
+  private statusCode = 0;
+  private statusMessage = '';
+  private responseLocation = '';
+  private loadHandler: () => void;
+  private errorHandler: (error: Error) => void;
+
+  constructor() {
+    FakeXMLHttpRequest.instances.push(this);
+  }
+
+  get status() {
+    return this.delegate ? this.delegate.status : this.statusCode;
+  }
+
+  get statusText() {
+    return this.delegate ? this.delegate.statusText : this.statusMessage;
+  }
+
+  get responseText() {
+    return this.delegate ? this.delegate.responseText : this.responseBody;
+  }
+
+  get responseURL() {
+    return this.delegate ? this.delegate.responseURL : this.responseLocation;
+  }
+
+  set onload(handler: () => void) {
+    this.loadHandler = handler;
+    if (this.delegate) {
+      this.delegate.onload = handler;
+    }
+  }
+
+  get onload() {
+    return this.loadHandler;
+  }
+
+  set onerror(handler: (error: Error) => void) {
+    this.errorHandler = handler;
+    if (this.delegate) {
+      this.delegate.onerror = handler;
+    }
+  }
+
+  get onerror() {
+    return this.errorHandler;
+  }
+
+  open(method: string, url: string, async: boolean) {
+    this.method = method;
+    this.url = url;
+    this.async = async;
+    this.responseLocation = url;
+    if (url.indexOf('https://node-hnapi.herokuapp.com') !== 0 && FakeXMLHttpRequest.original) {
+      this.delegate = new FakeXMLHttpRequest.original();
+      this.delegate.open(method, url, async);
+    }
+  }
+
+  send() {
+    if (this.delegate) {
+      this.delegate.onload = this.loadHandler;
+      this.delegate.onerror = this.errorHandler;
+      this.delegate.send();
+      return;
+    }
+    if (!FakeXMLHttpRequest.deferred) {
+      this.flush();
+    }
+  }
+
+  flush() {
+    if (FakeXMLHttpRequest.errorUrls[this.url]) {
+      this.errorHandler(new Error('boom'));
+      return;
+    }
+    this.statusCode = 200;
+    this.statusMessage = 'OK';
+    this.responseBody = JSON.stringify(FakeXMLHttpRequest.responses[this.url]);
+    this.loadHandler();
+  }
+
+  getAllResponseHeaders() {
+    return this.delegate ? this.delegate.getAllResponseHeaders() : '';
+  }
+
+  setRequestHeader(name: string, value: string) {
+    if (this.delegate) {
+      this.delegate.setRequestHeader(name, value);
+    }
+  }
+}
+
+describe('HackerNewsAPIService', () => {
+  let service: HackerNewsAPIService;
+  let originalXMLHttpRequest: any;
+
+  beforeEach(() => {
+    originalXMLHttpRequest = (window as any).XMLHttpRequest;
+    FakeXMLHttpRequest.original = originalXMLHttpRequest;
+    (window as any).XMLHttpRequest = FakeXMLHttpRequest;
+    FakeXMLHttpRequest.responses = {};
+    FakeXMLHttpRequest.errorUrls = {};
+    FakeXMLHttpRequest.deferred = false;
+    FakeXMLHttpRequest.instances = [];
+    service = new HackerNewsAPIService();
+  });
+
+  afterEach(() => {
+    (window as any).XMLHttpRequest = originalXMLHttpRequest;
+  });
+
+  it('fetches a feed by type and page', (done) => {
+    const story = {id: 1, title: 'Story'};
+    FakeXMLHttpRequest.responses['https://node-hnapi.herokuapp.com/news?page=2'] = [story];
+
+    service.fetchFeed('news', 2).subscribe(items => {
+      expect(items as any).toEqual([story]);
+      expect(FakeXMLHttpRequest.instances[0].method).toBe('get');
+      expect(FakeXMLHttpRequest.instances[0].url).toBe('https://node-hnapi.herokuapp.com/news?page=2');
+      done();
+    });
+  });
+
+  it('fetches a user', (done) => {
+    const user = {id: 'pg'};
+    FakeXMLHttpRequest.responses['https://node-hnapi.herokuapp.com/user/pg'] = user;
+
+    service.fetchUser('pg').subscribe(result => {
+      expect(result as any).toEqual(user);
+      expect(FakeXMLHttpRequest.instances[0].url).toBe('https://node-hnapi.herokuapp.com/user/pg');
+      done();
+    });
+  });
+
+  it('fetches poll content', (done) => {
+    const pollResult = {points: 5, content: 'Option'};
+    FakeXMLHttpRequest.responses['https://node-hnapi.herokuapp.com/item/5'] = pollResult;
+
+    service.fetchPollContent(5).subscribe(result => {
+      expect(result).toEqual(pollResult);
+      expect(FakeXMLHttpRequest.instances[0].url).toBe('https://node-hnapi.herokuapp.com/item/5');
+      done();
+    });
+  });
+
+  it('returns a non-poll story unchanged', (done) => {
+    const story: any = {id: 8, type: 'story', title: 'Story'};
+    FakeXMLHttpRequest.responses['https://node-hnapi.herokuapp.com/item/8'] = story;
+
+    service.fetchItemContent(8).subscribe(result => {
+      expect(result).toEqual(story);
+      expect(result.poll_votes_count).toBeUndefined();
+      done();
+    });
+  });
+
+  it('loads poll options and totals their votes', fakeAsync(() => {
+    const story: any = {
+      id: 10,
+      type: 'poll',
+      poll: [{content: 'One'}, {content: 'Two'}]
+    };
+    FakeXMLHttpRequest.responses['https://node-hnapi.herokuapp.com/item/10'] = story;
+    FakeXMLHttpRequest.responses['https://node-hnapi.herokuapp.com/item/11'] = {points: 3, content: 'One'};
+    FakeXMLHttpRequest.responses['https://node-hnapi.herokuapp.com/item/12'] = {points: 7, content: 'Two'};
+    let result: any;
+
+    service.fetchItemContent(10).subscribe(item => result = item);
+    tick();
+
+    expect(result.poll[0]).toEqual({points: 3, content: 'One'});
+    expect(result.poll[1]).toEqual({points: 7, content: 'Two'});
+    expect(result.poll_votes_count).toBe(10);
+    expect(FakeXMLHttpRequest.instances.map(instance => instance.url)).toEqual([
+      'https://node-hnapi.herokuapp.com/item/10',
+      'https://node-hnapi.herokuapp.com/item/11',
+      'https://node-hnapi.herokuapp.com/item/12'
+    ]);
+  }));
+
+  it('emits network errors', (done) => {
+    const url = 'https://node-hnapi.herokuapp.com/news?page=1';
+    FakeXMLHttpRequest.errorUrls[url] = true;
+
+    service.fetchFeed('news', 1).subscribe(
+      () => fail('expected an error'),
+      error => {
+        expect(error.message).toBe('boom');
+        done();
+      }
+    );
+  });
+
+  it('does not emit after unsubscribing before the response', () => {
+    const url = 'https://node-hnapi.herokuapp.com/news?page=1';
+    FakeXMLHttpRequest.deferred = true;
+    FakeXMLHttpRequest.responses[url] = [{id: 1}];
+    const next = jasmine.createSpy('next');
+    const subscription = service.fetchFeed('news', 1).subscribe(next);
+
+    subscription.unsubscribe();
+    FakeXMLHttpRequest.instances[0].flush();
+
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/shared/services/settings.service.spec.ts
+++ b/src/app/shared/services/settings.service.spec.ts
@@ -1,0 +1,136 @@
+import { SettingsService } from './settings.service';
+
+describe('SettingsService', () => {
+  let media: any;
+  let changeHandler: (event: any) => void;
+
+  beforeEach(() => {
+    localStorage.clear();
+    changeHandler = undefined;
+    media = {
+      media: '(prefers-color-scheme: dark)',
+      matches: false,
+      addEventListener: jasmine.createSpy('addEventListener').and.callFake((event, handler) => {
+        if (event === 'change') {
+          changeHandler = handler;
+        }
+      }),
+      removeEventListener: jasmine.createSpy('removeEventListener'),
+      dispatchEvent: (event) => {
+        if (changeHandler) {
+          changeHandler(event);
+        }
+        return true;
+      }
+    };
+    spyOn(window, 'matchMedia').and.returnValue(media);
+  });
+
+  it('uses default settings when nothing is persisted', () => {
+    const service = new SettingsService();
+
+    expect(service.settings).toEqual({
+      showSettings: false,
+      openLinkInNewTab: false,
+      titleFontSize: '16',
+      listSpacing: '0',
+      theme: 'default'
+    });
+  });
+
+  it('reads persisted settings', () => {
+    localStorage.setItem('openLinkInNewTab', 'true');
+    localStorage.setItem('titleFontSize', '20');
+    localStorage.setItem('listSpacing', '4');
+    localStorage.setItem('theme', 'amoledblack');
+
+    const service = new SettingsService();
+
+    expect(service.settings.openLinkInNewTab).toBe(true);
+    expect(service.settings.titleFontSize).toBe('20');
+    expect(service.settings.listSpacing).toBe('4');
+    expect(service.settings.theme).toBe('amoledblack');
+  });
+
+  it('uses the system dark preference when no theme is saved', () => {
+    media.matches = true;
+
+    const service = new SettingsService();
+
+    expect(service.settings.theme).toBe('night');
+    expect(localStorage.getItem('theme')).toBe('night');
+  });
+
+  it('uses the system light preference when no theme is saved', () => {
+    const service = new SettingsService();
+
+    expect(service.settings.theme).toBe('default');
+  });
+
+  it('prefers a saved theme over the system preference', () => {
+    localStorage.setItem('theme', 'amoledblack');
+    media.matches = true;
+
+    const service = new SettingsService();
+
+    expect(service.settings.theme).toBe('amoledblack');
+  });
+
+  it('handles system color scheme changes', () => {
+    const service = new SettingsService();
+
+    service.handleSystemPreferredColorSchemeChange({matches: true} as any);
+    expect(service.settings.theme).toBe('night');
+    service.handleSystemPreferredColorSchemeChange({matches: false} as any);
+    expect(service.settings.theme).toBe('default');
+  });
+
+  it('toggles settings visibility', () => {
+    const service = new SettingsService();
+
+    service.toggleSettings();
+    expect(service.settings.showSettings).toBe(true);
+    service.toggleSettings();
+    expect(service.settings.showSettings).toBe(false);
+  });
+
+  it('toggles and persists opening links in a new tab', () => {
+    const service = new SettingsService();
+
+    service.toggleOpenLinksInNewTab();
+
+    expect(service.settings.openLinkInNewTab).toBe(true);
+    expect(localStorage.getItem('openLinkInNewTab')).toBe('true');
+  });
+
+  it('updates and persists theme, font, and spacing settings', () => {
+    const service = new SettingsService();
+
+    service.setTheme('night');
+    service.setFont('18');
+    service.setSpacing('6');
+
+    expect(service.settings.theme).toBe('night');
+    expect(service.settings.titleFontSize).toBe('18');
+    expect(service.settings.listSpacing).toBe('6');
+    expect(localStorage.getItem('theme')).toBe('night');
+    expect(localStorage.getItem('titleFontSize')).toBe('18');
+    expect(localStorage.getItem('listSpacing')).toBe('6');
+  });
+
+  it('unsubscribes from system color scheme changes on destroy', () => {
+    const service = new SettingsService();
+
+    service.ngOnDestroy();
+
+    expect(media.removeEventListener).toHaveBeenCalledWith('change', jasmine.any(Function));
+  });
+
+  it('registers a change listener for the system color scheme', () => {
+    const service = new SettingsService();
+
+    service.subscribeToSystemPreferredColorScheme();
+
+    expect(media.addEventListener).toHaveBeenCalledWith('change', jasmine.any(Function));
+  });
+});

--- a/src/app/user/user.component.spec.ts
+++ b/src/app/user/user.component.spec.ts
@@ -1,0 +1,57 @@
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { Location } from '@angular/common';
+import { of, throwError } from 'rxjs';
+
+import { UserComponent } from './user.component';
+import { HackerNewsAPIService } from '../shared/services/hackernews-api.service';
+
+describe('UserComponent', () => {
+  let api: jasmine.SpyObj<HackerNewsAPIService>;
+  let location: jasmine.SpyObj<Location>;
+  let route: any;
+  const user = {id: 'pg', karma: 100} as any;
+
+  beforeEach(() => {
+    api = jasmine.createSpyObj('HackerNewsAPIService', ['fetchUser']);
+    location = jasmine.createSpyObj('Location', ['back']);
+    route = {params: of({id: 'pg'})};
+    TestBed.configureTestingModule({
+      declarations: [UserComponent],
+      providers: [
+        {provide: ActivatedRoute, useValue: route},
+        {provide: HackerNewsAPIService, useValue: api},
+        {provide: Location, useValue: location}
+      ],
+      schemas: [NO_ERRORS_SCHEMA]
+    });
+  });
+
+  it('loads a user', () => {
+    api.fetchUser.and.returnValue(of(user));
+    const component = TestBed.createComponent(UserComponent).componentInstance;
+
+    component.ngOnInit();
+
+    expect(api.fetchUser).toHaveBeenCalledWith('pg');
+    expect(component.user).toBe(user);
+  });
+
+  it('sets an error message when the user fails', () => {
+    api.fetchUser.and.returnValue(throwError('x'));
+    const component = TestBed.createComponent(UserComponent).componentInstance;
+
+    component.ngOnInit();
+
+    expect(component.errorMessage).toBe('Could not load user pg.');
+  });
+
+  it('goes back in browser history', () => {
+    const component = TestBed.createComponent(UserComponent).componentInstance;
+
+    component.goBack();
+
+    expect(location.back).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
The repo had no `*.spec.ts` files (baseline: 0% coverage, `ng test` ran zero specs). This adds 36 Jasmine/Karma specs covering every logic-bearing file under `src/app`.

**Coverage: 0% → Statements 100% (137/137), Branches 100% (22/22), Functions 95.24% (60/63), Lines 100% (125/125)** (`ng test --watch=false --code-coverage`).

Notable paths covered:
- `HackerNewsAPIService` — `unfetch` uses XHR, so a `FakeXMLHttpRequest` is swapped onto `window` for `node-hnapi.herokuapp.com` URLs (other URLs delegate to the real XHR so Karma reporting keeps working). Covers URL construction, poll stories (`fetchItemContent` fans out to `item/{id+1..n}` and sums `poll_votes_count`), network errors, and the `cancelToken` path (unsubscribe before response → no emission).
- `SettingsService` — `window.matchMedia` stubbed to control `prefers-color-scheme`: saved theme wins over system preference, dark/light system default, persistence to `localStorage`, `ngOnDestroy` listener removal.
- `FeedComponent` — `listStart` paging math (page 2 → 31, missing page → 1), error message, `scrollTo(0,0)`.
- `ItemDetailsComponent`/`ItemComponent` `hasUrl`, `UserComponent` error/`goBack`, `AppComponent` GA `NavigationEnd` tracking, `CommentPipe` singular/plural/`discuss`.

Component specs use `NO_ERRORS_SCHEMA` with `useValue` stubs, so no HTTP or child modules are pulled in. No source or config files changed. `npm run lint` has preexisting tslint errors in source files (unchanged); spec files lint clean.

Devin-Org: engineering

Link to Devin session: https://app.devin.ai/sessions/aec961096e4f4ab18a837249b5ad328e
Open in Devin Desktop: https://app.devin.ai/desktop/session/aec961096e4f4ab18a837249b5ad328e?variant=devin
Requested by: @dsalvadorjasin