### PR TITLE
feature: sync README with DeepWiki documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Data models live in `src/app/shared/models/`: `Story` (id, title, url, points, u
 - `openLinkInNewTab` - whether story links open in a new tab
 - `showSettings` - visibility of the settings panel
 
-All preferences are persisted to `localStorage`. If no theme has been saved, the service listens to the `prefers-color-scheme` media query and automatically picks `night` or `default` to follow the operating system, and switches when the system preference changes.
+All preferences are persisted to `localStorage`. On startup, a saved theme is restored if one exists; otherwise the current `prefers-color-scheme` value picks `night` or `default`. The service always listens for changes to that media query, so a later change in the operating system's colour scheme switches the theme (and overwrites the saved one) even if a theme was selected manually.
 
 Themes are implemented in SCSS. `_themes.scss` defines a `theme()` mixin that takes a theme name and a set of colour variables and emits a `.<name>` class; `default`, `night` and `amoledblack` are generated from it, and `AppComponent` applies the active class to the page. Adding a theme is a matter of adding another `@include theme(...)` with new variables.
 
@@ -279,12 +279,12 @@ npm run lint
 
 ## Testing
 
-- **Unit tests** (Karma + Jasmine): `npm test` runs `ng test`. Spec files live next to their sources as `*.spec.ts`; the entry point is `src/test.ts` and the runner is configured in `karma.conf.js`. Use `npm test -- --watch=false` for a single headless run.
+- **Unit tests** (Karma + Jasmine): `npm test` runs `ng test`. Spec files live next to their sources as `*.spec.ts`; the entry point is `src/test.ts` and the runner is configured in `karma.conf.js`. `karma.conf.js` launches regular Chrome; use `npm test -- --watch=false --browsers=ChromeHeadless` for a single headless run.
 - **End-to-end tests** (Protractor): `npm run e2e` runs `ng e2e` using `e2e/protractor.conf.js` and the specs in `e2e/src/`.
 
 ## Deployment and CI/CD
 
-- **Firebase Hosting**: `firebase.json` serves the built app with a catch-all rewrite to `/index.html` so Angular's client-side router handles deep links, and points at `database.rules.json` for Realtime Database rules. `.firebaserc` defines two project aliases: `default` (`angular2-hn`) and `experiment` (`angular2-hn-experiment`) for sandbox deployments.
+- **Firebase Hosting**: `firebase.json` sets the hosting `public` directory to `dist` with a catch-all rewrite to `/index.html` so Angular's client-side router handles deep links, and points at `database.rules.json` for Realtime Database rules. Note that Angular CLI writes the build to `dist/angular-hnpwa`, so the `public` directory and `outputPath` must be aligned (or the build copied to `dist/`) for a deploy to serve the app. `.firebaserc` defines two project aliases: `default` (`angular2-hn`) and `experiment` (`angular2-hn-experiment`) for sandbox deployments.
 - **Travis CI**: `.travis.yml` builds only the `master` branch. It installs `firebase-tools` and `@angular/cli`, runs `npm run build`, and on success runs `firebase use default` followed by `firebase deploy --token $FIREBASE_TOKEN`. `FIREBASE_TOKEN` is provided as an encrypted Travis environment variable.
 
 ## Glossary

--- a/README.md
+++ b/README.md
@@ -19,70 +19,306 @@
 
 ---
 
-:zap: **Fast:** Service Worker App Shell + Dynamic Content model to achieve faster load times with and without a network.
+Angular 2 HN is a Progressive Web Application (PWA) that provides a fast, responsive and offline-capable client for [Hacker News](https://news.ycombinator.com). It follows a Service Worker App Shell + Dynamic Content model: the application shell is precached by a service worker so it loads instantly with or without a network, while story, comment and user data are fetched from a Hacker News REST API at runtime.
 
-:iphone: **Responsive:** Completely responsive UI that can be installed to your mobile home screen to provide a native feel.
-
-:rocket: **Progressive:** [Lighthouse](https://github.com/GoogleChrome/lighthouse) score of 87/100.
+- **Fast:** App Shell model with service worker caching for quick loads on slow networks or offline.
+- **Responsive:** Fully responsive UI that can be installed to a mobile home screen for a native feel.
+- **Progressive:** Web App Manifest, Angular service worker and a [Lighthouse](https://github.com/GoogleChrome/lighthouse) score of 87/100.
 
 <p align="center">
   <img src = "http://i.imgur.com/fzJzLFO.png" width=500>
 </p>
 
-## Mobile Preview
+## Table of Contents
+
+- [Previews](#previews)
+- [Key Technologies](#key-technologies)
+- [Architecture](#architecture)
+- [Project Structure](#project-structure)
+- [Data Layer](#data-layer)
+- [Settings and Theming](#settings-and-theming)
+- [PWA and Service Worker](#pwa-and-service-worker)
+- [Getting Started](#getting-started)
+- [Testing](#testing)
+- [Deployment and CI/CD](#deployment-and-cicd)
+- [Glossary](#glossary)
+- [Areas of improvement](#areas-of-improvement)
+- [Contributors](#contributors)
+
+## Previews
+
+### Mobile
 
 <p align="center">
   <img src = "http://i.imgur.com/ZloA1hn.gif">
 </p>
 
-## Laptop Preview
+### Laptop
 
 <p align="center">
   <img src = "http://i.imgur.com/MrKHaln.gif">
 </p>
 
-## Offline Support
+### Manifest
 
-This app uses [Workbox](https://workboxjs.org/) to generate a service worker as part of the build step to load quickly and work offline.
-
-## Manifest
-
-With Chromium based browsers for Android (Chrome, Opera, etc...), Angular 2 HN includes a Web App Manifest that allows you to install to your homescreen.
+With Chromium based browsers for Android (Chrome, Opera, etc.), Angular 2 HN includes a Web App Manifest that allows you to install it to your home screen.
 
 <p align="center">
   <img src = "http://i.imgur.com/1RaaNkr.png">
 </p>
 
-## Themes
+## Key Technologies
 
-Built in theme engine!
+| Technology | Role |
+| :--- | :--- |
+| [Angular](https://angular.io) 9 | Application framework (`@angular/core`, `@angular/router`, `@angular/forms`, ...) |
+| [Angular CLI](https://cli.angular.io) | Build, serve, lint and test tooling (`angular.json`) |
+| [@angular/service-worker](https://angular.io/guide/service-worker-intro) | Service worker generation and App Shell caching (`ngsw-config.json`) |
+| [RxJS](https://rxjs.dev) 6 | Observable-based data access |
+| [unfetch](https://github.com/developit/unfetch) | Minimal `fetch` polyfill wrapped in Observables for API calls |
+| TypeScript 3.7, SCSS | Language and styling |
+| [Karma](https://karma-runner.github.io) + [Jasmine](https://jasmine.github.io) | Unit tests |
+| [Protractor](https://www.protractortest.org) | End-to-end tests |
+| [TSLint](https://palantir.github.io/tslint/) + [Codelyzer](http://codelyzer.com) | Linting |
+| [Firebase Hosting](https://firebase.google.com/docs/hosting) | Production hosting (`firebase.json`, `.firebaserc`) |
+| [Travis CI](https://travis-ci.org) | Continuous integration and deployment (`.travis.yml`) |
+
+## Architecture
+
+The application is a standard Angular CLI project organised around a root module, a core module, lazy-loaded feature modules and a shared layer.
+
+```mermaid
+graph TD
+    User -->|Interacts with| UI[UI: Feeds, Item Details, User]
+    UI -->|Requests data from| API[HackerNewsAPIService]
+    API -->|fetch| HN["Hacker News REST API (node-hnapi.herokuapp.com)"]
+    UI -->|Reads preferences from| Settings[SettingsService]
+    Settings -->|Persists to| LS[localStorage]
+    SW[Angular Service Worker] -->|Caches App Shell| UI
+    Build[Angular CLI build] -->|Deploys via Travis CI| Firebase[Firebase Hosting]
+```
+
+### Root module and bootstrapping
+
+`src/main.ts` bootstraps `AppModule` (`src/app/app.module.ts`), which:
+
+- declares `AppComponent`, `FeedComponent` and `ItemComponent`;
+- imports `BrowserModule`, the `routing` configuration, `CoreModule`, `SharedComponentsModule` and `PipesModule`;
+- registers the Angular service worker with `ServiceWorkerModule.register('ngsw-worker.js', { enabled: environment.production })`, so the service worker is only active in production builds;
+- provides `HackerNewsAPIService` and `SettingsService` as application-wide singletons.
+
+`AppComponent` is the root shell. It subscribes to router `NavigationEnd` events to send Google Analytics page views and applies the active theme class from `SettingsService`.
+
+### Routing and navigation
+
+Routes are defined in `src/app/app.routes.ts`:
+
+| Path | Target | Notes |
+| :--- | :--- | :--- |
+| `''` | redirect to `news/1` | Default landing page |
+| `news/:page`, `newest/:page`, `show/:page`, `ask/:page`, `jobs/:page` | `FeedComponent` | Each parent route carries `data: { feedType }` which the component uses to decide which feed to fetch |
+| `item/...` | `ItemDetailsModule` | Lazy loaded via `loadChildren` |
+| `user/...` | `UserModule` | Lazy loaded via `loadChildren` |
+
+Lazy loading the item and user modules keeps the initial bundle small; the feed list is part of the main bundle since it is the landing page.
+
+### Core module
+
+`CoreModule` (`src/app/core/`) contains the persistent chrome of the app:
+
+- `HeaderComponent` - navigation between feed types and a settings toggle.
+- `FooterComponent` - footer links.
+- `SettingsComponent` - the settings panel (theme, title font size, list spacing, open links in new tab) backed by `SettingsService`.
+
+### Feature modules
+
+- **Feeds** (`src/app/feeds/`): `FeedComponent` renders a paginated list of stories for the current `feedType` and page. It computes `listStart = (pageNum - 1) * 30 + 1` so rank numbers stay correct across pages (1-30, 31-60, ...). `ItemComponent` renders a single story row and honours the "open links in new tab" setting.
+- **Item Details** (`src/app/item-details/`): `ItemDetailsModule` is lazy loaded and shows a story with its recursive comment tree (`CommentComponent`) and poll results where applicable. `goBack()` uses Angular's `Location` service to return to the previous page.
+- **User Profile** (`src/app/user/`): `UserModule` is lazy loaded and shows a Hacker News user's karma, creation date and about text.
+
+### Shared layer
+
+`src/app/shared/` holds code reused across features:
+
+- `components/`: `SharedComponentsModule` with `LoaderComponent` and `ErrorMessageComponent`.
+- `pipes/`: `PipesModule` with `CommentPipe`, which formats a comment count as `"discuss"`, `"1 comment"` or `"N comments"`.
+- `models/`: TypeScript interfaces (`Story`, `Comment`, `User`, `PollResult`, `Settings`, `FeedType`).
+- `services/`: `HackerNewsAPIService` and `SettingsService`.
+- `scss/`: `_media.scss` (breakpoints), `_theme_variables.scss` and `_themes.scss` (theme engine).
+
+## Project Structure
+
+```
+angular2-hn/
+├── angular.json            # Angular CLI workspace config (build, serve, test, lint, e2e)
+├── package.json            # Dependencies and npm scripts
+├── ngsw-config.json        # Angular service worker asset groups
+├── firebase.json           # Firebase Hosting rules (SPA rewrite to /index.html) and database rules
+├── .firebaserc             # Firebase project aliases: default, experiment
+├── database.rules.json     # Firebase Realtime Database security rules
+├── .travis.yml             # CI: build on master and deploy to Firebase
+├── karma.conf.js           # Unit test runner config
+├── tslint.json             # Lint rules
+├── browserslist            # Target browsers
+├── tsconfig*.json          # Base, app and spec TypeScript configs
+├── e2e/                    # Protractor end-to-end tests
+│   ├── protractor.conf.js
+│   └── src/
+└── src/
+    ├── index.html          # App Shell entry point, manifest and theme-color metadata
+    ├── main.ts             # Bootstraps AppModule
+    ├── polyfills.ts        # Browser polyfills (evergreen browsers)
+    ├── styles.scss         # Global styles
+    ├── manifest.json       # Web App Manifest
+    ├── assets/             # Icons and static assets
+    ├── environments/       # environment.ts / environment.prod.ts
+    └── app/
+        ├── app.module.ts   # Root module
+        ├── app.routes.ts   # Route definitions
+        ├── app.component.* # Root shell component
+        ├── core/           # Header, footer, settings panel
+        ├── feeds/          # FeedComponent, ItemComponent
+        ├── item-details/   # Lazy-loaded story + comments module
+        ├── user/           # Lazy-loaded user profile module
+        └── shared/         # Components, pipes, models, services, SCSS
+```
+
+Production builds are written to `dist/angular-hnpwa` (the `outputPath` in `angular.json`).
+
+## Data Layer
+
+`HackerNewsAPIService` (`src/app/shared/services/hackernews-api.service.ts`) is the single point of contact with the backend. It targets the unofficial Hacker News REST API at `https://node-hnapi.herokuapp.com` and exposes:
+
+| Method | Endpoint | Returns |
+| :--- | :--- | :--- |
+| `fetchFeed(feedType, page)` | `GET /{feedType}?page={page}` | `Observable<Story[]>` |
+| `fetchItemContent(id)` | `GET /item/{id}` | `Observable<Story>` (also loads poll options for `poll` items) |
+| `fetchPollContent(id)` | `GET /item/{id}` | `Observable<PollResult>` |
+| `fetchUser(id)` | `GET /user/{id}` | `Observable<User>` |
+
+Requests go through a small `lazyFetch` helper that wraps `unfetch` in an RxJS `Observable`, so components can subscribe and unsubscribe like any other Angular data source.
+
+Data models live in `src/app/shared/models/`: `Story` (id, title, url, points, user, time, comments_count, type, comments, ...), `Comment` (recursive nested comments), `User`, `PollResult`, `Settings` and the `FeedType` alias.
+
+## Settings and Theming
+
+`SettingsService` (`src/app/shared/services/settings.service.ts`) holds a `Settings` object with:
+
+- `theme` - `default`, `night` or `amoledblack`
+- `titleFontSize` and `listSpacing` - typography and density of the feed list
+- `openLinkInNewTab` - whether story links open in a new tab
+- `showSettings` - visibility of the settings panel
+
+All preferences are persisted to `localStorage`. If no theme has been saved, the service listens to the `prefers-color-scheme` media query and automatically picks `night` or `default` to follow the operating system, and switches when the system preference changes.
+
+Themes are implemented in SCSS. `_themes.scss` defines a `theme()` mixin that takes a theme name and a set of colour variables and emits a `.<name>` class; `default`, `night` and `amoledblack` are generated from it, and `AppComponent` applies the active class to the page. Adding a theme is a matter of adding another `@include theme(...)` with new variables.
 
 Current themes:
-* Default
-* Night
-* Black (AMOLED)
 
-More to come!
+- Default
+- Night
+- Black (AMOLED)
+
+## PWA and Service Worker
+
+Offline support is provided by the Angular service worker (`@angular/service-worker`):
+
+- `angular.json` enables `serviceWorker: true` with `ngswConfigPath: ngsw-config.json` for the `production` configuration, so `ng build --prod` emits `ngsw-worker.js` and `ngsw.json` into `dist/angular-hnpwa`.
+- `ngsw-config.json` defines two asset groups: `app` (prefetched: `index.html`, CSS, JS, favicon and manifest - the App Shell) and `assets` (lazily cached images and fonts under `/assets/**`).
+- `AppModule` registers `ngsw-worker.js` only when `environment.production` is true, so the service worker is never active during `ng serve`.
+
+`src/index.html` links the Web App Manifest and sets `theme-color`, and `src/manifest.json` supplies the name, icons, start URL and display mode used for home screen installation.
+
+## Getting Started
+
+### Prerequisites
+
+- Node.js and npm
+- Angular CLI (optional globally; `npx ng` also works): `npm install -g @angular/cli`
+
+### Install
+
+```bash
+git clone https://github.com/COG-GTM/angular2-hn.git
+cd angular2-hn
+npm install
+```
+
+### Run in development
+
+```bash
+npm start
+```
+
+Runs `ng serve` with live reload at `http://localhost:4200`. Service worker changes are not reflected in development mode because the worker is only registered in production builds.
+
+### Build for production
+
+```bash
+npm run build -- --prod
+```
+
+Runs `ng build` with the `production` configuration (AOT, optimisation, output hashing, service worker). Output goes to `dist/angular-hnpwa`.
+
+### Validate PWA behaviour locally
+
+The service worker must be tested from a static server over the production build. Any static file server works, for example:
+
+```bash
+npm run build -- --prod
+npx http-server dist/angular-hnpwa -p 8080
+```
+
+Then open `http://localhost:8080`, and in the browser DevTools Application tab confirm the service worker is registered and the manifest is detected. Enable "Offline" in the Network tab and reload to confirm the App Shell still loads.
+
+### Lint
+
+```bash
+npm run lint
+```
+
+## Testing
+
+- **Unit tests** (Karma + Jasmine): `npm test` runs `ng test`. Spec files live next to their sources as `*.spec.ts`; the entry point is `src/test.ts` and the runner is configured in `karma.conf.js`. Use `npm test -- --watch=false` for a single headless run.
+- **End-to-end tests** (Protractor): `npm run e2e` runs `ng e2e` using `e2e/protractor.conf.js` and the specs in `e2e/src/`.
+
+## Deployment and CI/CD
+
+- **Firebase Hosting**: `firebase.json` serves the built app with a catch-all rewrite to `/index.html` so Angular's client-side router handles deep links, and points at `database.rules.json` for Realtime Database rules. `.firebaserc` defines two project aliases: `default` (`angular2-hn`) and `experiment` (`angular2-hn-experiment`) for sandbox deployments.
+- **Travis CI**: `.travis.yml` builds only the `master` branch. It installs `firebase-tools` and `@angular/cli`, runs `npm run build`, and on success runs `firebase use default` followed by `firebase deploy --token $FIREBASE_TOKEN`. `FIREBASE_TOKEN` is provided as an encrypted Travis environment variable.
+
+## Glossary
+
+| Term | Definition |
+| :--- | :--- |
+| App Shell | The minimal HTML, CSS and JS needed to render the UI, precached by the service worker for instant loads (`src/index.html`, `ngsw-config.json`). |
+| `app-root` | The custom element in `src/index.html` where Angular bootstraps `AppComponent`. |
+| `feedType` | Route `data` string (`news`, `newest`, `show`, `ask`, `jobs`) that tells `FeedComponent` which feed to fetch (`src/app/app.routes.ts`). |
+| `FeedType` | TypeScript alias (`'poll' | 'story' | 'job'`) for the type of an individual item (`src/app/shared/models/feed-type.type.ts`). |
+| `HackerNewsAPIService` | Singleton service that wraps all calls to the Hacker News REST API. |
+| `lazyFetch` | Helper in the API service that wraps `unfetch` in an RxJS `Observable`. |
+| `SettingsService` | Singleton that stores user preferences (theme, font size, spacing, link behaviour) in `localStorage`. |
+| `darkColorSchemeMedia` | `MediaQueryList` in `SettingsService` used to follow the system `prefers-color-scheme`. |
+| `FeedComponent` | Route component that renders a paginated feed based on `feedType`. |
+| `listStart` | Rank of the first item on the current page, `(page - 1) * 30 + 1`. |
+| `ItemComponent` | Renders a single story row within a feed. |
+| `ItemDetailsModule` | Lazy-loaded module for a story and its nested comment tree. |
+| `UserModule` | Lazy-loaded module for user profiles. |
+| `CommentPipe` | Pipe that formats a comment count (`discuss`, `1 comment`, `N comments`). |
+| `ngsw-worker.js` | The Angular service worker file, registered only in production. |
+| `ngsw-config.json` | Angular service worker configuration describing which assets to cache and how. |
+| AMOLED theme | The `amoledblack` pure black theme intended for OLED screens. |
+| `experiment` | Firebase project alias for sandbox deployments (`.firebaserc`). |
+| `FIREBASE_TOKEN` | Environment variable Travis CI uses to authenticate `firebase deploy`. |
+| SPA rewrites | `firebase.json` rule routing every path to `/index.html` for client-side routing. |
+| AOT | Ahead-of-Time compilation of Angular templates at build time (enabled in `angular.json`). |
 
 ## Areas of improvement
 
- - Realtime updating using the Firebase SDK (may need to add option to settings so service worker can still rely on REST endpoints)
- - Server side rendering
+- Realtime updating using the Firebase SDK (may need to add an option to settings so the service worker can still rely on REST endpoints)
+- Server side rendering
 
-Feel free to send me feedback on [twitter](https://twitter.com/hdjirdeh) or [file an issue](https://github.com/hdjirdeh/angular2-hn/issues/new)! Feature requests are always welcome.
-
-## Build process
-
-Note: This project has been ejected (with AOT + production settings) in order to customize Webpack configurations.
-
- - Clone or download the repo
- - `npm install`
- - `npm start` to run the application with webpack-dev-server or `npm build` to kick off a fresh build and update the output directory (`dist/`)
-
-Note: Any Service Worker changes will not be reflected when you run the application locally in development. To test service worker changes:
- - `npm build`
- - `npm run precache` to generate the service worker file
- - `npm run static-serve` to load the application along with the service worker asset using [live-server](https://github.com/tapio/live-server)
+Feel free to send feedback on [twitter](https://twitter.com/hdjirdeh) or [file an issue](https://github.com/hdjirdeh/angular2-hn/issues/new). Feature requests are always welcome.
 
 ## Contributors
 


### PR DESCRIPTION
## Summary
Rewrites `README.md` to mirror the structure of the repo's DeepWiki (Overview, Key Technologies, Architecture, Project Structure, Data Layer, Settings and Theming, PWA/Service Worker, Getting Started, Testing, Deployment/CI, Glossary), while keeping the existing header, badges, previews, "Areas of improvement" and Contributors sections.

Every wiki claim was cross-checked against the code; the following wiki/old-README statements were **not** carried over because they are wrong for the current codebase:
- Offline support is via `@angular/service-worker` + `ngsw-config.json` (`ServiceWorkerModule.register('ngsw-worker.js', { enabled: environment.production })`), not Workbox / `sw-precache`.
- `npm run precache` and `npm run static-serve` do not exist in `package.json` (scripts are `start`, `build`, `test`, `lint`, `e2e`); the PWA validation section now uses `npm run build -- --prod` and any static server.
- The project is a standard Angular CLI 9 workspace (`angular.json`), not an "ejected" Webpack config.
- Glossary distinguishes route `data.feedType` (`news|newest|show|ask|jobs`) from the `FeedType` model alias (`'poll' | 'story' | 'job'`), which the wiki conflates.

Only `README.md` is changed.

Devin-Org: engineering

Link to Devin session: https://app.devin.ai/sessions/fb5f81e3c3f543c79e9a656045e4069b
Open in Devin Desktop: https://app.devin.ai/desktop/session/fb5f81e3c3f543c79e9a656045e4069b?variant=devin
Requested by: @charityquinn-cognition
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cog-gtm/angular2-hn/pull/762" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->